### PR TITLE
Don't run dist-upgrade when creating AMIs

### DIFF
--- a/deployment/packer/cac.json
+++ b/deployment/packer/cac.json
@@ -43,7 +43,6 @@
       "inline": [
         "sleep 10",
         "sudo apt-get update",
-        "sudo apt-get -y dist-upgrade",
         "mkdir -p {{user `ansible_staging_directory`}}",
         "mkdir -p {{user `intermediate_directory`}}",
         "sudo apt-get -y install build-essential python-dev python-pip git",


### PR DESCRIPTION
We are always grabbing the latest available AMI, so there should
be no reason to perform an upgrade. And if there is a change, such
as a kernel update, it could require user input when installing
the bootloader, which will cause Packer to fail.