### PR TITLE
Extend geocoder search categories

### DIFF
--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -48,6 +48,7 @@
     <script src="{% static 'scripts/main/cac/cac.js' %}"></script>
     <script src="{% static 'scripts/main/cac/utils.js' %}"></script>
     <script src="{% static 'scripts/main/cac/user/cac-user-preferences.js' %}"></script>
+    <script src="{% static 'scripts/main/cac/search/cac-search-params.js' %}"></script>
     <script src="{% static 'scripts/main/cac/search/cac-geocoder.js' %}"></script>
     <script src="{% static 'scripts/main/cac/search/cac-typeahead.js' %}"></script>
     <script src="{% static 'scripts/main/cac/routing/cac-routing-itinerary.js' %}"></script>

--- a/src/app/scripts/cac/search/cac-geocoder.js
+++ b/src/app/scripts/cac/search/cac-geocoder.js
@@ -1,17 +1,12 @@
-CAC.Search.Geocoder = (function ($) {
+CAC.Search.Geocoder = (function ($, SearchParams) {
     'use strict';
 
     var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find';
     var reverseUrl = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode';
 
     var defaults = {
-        bbox: [
-            '-75.243620',
-            '39.898295',
-            '-75.126531',
-            '39.967842'
-        ].join(','),
-        category: 'Address,POI',
+        bbox: SearchParams.searchBounds,
+        category: SearchParams.searchCategories,
         outFields: 'StAddr,City,Region,Postal',
         f: 'pjson',
         maxLocations: 1
@@ -88,4 +83,4 @@ CAC.Search.Geocoder = (function ($) {
         return dfd.promise();
     }
 
-})(jQuery);
+})(jQuery, CAC.Search.SearchParams);

--- a/src/app/scripts/cac/search/cac-search-params.js
+++ b/src/app/scripts/cac/search/cac-search-params.js
@@ -1,0 +1,30 @@
+/**
+ * Holds shared search parameters used by suggest and geocoder services.
+ */
+CAC.Search.SearchParams = (function () {
+    'use strict';
+
+    var searchBounds = [
+        '-75.243620',
+        '39.898295',
+        '-75.126531',
+        '39.967842'
+    ].join(',');
+
+    // search categories from here:
+    // https://developers.arcgis.com/rest/geocode/api-reference/geocoding-category-filtering.htm
+    var searchCategories = ['Address',
+                            'Postal',
+                            'Coordinate System',
+                            'Populated Place',
+                            'POI'
+                            ].join(',');
+
+    var module = {
+        searchBounds: searchBounds,
+        searchCategories: searchCategories
+    };
+
+    return Object.freeze(module);
+
+})();

--- a/src/app/scripts/cac/search/cac-typeahead.js
+++ b/src/app/scripts/cac/search/cac-typeahead.js
@@ -121,6 +121,15 @@ CAC.Search.Typeahead = (function ($) {
 
     function suggestAdapterFactory() {
         var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest';
+
+        // search categories from here:
+        // https://developers.arcgis.com/rest/geocode/api-reference/geocoding-category-filtering.htm
+        var searchCategories = ['Address',
+                                'Postal',
+                                'Coordinate System',
+                                'Populated Place',
+                                'POI'
+                                ].join(',');
         var params = {
             searchExtent: [
                 '-75.243620',
@@ -128,7 +137,7 @@ CAC.Search.Typeahead = (function ($) {
                 '-75.126531',
                 '39.967842'
             ].join(','),
-            category: 'Address,POI',
+            category: searchCategories,
             f: 'pjson'
         };
 

--- a/src/app/scripts/cac/search/cac-typeahead.js
+++ b/src/app/scripts/cac/search/cac-typeahead.js
@@ -16,7 +16,7 @@
  *                                    String typeaheadKey
  *                                    Object location
  */
-CAC.Search.Typeahead = (function ($) {
+CAC.Search.Typeahead = (function ($, SearchParams) {
     'use strict';
 
     var defaults = {
@@ -122,22 +122,9 @@ CAC.Search.Typeahead = (function ($) {
     function suggestAdapterFactory() {
         var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest';
 
-        // search categories from here:
-        // https://developers.arcgis.com/rest/geocode/api-reference/geocoding-category-filtering.htm
-        var searchCategories = ['Address',
-                                'Postal',
-                                'Coordinate System',
-                                'Populated Place',
-                                'POI'
-                                ].join(',');
         var params = {
-            searchExtent: [
-                '-75.243620',
-                '39.898295',
-                '-75.126531',
-                '39.967842'
-            ].join(','),
-            category: searchCategories,
+            searchExtent: SearchParams.searchBounds,
+            category: SearchParams.searchCategories,
             f: 'pjson'
         };
 
@@ -155,4 +142,4 @@ CAC.Search.Typeahead = (function ($) {
         return adapter;
     }
 
-})(jQuery);
+})(jQuery, CAC.Search.SearchParams);


### PR DESCRIPTION
The 'Populated Place' category adds city and neighborhood names; the suggest service will preferentially suggest street names first, if there are some that also match.  Adding 'Postal' as a category seems to make the service better at finding some addresses (e.g., addresses on Girard would not geocode before.)