### PR TITLE
Use/Watch NFS to speed up gulp-watch

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -108,7 +108,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     app.vm.hostname = "app"
     app.vm.network "private_network", ip: "192.168.8.24"
 
-    app.vm.synced_folder ".", "/opt/app"
+    if testing?
+        app.vm.synced_folder ".", "/opt/app"
+    else
+        app.vm.synced_folder ".", "/opt/app", :nfs => true, :mount_options => ['actimeo=2']
+    end
 
     # Web
     app.vm.network "forwarded_port", guest: 80, host: 8024


### PR DESCRIPTION
This switches the project to use NFS
for the app VM to speed up gulp watches.

Also tunes NFS to reduce the period that
the NFS client will cache attribtues of
directories and files to 2 seconds.