### PR TITLE
Use flag in new plugin release to always write jshint report.

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -15,5 +15,4 @@ vagrant ssh app -c "flake8 /opt/app/python --exclude=migrations --output-file=/o
 # Run JS linting
 vagrant ssh app -c "cd /opt/app/src && npm run gulp-lint"
 # Run again, writing results to file.
-# First delete previous lint file, if it exists, and create an empty file (in case no warnings found).
-vagrant ssh app -c "cd /opt/app/src && rm -f coverage/jshint-output.xml && touch coverage/jshint-output.xml && npm run gulp-lint-jenkins"
+vagrant ssh app -c "cd /opt/app/src && npm run gulp-lint-jenkins"

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -115,7 +115,8 @@ gulp.task('jshint:jenkins', function () {
         .pipe($.jshint())
         .pipe($.jshint.reporter(jshintXMLReporter))
         .on('end', jshintXMLReporter.writeFile({
-            format: 'jslint_xml',
+            alwaysReport: true,
+            format: 'jslint',
             filePath: 'coverage/jshint-output.xml'
         }))
         .pipe($.jshint.reporter('fail'));

--- a/src/package.json
+++ b/src/package.json
@@ -22,7 +22,7 @@
     "gulp-if": "^1.2.1",
     "gulp-imagemin": "^1.2.1",
     "gulp-jshint": "^1.5.3",
-    "gulp-jshint-xml-file-reporter": "^0.3.3",
+    "gulp-jshint-xml-file-reporter": "^0.5.1",
     "gulp-load-plugins": "^0.7.1",
     "gulp-order": "^1.1.1",
     "gulp-plumber": "^0.6.3",


### PR DESCRIPTION
Fixes issue with Jenkins failing build if empty lint file found.