### PR TITLE
Feature/fix firefox issues

### DIFF
--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -122,7 +122,7 @@ CAC.Pages.Home = (function ($, Templates, UserPreferences, Utils) {
 
     return Home;
 
-    function clickedViewAll() {
+    function clickedViewAll(event) {
         event.preventDefault();
 
         // hide existing destinations list and show loading spinner

--- a/src/app/scripts/cac/search/cac-typeahead.js
+++ b/src/app/scripts/cac/search/cac-typeahead.js
@@ -24,6 +24,7 @@ CAC.Search.Typeahead = (function ($) {
         minLength: 2
     };
     var defaultTypeaheadKey = 'default';
+    var thisLocation = null;
 
     function CACTypeahead(selector, options) {
 
@@ -85,27 +86,33 @@ CAC.Search.Typeahead = (function ($) {
     */
 
     function locationAdapter(query, callback) {
-        if ('geolocation' in navigator) {
-            navigator.geolocation.getCurrentPosition(function(position) {
-                var list = [{
-                    name: 'Current Location',
-                    feature: {
-                        geometry: {
-                            x: position.coords.longitude,
-                            y: position.coords.latitude
-                        }
-                    }
-                }];
-                callback(list);
-            }, function (error) {
-                console.error('geolocation', error);
-            }, {
-                enableHighAccuracy: true,
-                timeout: 1000,
-                maximumAge: 0
-            });
+        if (thisLocation) {
+            callback(thisLocation);
         } else {
-            console.error('geolocation not supported');
+            if ('geolocation' in navigator) {
+                // set a watch on current location the first time it's requested
+                navigator.geolocation.watchPosition(function(position) {
+                    var list = [{
+                        name: 'Current Location',
+                        feature: {
+                            geometry: {
+                                x: position.coords.longitude,
+                                y: position.coords.latitude
+                            }
+                        }
+                    }];
+                    thisLocation = list;
+                    callback(thisLocation);
+                }, function (error) {
+                    console.error('geolocation', error);
+                }, {
+                    enableHighAccuracy: true,
+                    timeout: 5000,
+                    maximumAge: 10000
+                });
+            } else {
+                console.error('geolocation not supported');
+            }
         }
     }
 


### PR DESCRIPTION
Fixes a couple of issues in Firefox:
* Missing `event` argument for view all locations link on homepage
* Puts watch on geolocation, to prevent repeated browser prompts in the typeahead to access location
