### PR TITLE
Wire up feature directions clicks on explore page

### DIFF
--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -54,7 +54,7 @@ CAC.Map.Templates = (function (Handlebars) {
                 '<div class="modes"></div>',
                 '<h3>{{ d.name }}</h3>',
                 '<h5>20 minutes away</h5>',
-                '<img src="{{ d.image }}" width="300px" height="200px" />',
+                '<img src="{{ d.wide_image }}" width="300px" height="150px" />',
             '</a>'
         ].join('');
         var template = Handlebars.compile(source);

--- a/src/app/scripts/cac/pages/cac-pages-map.js
+++ b/src/app/scripts/cac/pages/cac-pages-map.js
@@ -154,8 +154,26 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl, Routing, MockDe
         var $container = $('<div></div>').addClass('destinations');
         $.each(destinations, function (i, destination) {
             var $destination = $(CAC.Map.Templates.destinationBlock(destination));
+
             $destination.click(function () {
-                // TODO: What to do on click?!?!
+                // TODO: see issue #78 regarding refactors to improve this
+
+                showDirectionsTab();
+
+                // Set origin
+                var from = UserPreferences.getPreference('origin');
+                var originText = UserPreferences.getPreference('originText');
+                directions.origin = [from.feature.geometry.y, from.feature.geometry.x];
+                $('section.directions input.origin').val(originText);
+
+                // Set destination
+                var toCoords = destination.point.coordinates;
+                var destinationText = destination.address;
+                directions.destination = [toCoords[1], toCoords[0]];
+                $('section.directions input.destination').val(destinationText);
+
+                // Get directions
+                planTrip();
             });
             $container.append($destination);
         });
@@ -186,6 +204,14 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl, Routing, MockDe
     }
 
     /**
+     * Switch to the 'Get Directions' tab
+     */
+    function showDirectionsTab() {
+        $('.explore').addClass('hidden');
+        $('.directions').removeClass('hidden');
+    }
+
+    /**
      * When first naviagting to this page, check for user preferences to load.
      */
     function setFromUserPreferences() {
@@ -198,8 +224,7 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl, Routing, MockDe
 
         if (method === 'directions') {
             // switch tabs
-            $('.explore').addClass('hidden');
-            $('.directions').removeClass('hidden');
+            showDirectionsTab();
 
             var from = UserPreferences.getPreference('from');
             var to = UserPreferences.getPreference('to');

--- a/src/app/styles/components/_blocks.scss
+++ b/src/app/styles/components/_blocks.scss
@@ -5,10 +5,11 @@
 
     &.block-destination {
         height: 360px;
+        cursor: pointer;
 
         &.block-half {
             height: 172px;
-            
+
             &:first-of-type {
                 margin-bottom: 15px;
             }
@@ -35,7 +36,7 @@
         height: 155px;
         margin-bottom: 15px;
         background: $light-gray;
-        
+
         &:last-of-type {
             margin-bottom: 0;
         }


### PR DESCRIPTION
This makes it so the featured destinations that show up in the
left-panel of the explore page can be clicked, which changes
to the directions tab and routes to that destination.

Note: I wasn't able to write a test for this, because the test
suite is currently broken per issue #77.