### PR TITLE
Feature/styling geocode caching fixes

### DIFF
--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -42,6 +42,7 @@
     <script src="{% static 'scripts/vendor/typeahead.bundle.js' %}"></script>
     <script src="{% static 'scripts/vendor/leaflet.awesome-markers.js' %}"></script>
     <script src="{% static 'scripts/vendor/moment.js' %}"></script>
+    <script src="{% static 'scripts/vendor/moment-duration-format.js' %}"></script>
     <script src="{% static 'scripts/vendor/bootstrap-datetimepicker.js' %}"></script>
     <script src="{% static 'scripts/vendor/bootstrap-select.js' %}"></script>
 

--- a/src/app/scripts/cac/control/cac-control-directions-list.js
+++ b/src/app/scripts/cac/control/cac-control-directions-list.js
@@ -117,38 +117,52 @@ CAC.Control.DirectionsList = (function ($, Handlebars, UserPreferences, Utils) {
         });
 
         var templateData = {
+            showBackButton: options.showBackButton,
+            showShareButton: options.showShareButton,
             start: {
                 text:  UserPreferences.getPreference('fromText'),
-                time: new Date(itinerary.startTime).toLocaleTimeString()
+                time: itinerary.startTime
             },
             end: {
                 text:  UserPreferences.getPreference('toText'),
-                time: new Date(itinerary.endTime).toLocaleTimeString()
+                time: itinerary.endTime
             },
             legs: itinerary.legs
         };
+
+        console.log(templateData);
 
         // The &nbsp;'s are used instead of 'hide' classes because of some styling-related issues
         var source = [
             '<div class="block block-step directions-header">',
                 'Directions',
-                '<div class="pull-right"><a class="back pull-right">' + (options.showBackButton ? '<i class="md md-close"></i>' : '&nbsp;') + '</a></div>',
-                '<div class="pull-right"><a class="share">' + (options.showShareButton ? '<i class="md md-share"></i>' : '&nbsp;') + '</a> <span class="directions-header-divider">|</span> </div>',
+                '{{#if data.showBackButton}}<div class="pull-right"><a class="back pull-right">',
+                 '<i class="md md-close"></i></a></div>{{/if}}',
+                '<div class="pull-right">{{#if data.showShareButton}}<a class="share">',
+                 '<i class="md md-share"></i></a>{{/if}} ',
+                 '<span class="directions-header-divider">|</span> </div>',
+            '</div>',
+            '<div class="block block-step direction-depart">',
+                '<table><tr><td class="direction-icon"><i class="md md-place"></i></td>',
+                    '<td>Depart from <strong>{{data.start.text}} at {{datetime data.start.time}}</td>',
+                '</tr></table></strong>',
             '</div>',
             '<div class="block-legs">',
                 '{{#each data.legs}}',
                     '<div class="block block-leg">',
                         '<div class="trip-numbers">',
                             '<div class="trip-duration">',
-                                // TODO: Replace with time in minutes
-                                '{{inMiles this.distance}} min',
+                                '{{this.formattedDuration}}',
                             '</div>',
                             '<div class="trip-distance">',
                                 '{{inMiles this.distance}} mi',
                             '</div>',
                         '</div>',
                         '<div class="trip-details">',
-                            '<div class="direction-section"><table><tr><td class="direction-icon">{{modeIcon this.mode}}</td><td class="direction-text">{{#if this.transitLeg}}{{this.agencyName}} {{this.route}} {{this.headsign}}{{/if}} to {{this.to.name}}</td></tr></table></div>',
+                            '<div class="direction-section"><table><tr><td class="direction-icon">',
+                            '{{modeIcon this.mode}}</td><td class="direction-text">',
+                            '{{#if this.transitLeg}}{{this.agencyName}} {{this.route}} {{this.headsign}}{{/if}} ',
+                            'to {{this.to.name}}</td></tr></table></div>',
                             '<div class="block direction-item"',
                             ' data-lat="{{this.from.lat}}" data-lon="{{this.from.lon}}" >',
                                 '{{#each steps}}',
@@ -167,7 +181,9 @@ CAC.Control.DirectionsList = (function ($, Handlebars, UserPreferences, Utils) {
                 '{{/each}}',
             '</div>',
             '<div class="block block-step direction-arrive">',
-                '<table><tr><td class="direction-icon"><i class="md md-place"></i></td><td>Arrive at <strong>{{data.end.text}} at {{data.end.time}}</td></tr></table></strong>',
+                '<table><tr><td class="direction-icon"><i class="md md-place"></i></td>',
+                    '<td>Arrive at <strong>{{data.end.text}} at {{datetime data.end.time}}</td>',
+                '</tr></table></strong>',
             '</div>',
         ].join('');
         var template = Handlebars.compile(source);

--- a/src/app/scripts/cac/control/cac-control-directions-list.js
+++ b/src/app/scripts/cac/control/cac-control-directions-list.js
@@ -130,8 +130,6 @@ CAC.Control.DirectionsList = (function ($, Handlebars, UserPreferences, Utils) {
             legs: itinerary.legs
         };
 
-        console.log(templateData);
-
         // The &nbsp;'s are used instead of 'hide' classes because of some styling-related issues
         var source = [
             '<div class="block block-step directions-header">',
@@ -160,8 +158,10 @@ CAC.Control.DirectionsList = (function ($, Handlebars, UserPreferences, Utils) {
                         '</div>',
                         '<div class="trip-details">',
                             '<div class="direction-section"><table><tr><td class="direction-icon">',
-                            '{{modeIcon this.mode}}</td><td class="direction-text">',
-                            '{{#if this.transitLeg}}{{this.agencyName}} {{this.route}} {{this.headsign}}{{/if}} ',
+                            '{{modeIcon this.mode}}</td><td class="direction-text direction-item"',
+                            ' data-lat="{{this.from.lat}}" data-lon="{{this.from.lon}}" >',
+                            '{{#if this.transitLeg}}{{this.agencyName}} {{this.route}} ',
+                                '{{this.headsign}}{{/if}} ',
                             'to {{this.to.name}}</td></tr></table></div>',
                             '<div class="block direction-item"',
                             ' data-lat="{{this.from.lat}}" data-lon="{{this.from.lon}}" >',

--- a/src/app/scripts/cac/control/cac-control-itinerary-list.js
+++ b/src/app/scripts/cac/control/cac-control-itinerary-list.js
@@ -71,7 +71,7 @@ CAC.Control.ItineraryList = (function ($, Handlebars, Utils) {
         var source = '{{#each itineraries}}' +
                 '<div class="block block-itinerary" data-itinerary="{{this.id}}">' +
                     '<div class="trip-numbers">' +
-                        '<div class="trip-duration"> {{this.durationMinutes}} min</div>' +
+                        '<div class="trip-duration"> {{this.formattedDuration}}</div>' +
                         '<div class="trip-distance"> {{this.distanceMiles}} mi</div>' +
                     '</div>' +
                     '<div class="trip-details">' +

--- a/src/app/scripts/cac/control/cac-control-sidebar-explore.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-explore.js
@@ -274,8 +274,8 @@ CAC.Control.SidebarExplore = (function ($, BikeModeOptions, Geocoder, MapTemplat
         }
 
         // first check if we have distance cached
-        if (destination.durationMinutes) {
-            setDestinationMinutesText(destination.durationMinutes);
+        if (destination.formattedDuration) {
+            setDestinationMinutesText(destination.formattedDuration);
             return;
         }
 
@@ -309,8 +309,8 @@ CAC.Control.SidebarExplore = (function ($, BikeModeOptions, Geocoder, MapTemplat
         Routing.planTrip(exploreLatLng, dest, date, otpOptions)
             .then(function (itineraries) {
             if (itineraries.length) {
-                var distance = itineraries[0].durationMinutes;
-                destination.durationMinutes = distance;
+                var distance = itineraries[0].formattedDuration;
+                destination.formattedDuration = distance;
                 setDestinationMinutesText(distance);
             }
         });

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -85,15 +85,20 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
     function destinationDetail(destination) {
         var source = [
             '<div class="block-detail">',
-                '<div class="trip-numbers">{{#if d.durationMinutes}}<div class="trip-duration"> {{ d.durationMinutes }} min</div>{{/if}}<div class="trip-distance">{{ d.distanceMiles }}</div></div>',
+                '<div class="trip-numbers">{{#if d.formattedDuration}}<div class="trip-duration"> ',
+                '{{ d.formattedDuration }}</div>{{/if}}<div class="trip-distance">',
+                '{{ d.distanceMiles }}</div></div>',
                 '<h3>{{ d.name }}</h3>',
-                '<img class="explore-block" src="{{#if d.wide_image}}{{ d.wide_image }}{{^}}https://placehold.it/300x150{{/if}}" />',
-                '<div class="explore-block">{{{ d.description }}}</div>',    // the parent element of whatever is put here is a <p> tag
+                '<img class="explore-block" src="{{#if d.wide_image}}{{ d.wide_image }}',
+                    '{{^}}https://placehold.it/300x150{{/if}}" />',
+                    // the parent element of whatever is put here is a <p> tag
+                '<div class="explore-block">{{{ d.description }}}</div>',
                 '<div class="explore-block">',
                     '<div class="row">',
                         // .back and .getdirections are used to select these elements for the click event
                         '<div class="col-xs-6"><a class="back btn btn-primary btn-block">Back</a></div>',
-                        '<div class="col-xs-6"><a class="getdirections btn btn-primary btn-block">Get Directions</a></div>',
+                        '<div class="col-xs-6"><a class="getdirections btn btn-primary btn-block">',
+                            'Get Directions</a></div>',
                     '</div>',
                 '</div>',
             '</div>'

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -14,7 +14,7 @@ CAC.Routing.Itinerary = (function ($, L, _, Geocoder) {
         this.via = getVia(otpItinerary);
         this.modes = getModes(otpItinerary);
         this.distanceMiles = getDistanceMiles(otpItinerary);
-        this.durationMinutes = getDurationMinutes(otpItinerary);
+        this.formattedDuration = getFormattedDuration(otpItinerary);
         this.startTime = otpItinerary.startTime;
         this.endTime = otpItinerary.endTime;
         this.legs = getLegs(otpItinerary.legs);
@@ -108,14 +108,18 @@ CAC.Routing.Itinerary = (function ($, L, _, Geocoder) {
     }
 
     /**
-     * Helper function to get label/via summary for an itinerary
+     * Helper function to get label/via summary for an itinerary or leg
      *
-     * @param {object} otpItinerary OTP itinerary
+     * @param {object} otpItinerary OTP itinerary or leg
      *
-     * @return {integer} duration of itinerary in minutes
+     * @return {string} duration of itinerary/leg, formatted with unit (minutes, hours, etc.)
      */
-    function getDurationMinutes(otpItinerary) {
-        return parseInt(otpItinerary.duration / 60.0);
+    function getFormattedDuration(otpItineraryLeg) {
+        var mins = parseInt(otpItineraryLeg.duration / 60.0);
+        console.log(mins);
+        var str = mins.toString() + ' min';
+        console.log(str);
+        return str;
     }
 
     /**
@@ -174,6 +178,7 @@ CAC.Routing.Itinerary = (function ($, L, _, Geocoder) {
                     leg.to.name = name;
                 });
             }
+            leg.formattedDuration = getFormattedDuration(leg);
             return leg;
         });
     }

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -1,4 +1,4 @@
-CAC.Routing.Itinerary = (function ($, L, _, Geocoder) {
+CAC.Routing.Itinerary = (function ($, L, _, moment, Geocoder) {
     'use strict';
 
     /**
@@ -112,13 +112,19 @@ CAC.Routing.Itinerary = (function ($, L, _, Geocoder) {
      *
      * @param {object} otpItinerary OTP itinerary or leg
      *
-     * @return {string} duration of itinerary/leg, formatted with unit (minutes, hours, etc.)
+     * @return {string} duration of itinerary/leg, formatted with units (hrs, min, s)
      */
     function getFormattedDuration(otpItineraryLeg) {
-        var mins = parseInt(otpItineraryLeg.duration / 60.0);
-        console.log(mins);
-        var str = mins.toString() + ' min';
-        console.log(str);
+        // x hrs, y min, z s (will trim empty units from left)
+        var fmt = 'h [hrs], m [min], ss [s]';
+        var str = moment.duration(otpItineraryLeg.duration, 'seconds').format(fmt);
+        // trim empty seconds from right of string
+        var emptySecIdx = str.indexOf(', 00 s');
+        if (emptySecIdx > 0) {
+            str = str.substring(0, emptySecIdx);
+        }
+        // fix hour singular
+        str = str.replace('1 hrs,', '1 hr,');
         return str;
     }
 
@@ -205,4 +211,4 @@ CAC.Routing.Itinerary = (function ($, L, _, Geocoder) {
         return defaultStyle;
     }
 
-})(jQuery, L, _, CAC.Search.Geocoder);
+})(jQuery, L, _, moment, CAC.Search.Geocoder);

--- a/src/app/scripts/cac/search/cac-geocoder.js
+++ b/src/app/scripts/cac/search/cac-geocoder.js
@@ -35,6 +35,7 @@ CAC.Search.Geocoder = (function ($, SearchParams) {
         $.ajax(url, {
             data: params,
             dataType: 'json',
+            cache: true,
             success: function (data) {
                 if (data && data.locations && data.locations.length &&
                     data.locations[0].feature.attributes.StAddr.length) {
@@ -57,6 +58,7 @@ CAC.Search.Geocoder = (function ($, SearchParams) {
                                 $.ajax(url, {
                                     data: params,
                                     dataType: 'json',
+                                    cache: true,
                                     success: function (data) {
                                         if (data && data.locations && data.locations.length &&
                                             data.locations[0].feature.attributes.StAddr.length) {
@@ -105,7 +107,8 @@ CAC.Search.Geocoder = (function ($, SearchParams) {
             location: [lng, lat].join(','),
             distance: 900,  // radius, in meters, to search within; defaults to 100m
             returnIntersection: true,
-            f: 'pjson'
+            f: 'pjson',
+            cache: true
         };
 
         $.ajax(reverseUrl, {

--- a/src/app/styles/components/_sidebar-route.scss
+++ b/src/app/styles/components/_sidebar-route.scss
@@ -26,6 +26,12 @@
     padding: 15px 0 20px;
 }
 
+.direction-depart {
+    border-bottom: 2px solid #bbb;
+    font-size: 16px;
+    padding: 15px 0 20px;
+}
+
 .direction-text {
     padding-right: 8px;
 }

--- a/src/bower.json
+++ b/src/bower.json
@@ -11,6 +11,7 @@
     "leaflet": "^0.7.3",
     "Leaflet.encoded": "^0.0.5",
     "moment": "^2.9.0",
+    "moment-duration-format": "^1.3.0",
     "lodash": "^3.6.0",
     "spinkit": "^1.0.1",
     "typeahead.js": "~0.10.5",


### PR DESCRIPTION
* Use [moment-duration-format](https://www.npmjs.com/package/moment-duration-format) for formatting travel times

* Fix issue with asynchronously fetched reverse geocoded direction step labels not showing up on directions page

* Fix issue with formatted date/times not displaying properly on directions page data refresh

* Post-styling fixes for directions list (fix hover interactivity for transit, add departure info, fix step travel times)