### PR TITLE
Fix destination.website_url migration and model inconsistency

### DIFF
--- a/python/cac_tripplanner/destinations/migrations/0007_destination_website_url.py
+++ b/python/cac_tripplanner/destinations/migrations/0007_destination_website_url.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='destination',
             name='website_url',
-            field=models.URLField(),
+            field=models.URLField(blank=True, null=True),
             preserve_default=False,
         ),
     ]


### PR DESCRIPTION
Migrations failed when updating to current develop wtih error:

`django.db.utils.IntegrityError: column "website_url" contains null values`

Made the assumption that the model definition was the correct one.