### PR TITLE
Bump azavea/ansible-opentripplanner to 0.2.2

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -1,6 +1,6 @@
 azavea.git,0.1.0
 azavea.java,0.1.1
-azavea.opentripplanner,0.2.0
+azavea.opentripplanner,0.2.2
 azavea.nginx,0.2.0
 azavea.nodejs,0.3.0
 azavea.pip,0.1.0


### PR DESCRIPTION
Adds OTP analyst flag to upstart job