### PR TITLE
Closes #152: Always show all featured dests on map and sidebar

### DIFF
--- a/python/cac_tripplanner/destinations/views.py
+++ b/python/cac_tripplanner/destinations/views.py
@@ -101,7 +101,9 @@ class FindReachableDestinations(View):
             for poly in json_poly['features']:
                 geom_str = json.dumps(poly['geometry'])
                 geom = GEOSGeometry(geom_str)
-                matched_objects = Destination.objects.filter(point__within=geom, published=True)
+                matched_objects = (Destination.objects.filter(published=True)
+                                                      .distance(geom)
+                                                      .order_by('distance'))
         else:
             matched_objects = []
 


### PR DESCRIPTION
Simplest way to show all destinations is to return them sorted
by distance with the isochrone. Could refactor to pull list
of destinations from /api/destinations, but not really worth it
atm, since that would require moving around some app logic
to fetch/display them.