### PR TITLE
Feature/pois

### DIFF
--- a/src/app/scripts/cac/search/cac-geocoder.js
+++ b/src/app/scripts/cac/search/cac-geocoder.js
@@ -36,12 +36,51 @@ CAC.Search.Geocoder = (function ($, SearchParams) {
             data: params,
             dataType: 'json',
             success: function (data) {
-                if (data && data.locations && data.locations.length) {
-                    dfd.resolve(data.locations[0]);
-                } else {
-                    // no geocode result found; return null
-                    dfd.resolve(null);
-                }
+                if (data && data.locations && data.locations.length &&
+                    data.locations[0].feature.attributes.StAddr.length) {
+                        // results with a street address are probably good
+                        dfd.resolve(data.locations[0]);
+                    } else {
+                        // Deal with geocoder not being able to handle all POI results from
+                        // suggest service when POI name comes before street address.
+                        var splitText = text.split(', ');
+                        if (splitText.length > 1) {
+                            var maybeStAddr = splitText[1].split(' ')[0];
+                            if (!isNaN(maybeStAddr)) {
+                                // probably have POI with street address after name
+                                var newText = '';
+                                for (var i = 1; i < splitText.length; i++) {
+                                    newText += splitText[i] + ', ';
+                                }
+                                // try searching again without the POI name part
+                                params.text = newText;
+                                $.ajax(url, {
+                                    data: params,
+                                    dataType: 'json',
+                                    success: function (data) {
+                                        if (data && data.locations && data.locations.length &&
+                                            data.locations[0].feature.attributes.StAddr.length) {
+                                            // second search got something with a street address;
+                                            // it is probably good now
+                                            dfd.resolve(data.locations[0]);
+                                        } else {
+                                            // no good geocode result found on second search
+                                            dfd.resolve(null);
+                                        }
+                                    }, error: function (error) {
+                                        dfd.reject(error);
+                                    }
+                                });
+                            } else if (data && data.locations && data.locations.length) {
+                                // might have result for searching on something that has no
+                                // street address, such as a city name or zip code
+                                dfd.resolve(data.locations[0]);
+                            } else {
+                                // no result found
+                                dfd.resolve(null);
+                            }
+                        }
+                    }
             },
             error: function (error) {
                 dfd.reject(error);

--- a/src/app/scripts/cac/search/cac-search-params.js
+++ b/src/app/scripts/cac/search/cac-search-params.js
@@ -18,7 +18,8 @@ CAC.Search.SearchParams = (function () {
     var searchCategories = ['Address',
                             'Postal',
                             'Coordinate System',
-                            'Populated Place'
+                            'Populated Place',
+                            'POI'
                             ].join(',');
 
     var module = {

--- a/src/app/scripts/cac/search/cac-typeahead.js
+++ b/src/app/scripts/cac/search/cac-typeahead.js
@@ -164,7 +164,7 @@ CAC.Search.Typeahead = (function (_, $, SearchParams) {
 
             // Due to bug, cannot specify both searchExtent and location
             // https://geonet.esri.com/thread/132900
-            delete params.searchExtent;
+            // delete params.searchExtent;
         }
 
         var adapter = new Bloodhound({

--- a/src/app/scripts/cac/search/cac-typeahead.js
+++ b/src/app/scripts/cac/search/cac-typeahead.js
@@ -154,6 +154,9 @@ CAC.Search.Typeahead = (function (_, $, SearchParams) {
             f: 'pjson'
         };
 
+        // TODO: re-enable result distance ranking when bug fixed to work with searchExtent
+        // https://geonet.esri.com/thread/132900
+        /*
         // rank results by distance, if we have user location
         if (thisLocation) {
             params.location = [
@@ -161,11 +164,8 @@ CAC.Search.Typeahead = (function (_, $, SearchParams) {
                 thisLocation[0].feature.geometry.y
             ].join(',');
             params.distance = 16093; // ~10mi.
-
-            // Due to bug, cannot specify both searchExtent and location
-            // https://geonet.esri.com/thread/132900
-            // delete params.searchExtent;
         }
+        */
 
         var adapter = new Bloodhound({
             datumTokenizer: Bloodhound.tokenizers.obj.whitespace('text'),


### PR DESCRIPTION
Enable POIs in typeahead suggestions.  Fixes issue with POIs not geocoding properly when the place name comes before its street address.  Disables ranking search results by distance in favor of using bounding box, as requested by @jbranigan.