### PR TITLE
Mark build unstable on linting errors

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+function mark_unstable {
+    java -jar jenkins-cli.jar -s $JENKINS_URI set-build-result unstable
+}
+
+set -x
+trap 'mark_unstable' ERR
+
+# Python linting
+vagrant ssh app -c "flake8 /opt/app/python --exclude migrations"
+
+# Run JS linting
+vagrant ssh app -c "cd /opt/app/src && npm run gulp-lint"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,9 +3,6 @@
 set -e
 set -x
 
-# Python linting
-vagrant ssh app -c "flake8 /opt/app/python --exclude migrations"
-
 # Run the Django test suite with --noinput flag.
 vagrant ssh app -c "cd /opt/app/python/cac_tripplanner && ./manage.py test --noinput"
 

--- a/src/package.json
+++ b/src/package.json
@@ -51,6 +51,7 @@
     "gulp-production": "gulp production",
     "gulp-test": "gulp test",
     "gulp-test-dev": "gulp test:development",
+    "gulp-lint": "gulp jshint",
     "gulp-watch": "gulp watch"
   }
 }


### PR DESCRIPTION
The build still currently fails because one of the tests relies on having a running OTP server, which we don't have at the moment. But this will mark the build unstable if linting fails, rather than failing the whole build.