### PR TITLE
Do not download OSM on provision.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Development Installation
 ------------------------
 
 1. Make sure you have the development dependencies installed
-2. Place GTFS .zip files and elevation .tif files (optional) in the otp_data folder
+2. Place GTFS .zip files, OSM files, and elevation .tif files (optional) in the otp_data folder
 3. Run `vagrant up`
 4. See the app at http://localhost:8024! See OpenTripPlanner at http://localhost:9090.
 5. Running `npm run gulp-watch` from `/opt/app/src` will automatically collect static files together when changes are detected for Django template consumption.

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/defaults/main.yml
@@ -2,7 +2,5 @@
 # defined in azavea.opentripplanner
 #otp_bin_dir: /opt/opentripplanner
 #otp_data_dir: /var/otp
-otp_osm_source: https://s3.amazonaws.com/metro-extracts.mapzen.com/philadelphia_pennsylvania.osm.pbf
-otp_osm_filename: /var/otp/philadelphia.osm.pbf
 otp_repo: "https://github.com/opentripplanner/OpenTripPlanner.git"
 otp_router: "default"

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
@@ -17,10 +17,6 @@
   copy: src=./otp_data/ dest="{{ otp_data_dir }}/" owner={{ansible_ssh_user}} group={{ansible_ssh_user}} mode=0664
   notify: Validate GTFS
 
-- name: Download Philadelphia OSM Data
-  get_url: url={{ otp_osm_source }}
-           dest={{ otp_osm_filename }}
-
 - name: Build OTP Graph
   command: /usr/bin/java -Xmx{{ otp_process_mem }} -jar {{ otp_jarfile }} --build {{ otp_data_dir }}
   args:


### PR DESCRIPTION
Expect to find OSM file(s) with GTFS, other OTP files.

We will want to use a custom extract to cover our specific bounding box, rather than use the MapZen Philadelphia extract.