### PR TITLE
Copy and serve static files for nginx

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.app/files/default
+++ b/deployment/ansible/roles/cac-tripplanner.app/files/default
@@ -7,4 +7,9 @@ server {
                 proxy_set_header Host $http_host;
 		proxy_pass http://127.0.0.1:8000;
 	}
+
+        location /static/ {
+                alias /opt/app/src/dist/;
+
+        }
 }

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -80,6 +80,14 @@ gulp.task('wiredep', function () {
 
 });
 
+gulp.task('copy', function() {
+    gulp.src([
+        'app/styles/**/*.css',
+        'app/scripts/**/*.js',
+        '../python/cac_tripplanner/cac_tripplanner/static/*'
+    ]).pipe(gulp.dest('./dist'));
+});
+
 gulp.task('watch', function () {
 
   // watch for changes
@@ -93,7 +101,7 @@ gulp.task('watch', function () {
   gulp.watch('bower.json', ['wiredep']);
 });
 
-gulp.task('build', ['jshint', 'html', 'images', 'fonts', 'extras', 'collectstatic'], function () {
+gulp.task('build', ['jshint', 'html', 'images', 'fonts', 'extras', 'collectstatic', 'copy'], function () {
   return gulp.src('dist/**/*')
     .pipe($.size({title: 'build', gzip: true}));
 });


### PR DESCRIPTION
Mostly fixes gulp and nginx so that they
work with each other. This copies the django
static files to dist/ and the other static
files there as well.

TODO: Figure out a sane strategy for static
files.