### PR TITLE
Feature/increase otp request timeouts

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -6,7 +6,7 @@ otp_process_mem: 2G
 otp_repo: "https://github.com/OpenTripPlanner/OpenTripPlanner.git"
 otp_version: "otp-0.14.0"
 otp_jarfile: "./target/otp-0.14.0.jar"
-otp_session_timeout: 90
+otp_session_timeout_s: 90
 
 s3_otp_data: cleanair-otp-data
 

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -6,6 +6,7 @@ otp_process_mem: 2G
 otp_repo: "https://github.com/OpenTripPlanner/OpenTripPlanner.git"
 otp_version: "otp-0.14.0"
 otp_jarfile: "./target/otp-0.14.0.jar"
+otp_session_timeout: 90
 
 s3_otp_data: cleanair-otp-data
 

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -1,6 +1,6 @@
 azavea.git,0.1.0
 azavea.java,0.2.1
-azavea.opentripplanner,0.3.1
+azavea.opentripplanner,0.3.2
 azavea.nginx,0.2.0
 azavea.nodejs,0.3.0
 azavea.pip,0.1.0

--- a/deployment/ansible/roles/cac-tripplanner.app/templates/nginx-default.j2
+++ b/deployment/ansible/roles/cac-tripplanner.app/templates/nginx-default.j2
@@ -6,7 +6,7 @@ server {
     location / {
         proxy_set_header Host $http_host;
         proxy_pass http://127.0.0.1:8000;
-        proxy_read_timeout 90s;
+        proxy_read_timeout {{ otp_session_timeout }}s;
     }
 
     location /admin/destinations/destination/add/ {

--- a/deployment/ansible/roles/cac-tripplanner.app/templates/nginx-default.j2
+++ b/deployment/ansible/roles/cac-tripplanner.app/templates/nginx-default.j2
@@ -6,7 +6,7 @@ server {
     location / {
         proxy_set_header Host $http_host;
         proxy_pass http://127.0.0.1:8000;
-        proxy_read_timeout {{ otp_session_timeout }}s;
+        proxy_read_timeout {{ otp_session_timeout_s }}s;
     }
 
     location /admin/destinations/destination/add/ {

--- a/deployment/ansible/roles/cac-tripplanner.app/templates/nginx-default.j2
+++ b/deployment/ansible/roles/cac-tripplanner.app/templates/nginx-default.j2
@@ -6,6 +6,7 @@ server {
     location / {
         proxy_set_header Host $http_host;
         proxy_pass http://127.0.0.1:8000;
+        proxy_read_timeout 90s;
     }
 
     location /admin/destinations/destination/add/ {

--- a/deployment/ansible/roles/cac-tripplanner.app/templates/upstart-cac-tripplanner-app.conf.j2
+++ b/deployment/ansible/roles/cac-tripplanner.app/templates/upstart-cac-tripplanner-app.conf.j2
@@ -11,4 +11,4 @@ respawn
 setuid {{ app_username }}
 chdir {{ root_app_dir }}
 
-exec gunicorn --config {{ root_conf_dir }}/gunicorn.py cac_tripplanner.wsgi
+exec gunicorn --config {{ root_conf_dir }}/gunicorn.py --timeout 90 cac_tripplanner.wsgi

--- a/deployment/ansible/roles/cac-tripplanner.app/templates/upstart-cac-tripplanner-app.conf.j2
+++ b/deployment/ansible/roles/cac-tripplanner.app/templates/upstart-cac-tripplanner-app.conf.j2
@@ -11,4 +11,4 @@ respawn
 setuid {{ app_username }}
 chdir {{ root_app_dir }}
 
-exec gunicorn --config {{ root_conf_dir }}/gunicorn.py --timeout 90 cac_tripplanner.wsgi
+exec gunicorn --config {{ root_conf_dir }}/gunicorn.py --timeout {{ otp_session_timeout }} cac_tripplanner.wsgi

--- a/deployment/ansible/roles/cac-tripplanner.app/templates/upstart-cac-tripplanner-app.conf.j2
+++ b/deployment/ansible/roles/cac-tripplanner.app/templates/upstart-cac-tripplanner-app.conf.j2
@@ -11,4 +11,4 @@ respawn
 setuid {{ app_username }}
 chdir {{ root_app_dir }}
 
-exec gunicorn --config {{ root_conf_dir }}/gunicorn.py --timeout {{ otp_session_timeout }} cac_tripplanner.wsgi
+exec gunicorn --config {{ root_conf_dir }}/gunicorn.py --timeout {{ otp_session_timeout_s }} cac_tripplanner.wsgi

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -239,6 +239,12 @@ CAC.Map.Control = (function ($, Handlebars, L, _) {
             cutoffSec: exploreMinutes * 60, // API expects seconds
         };
 
+        // Default precision of 200m; 100m seems good for improving response times on non-transit
+        // http://dev.opentripplanner.org/apidoc/0.12.0/resource_LIsochrone.html
+        if (otpParams.mode === 'WALK' || otpParams.mode === 'BICYCLE') {
+            params.precisionMeters = 100;
+        }
+
         params = $.extend(otpParams, params);
 
         if (coordsOrigin) {


### PR DESCRIPTION
Pending azavea/ansible-opentripplanner/pull/13.

Large isochrones may hit the 30s timeout; this increases the timeout to 90s for OTP/gunicorn/nginx, and tweaks the isochrone precision for some requests, to speed processing.