### PR TITLE
Add Jenkins integration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,9 @@ else
   CPUS = ENV['CAC_TRIPPLANNER_CPU']
 end
 
+def testing?
+  !ENV["VAGRANT_ENV"].nil? && ENV["VAGRANT_ENV"] == "TEST"
+end
 
 # Deserialize Ansible Galaxy installation metadata for a role
 def galaxy_install_info(role_name)
@@ -57,7 +60,7 @@ if [ "up", "provision" ].include?(ARGV.first)
   install_dependent_roles
 end
 
-ANSIBLE_INVENTORY_PATH = if !ENV["VAGRANT_ENV"].nil? && ENV["VAGRANT_ENV"] == "TEST"
+ANSIBLE_INVENTORY_PATH = if testing?
   "deployment/ansible/inventory/test"
 else
   "deployment/ansible/inventory/development"
@@ -105,7 +108,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     app.vm.hostname = "app"
     app.vm.network "private_network", ip: "192.168.8.24"
 
-    app.vm.synced_folder ".", "/opt/app", nfs: true
+    app.vm.synced_folder ".", "/opt/app"
 
     # Web
     app.vm.network "forwarded_port", guest: 80, host: 8024

--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -1,0 +1,4 @@
+---
+test: false
+develop: true
+production: false

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -1,0 +1,4 @@
+---
+test: true
+develop: false
+production: false

--- a/deployment/ansible/inventory/test
+++ b/deployment/ansible/inventory/test
@@ -1,4 +1,4 @@
-[development]
+[test]
 app ansible_ssh_host=192.168.8.24
 database ansible_ssh_host=192.168.8.25
 otp ansible_ssh_host=192.168.8.26

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/dev-test-dependencies.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/dev-test-dependencies.yml
@@ -1,0 +1,5 @@
+---
+- name: Install dev/test python packages
+  pip: name={{ item.name }} version={{ item.version }}
+  with_items:
+    - { name: 'flake8', version: '2.3.0' }

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/jslibs.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/jslibs.yml
@@ -11,7 +11,7 @@
        state=present
 
 - name: Install NPM dependencies
-  npm: path="{{ root_src_dir }}" state=present
+  command: npm install chdir="{{ root_src_dir }}"
   sudo: no
 
 - name: Create Static Directory
@@ -29,11 +29,11 @@
   sudo: no
   args:
     chdir: "{{ root_src_dir }}"
-  when: not production
+  when: not production and not test
 
 - name: Create static files -- production
   command: npm run gulp-production
   sudo: no
   args:
     chdir: "{{ root_src_dir }}"
-  when: production
+  when: production or test

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -40,3 +40,5 @@
   notify: Restart nginx
 
 - { include: jslibs.yml }
+
+- { include: dev-test-dependencies.yml, when: develop or test }

--- a/deployment/ansible/roles/cac-tripplanner.database/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.database/tasks/main.yml
@@ -13,7 +13,7 @@
   postgresql_user: db={{ postgres_db }}
                    name={{ postgres_user }}
                    password={{ postgres_password }}
-                   role_attr_flags=CREATEDB,SUPERUSER
+                   role_attr_flags=SUPERUSER
   sudo_user: postgres
 
 - name: Add PostGIS extension

--- a/python/cac_tripplanner/cac_tripplanner/tests.py
+++ b/python/cac_tripplanner/cac_tripplanner/tests.py
@@ -58,4 +58,3 @@ class CACTripPlannerIsochroneTestCase(TestCase):
         isochrone_url = '/map/reachable?coords%5Blat%5D=39.954688&coords%5Blng%5D=-75.204677&mode%5B%5D=WALK&mode%5B%5D=TRANSIT&date=01-21-2015&time=7%3A30am&maxTravelTime=5000&maxWalkDistance=5000'
         response = self.client.get(isochrone_url)
         self.assertEqual('{"matched": "[<Destination: testWithin>]"}', response.content)
-

--- a/python/cac_tripplanner/cac_tripplanner/urls.py
+++ b/python/cac_tripplanner/cac_tripplanner/urls.py
@@ -7,7 +7,7 @@ from .views import FindReachableDestinations
 import settings
 
 urlpatterns = patterns('',
-    url(r'^$', 'cac_tripplanner.views.home', name='home'),
+    url(r'^$', 'cac_tripplanner.views.home', name='home'),  # NOQA
     url(r'^map/$', 'cac_tripplanner.views.map', name='map'),
     url(r'^map/reachable$', FindReachableDestinations.as_view(), name='reachable'),
     url(r'^admin/', include(admin.site.urls)),
@@ -18,4 +18,3 @@ if settings.DEBUG:
     urlpatterns += [
         url(r'^static/(?P<path>.*)$', staticviews.serve),
     ]
-

--- a/python/cac_tripplanner/cms/tests.py
+++ b/python/cac_tripplanner/cms/tests.py
@@ -1,3 +1,10 @@
 from django.test import TestCase
 
-# Create your tests here.
+
+class UselessTestCase(TestCase):
+    """TODO: Replace with real tests."""
+    def setUp(self):
+        pass
+
+    def test_true_is_true(self):
+        self.assertTrue(True)

--- a/python/cac_tripplanner/cms/views.py
+++ b/python/cac_tripplanner/cms/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
-
 # Create your views here.

--- a/python/cac_tripplanner/destinations/tests.py
+++ b/python/cac_tripplanner/destinations/tests.py
@@ -1,3 +1,10 @@
 from django.test import TestCase
 
-# Create your tests here.
+
+class UselessTestCase(TestCase):
+    """TODO: Replace with real tests."""
+    def setUp(self):
+        pass
+
+    def test_true_is_true(self):
+        self.assertTrue(True)

--- a/python/cac_tripplanner/destinations/views.py
+++ b/python/cac_tripplanner/destinations/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
-
 # Create your views here.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# Python linting
+vagrant ssh app -c "flake8 /opt/app/python --exclude migrations"
+
+# Run the Django test suite with --noinput flag.
+vagrant ssh app -c "cd /opt/app/python/cac_tripplanner && ./manage.py test --noinput"
+
+# Run JS unit tests.
+vagrant ssh app -c "cd /opt/app/src && npm run gulp-test"

--- a/scripts/vagrant-up.sh
+++ b/scripts/vagrant-up.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+# The otp machine is currently disabled because it takes a long time, the built-in
+# OTP tests apparently don't work very well, and we don't have any other tests that use it yet.
+vagrant up app database --no-provision
+for vm in database app;
+do
+    vagrant provision ${vm}
+done

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/src/karma/karma-dev.conf.js
+++ b/src/karma/karma-dev.conf.js
@@ -1,0 +1,70 @@
+// Karma configuration
+// Generated on Wed Jan 21 2015 22:49:29 GMT+0000 (UTC)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '/opt/app/src',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'test/spec/*.js',
+      'test/spec/**/*.js',
+      '/srv/cac/scripts/vendor/jquery.js',
+      '/srv/cac/scripts/vendor/*.js',
+      '/srv/cac/scripts/main/cac/cac.js',
+      '/srv/cac/scripts/main/**/*.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['PhantomJS'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false
+  });
+};

--- a/src/karma/karma.conf.js
+++ b/src/karma/karma.conf.js
@@ -1,0 +1,68 @@
+// Karma configuration
+// Generated on Wed Jan 21 2015 23:35:38 GMT+0000 (UTC)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '/opt/app/src',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      '/srv/cac/scripts/jquery.js',
+      '/srv/cac/scripts/vendor.js',
+      '/srv/cac/scripts/main.js',
+      'test/spec/test.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: false,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['PhantomJS'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true
+  });
+};

--- a/src/package.json
+++ b/src/package.json
@@ -32,10 +32,15 @@
     "gulp-uglify": "^1.0.1",
     "gulp-useref": "^1.0.2",
     "gulp-watch": "^3.0.0",
+    "jasmine-core": "^2.1.3",
     "jshint-stylish": "^1.0.0",
+    "karma": "^0.12.31",
+    "karma-jasmine": "^0.3.5",
+    "karma-phantomjs-launcher": "^0.1.4",
     "lazypipe": "^0.2.1",
     "main-bower-files": "^2.1.0",
     "opn": "^1.0.0",
+    "phantomjs": "^1.9.13",
     "serve-index": "^1.1.4",
     "serve-static": "^1.4.0",
     "wiredep": "^2.0.0"
@@ -45,6 +50,7 @@
     "gulp-development": "gulp development",
     "gulp-production": "gulp production",
     "gulp-test": "gulp test",
+    "gulp-test-dev": "gulp test:development",
     "gulp-watch": "gulp watch"
   }
 }

--- a/src/test/spec/test.js
+++ b/src/test/spec/test.js
@@ -1,13 +1,9 @@
-/* global describe, it */
+(function() {
+    'use strict';
 
-(function () {
-  'use strict';
-
-  describe('Give it some context', function () {
-    describe('maybe a bit more context here', function () {
-      it('should run here few assertions', function () {
-
-      });
+    describe('CAC Trip Planner test stub', function() {
+        it('Should successfully run a trivial test', function() {
+            expect(true).toBe(true);
+        });
     });
-  });
 })();


### PR DESCRIPTION
Fixes various issues encountered when running on Jenkins; adds Django
tests and Karma tests via PhantomJS for Javascript. OTP tests are not
implemented at the moment because they are apparently not often
functional; if we want to test OTP we should probably set up our own
test suite.

Note that the Karma tests don't always pass because vendor.js throws an error; this is ready for review otherwise.

@hectcastro may also want to take a look.