### PR TITLE
Limit rich text editor options.

### DIFF
--- a/python/cac_tripplanner/cac_tripplanner/settings.py
+++ b/python/cac_tripplanner/cac_tripplanner/settings.py
@@ -162,6 +162,18 @@ CKEDITOR_IMAGE_BACKEND = 'pillow'
 # TODO: delete later.
 CKEDITOR_JQUERY_URL = '//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js'
 
+CKEDITOR_CONFIGS = {
+    'default': {
+        'toolbar': [
+            ["Styles", "Format", "Bold", "Italic", "Underline", "Strike", "SpellChecker", "Undo", "Redo"],
+            ["Link", "Unlink", "Anchor"],
+            ["Table", "HorizontalRule"],
+            ["SpecialChar"],
+            ["Source"]
+        ]
+    }
+}
+
 WPADMIN = {
     'admin': {
         'title': 'Clean Air Council Content Management System',


### PR DESCRIPTION
Explicitly define what is available in the toolbar, removing options such as smileys and image embedding.