### PR TITLE
Move to v0.14 on main OTP repo

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -3,9 +3,9 @@ app_username: "vagrant"
 
 # open trip planner vars
 otp_process_mem: 2G
-otp_repo: "https://github.com/azavea/OpenTripPlanner.git"
-otp_version: "cac"
-otp_jarfile: "./target/otp-0.13.0.jar"
+otp_repo: "https://github.com/OpenTripPlanner/OpenTripPlanner.git"
+otp_version: "otp-0.14.0"
+otp_jarfile: "./target/otp-0.14.0.jar"
 
 s3_otp_data: cleanair-otp-data
 

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/defaults/main.yml
@@ -5,4 +5,4 @@
 otp_osm_source: https://s3.amazonaws.com/metro-extracts.mapzen.com/philadelphia_pennsylvania.osm.pbf
 otp_osm_filename: /var/otp/philadelphia.osm.pbf
 otp_repo: "https://github.com/opentripplanner/OpenTripPlanner.git"
-otp_version: "opentripplanner-0.13.0"
+otp_router: "default"

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
@@ -5,6 +5,9 @@
 - name: Copy Feed Validator
   copy: src=validate_feed.py dest="{{ otp_data_dir }}"
 
+- name: Overwrite upstart service
+  template: src=otp.conf.j2 dest=/etc/init/otp.conf
+
 - name: Download OTP Data
   local_action: command aws s3 sync s3://cleanair-otp-data/ ../../otp_data/
   sudo: no
@@ -22,4 +25,10 @@
   command: /usr/bin/java -Xmx{{ otp_process_mem }} -jar {{ otp_jarfile }} --build {{ otp_data_dir }}
   args:
     chdir: "{{ otp_bin_dir }}"
+
+- name: Create Graph Directory
+  file: path="{{ otp_data_dir}}/{{ otp_router }}" state=directory
+
+- name: Move Graph to Graph Directory
+  command: mv {{ otp_data_dir }}/Graph.obj {{ otp_data_dir }}/{{ otp_router }}
   notify: Restart OpenTripPlanner

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/templates/otp.conf.j2
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/templates/otp.conf.j2
@@ -1,0 +1,13 @@
+## NOTICE: This file is written by ansible, and any changes made here will be overwritten on next provision.
+#           Modify cac-tripplanner.otp-data/templates/otp.conf.j2 to make changes stick.
+description "start OpenTripPlanner process"
+
+start on {{ upstart_start_on }}
+stop on runlevel [!2345]
+
+setuid {{ otp_user }}
+
+chdir {{ otp_bin_dir }}
+script
+    exec /usr/bin/java -Xmx{{otp_process_mem}} -jar {{ otp_jarfile }} --server --analyst --port {{ otp_web_port }} --basePath {{ otp_data_dir}} --graphs {{ otp_data_dir }} --router default
+end script


### PR DESCRIPTION
This switches OTP to the new 0.14 release, and updates the build and serve parameters for the changes.  It switches back to the main repo, as they've since re-enabled loading elevation data.