### PR TITLE
Fix references to `this` broken by linting

### DIFF
--- a/src/app/scripts/cac/.jshintrc
+++ b/src/app/scripts/cac/.jshintrc
@@ -18,6 +18,7 @@
   "strict": true,
   "trailing": true,
   "smarttabs": true,
+  "validthis": true,
   "globals": {
     "CAC": true,
     "Handlebars": true,

--- a/src/app/scripts/cac/pages/cac-pages-map.js
+++ b/src/app/scripts/cac/pages/cac-pages-map.js
@@ -1,7 +1,6 @@
 CAC.Pages.Map = (function ($, Handlebars, _, MapControl, Routing, MockDestinations, MapTemplates) {
     'use strict';
 
-    var self = this;
     var defaults = {
         map: {}
     };
@@ -14,7 +13,7 @@ CAC.Pages.Map = (function ($, Handlebars, _, MapControl, Routing, MockDestinatio
     };
 
     function Map(options) {
-        self.options = $.extend({}, defaults, options);
+        this.options = $.extend({}, defaults, options);
     }
 
     Map.prototype.initialize = function () {
@@ -45,8 +44,8 @@ CAC.Pages.Map = (function ($, Handlebars, _, MapControl, Routing, MockDestinatio
             $('.explore').removeClass('hidden');
         });
 
-        self.typeahead  = new CAC.Search.Typeahead('input.typeahead');
-        self.typeahead.events.on('cac:typeahead:selected', $.proxy(onTypeaheadSelected, this));
+        this.typeahead  = new CAC.Search.Typeahead('input.typeahead');
+        this.typeahead.events.on('cac:typeahead:selected', $.proxy(onTypeaheadSelected, this));
     };
 
     return Map;
@@ -100,7 +99,7 @@ CAC.Pages.Map = (function ($, Handlebars, _, MapControl, Routing, MockDestinatio
      * Event handler, so this is set to the clicked event
      */
     function onItineraryClicked() {
-        var itineraryId = self.getAttribute('data-itinerary');
+        var itineraryId = this.getAttribute('data-itinerary');
         var itinerary = mapControl.getItineraryById(itineraryId);
         if (itinerary) {
             currentItinerary.highlight(false);

--- a/src/app/scripts/cac/search/cac-typeahead.js
+++ b/src/app/scripts/cac/search/cac-typeahead.js
@@ -50,13 +50,14 @@ CAC.Search.Typeahead = (function ($) {
     return CACTypeahead;
 
     function onTypeaheadSelected(event, suggestion, dataset) {
+        var self = this;
         var typeaheadKey = $(event.currentTarget).data('typeahead-key') || defaultTypeaheadKey;
 
         if (dataset === 'currentlocation') {
-            this.events.trigger('cac:typeahead:selected', [typeaheadKey, suggestion]);
+            self.events.trigger('cac:typeahead:selected', [typeaheadKey, suggestion]);
         } else {
             CAC.Search.Geocoder.search(suggestion.text, suggestion.magicKey).then(function (location) {
-                this.events.trigger('cac:typeahead:selected', [typeaheadKey, location]);
+                self.events.trigger('cac:typeahead:selected', [typeaheadKey, location]);
             });
         }
     }

--- a/src/app/scripts/cac/search/cac-typeahead.js
+++ b/src/app/scripts/cac/search/cac-typeahead.js
@@ -24,7 +24,6 @@ CAC.Search.Typeahead = (function ($) {
         minLength: 2
     };
     var defaultTypeaheadKey = 'default';
-    var self = this;
 
     function CACTypeahead(selector, options) {
 
@@ -54,10 +53,10 @@ CAC.Search.Typeahead = (function ($) {
         var typeaheadKey = $(event.currentTarget).data('typeahead-key') || defaultTypeaheadKey;
 
         if (dataset === 'currentlocation') {
-            self.events.trigger('cac:typeahead:selected', [typeaheadKey, suggestion]);
+            this.events.trigger('cac:typeahead:selected', [typeaheadKey, suggestion]);
         } else {
             CAC.Search.Geocoder.search(suggestion.text, suggestion.magicKey).then(function (location) {
-                self.events.trigger('cac:typeahead:selected', [typeaheadKey, location]);
+                this.events.trigger('cac:typeahead:selected', [typeaheadKey, location]);
             });
         }
     }


### PR DESCRIPTION
Remaining references to `self` are necessary to avoid linter errors; this reverts those references that broke functionality (and also happened to not be linter errors).