### PR TITLE
Feature/link shortener encoding

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -20,15 +20,16 @@ root_media_dir: "/media/cac"
 app_cron_event_feed: "cd {{ root_app_dir }} && python manage.py load_events >> {{ app_cron_event_feed_log }} 2>&1"
 
 cac_python_dependencies:
-    - { name: 'boto', version: '2.36.0' }
-    - { name: 'django', version: '1.7.7' }
+    - { name: 'base58', version: '0.2.1' }
+    - { name: 'boto', version: '2.38.0' }
+    - { name: 'django', version: '1.7.8' }
     - { name: 'django-ckeditor', version: '4.4.7' }
-    - { name: 'django-extensions', version: '1.5.2' }
+    - { name: 'django-extensions', version: '1.5.3' }
     - { name: 'django-storages-redux', version: '1.2.3' }
     - { name: 'django-wpadmin', version: '1.7.2'}
     - { name: 'gunicorn', version: '19.3.0'}
     - { name: 'ipython', version: '2.3.1' }
-    - { name: 'pillow', version: '2.7.0' }
+    - { name: 'pillow', version: '2.8.1' }
     - { name: 'psycopg2', version: '2.5.4' }
     - { name: 'pytz', version: '2015.2' }
     - { name: 'pyyaml', version: '3.11' }

--- a/python/cac_tripplanner/shortlinks/migrations/0002_auto_20150507_1413.py
+++ b/python/cac_tripplanner/shortlinks/migrations/0002_auto_20150507_1413.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shortlinks', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='shortenedlink',
+            name='key',
+            field=models.CharField(max_length=22, db_index=True),
+            preserve_default=True,
+        ),
+    ]

--- a/python/cac_tripplanner/shortlinks/models.py
+++ b/python/cac_tripplanner/shortlinks/models.py
@@ -3,7 +3,7 @@ from django.db import models
 
 class ShortenedLink(models.Model):
     """Represents a shortened URL used to share routes"""
-    key = models.CharField(max_length=24, db_index=True)  # base-64-encoded UUID
+    key = models.CharField(max_length=22, db_index=True)  # base-58-encoded UUID
     destination = models.CharField(max_length=512)
     create_date = models.DateTimeField(auto_now_add=True)
     is_public = models.BooleanField(default=True)

--- a/python/cac_tripplanner/shortlinks/shortener.py
+++ b/python/cac_tripplanner/shortlinks/shortener.py
@@ -1,13 +1,10 @@
-import base64
+from base58 import b58encode
 import uuid
 
 
-# TODO: Switch this to use a shorter scheme, e.g. base58 a la Flickr, or
-# some sort of hashing if we want to ensure that identical routes receive the
-# same shortened link.
 class LinkShortener(object):
     """Shorten links"""
     # If the logic of this function is changed, you will also likely need to
     # change urls.py and the ShortenedLink.key field.
     def generate_key(self, link_text):
-        return base64.urlsafe_b64encode(uuid.uuid4().bytes)
+        return b58encode(uuid.uuid4().bytes)

--- a/python/cac_tripplanner/shortlinks/tests.py
+++ b/python/cac_tripplanner/shortlinks/tests.py
@@ -23,7 +23,7 @@ class LinkShortenerTestCase(TestCase):
 
     def test_generate_key(self):
         shortener = LinkShortener()
-        self.assertEqual(len(shortener.generate_key(self.long_link)), 24)
+        self.assertEqual(len(shortener.generate_key(self.long_link)), 22)
 
 
 class ShortenedLinkModelsTestCase(TestCase):
@@ -100,14 +100,14 @@ class ShortenedLinkViewsTestCase(TestCase):
         response = self.client.post('/link/shorten/')
         self.assertEqual(response.status_code, 400)
 
-        response = self.client.post('/link/abcdefghijklmnopqrstuvwx')
+        response = self.client.post('/link/abcdefghijklmnopqrstuv')
         self.assertEqual(response.status_code, 405)
-        response = self.client.get('/link/abcdefghijklmnopqrstuvwx')
+        response = self.client.get('/link/abcdefghijklmnopqrstuv')
         self.assertEqual(response.status_code, 404)
         # This will throw an error if it fails; this is to make sure that the
         # URL resolution is fully working since the redirect method will return a
         # 404 if it is given a bad key.
-        reverse('dereference-shortened', kwargs={'key': u'CMBOzqQbSPq25N-9BTD_4w=='})
+        reverse('dereference-shortened', kwargs={'key': u'CMBOzqQbSPq25N29BTD54w'})
 
 
 class ShortenedLinkCreateTestCase(TestCase):

--- a/python/cac_tripplanner/shortlinks/urls.py
+++ b/python/cac_tripplanner/shortlinks/urls.py
@@ -5,7 +5,7 @@ from .views import ShortenedLinkRedirectView, ShortenedLinkCreateView
 
 urlpatterns = patterns(
     '',
-    url(r'^(?P<key>[-=\w]{24})$', ShortenedLinkRedirectView.as_view(),
+    url(r'^(?P<key>[1-9A-Za-z]{22})$', ShortenedLinkRedirectView.as_view(),
         name='dereference-shortened'),
     url(r'^shorten/$', csrf_exempt(ShortenedLinkCreateView.as_view()),
         name='shorten-link')


### PR DESCRIPTION
* Use base 58 instead of base 64 encoding for shortened URLs.
  - The existing shortened URLs in the database will need to be dropped
* Update minor versions on some of the app pip-installed packages

I found [python-basehash](https://github.com/bnlucas/python-basehash) while working on this, which might be suitable if we want shortened URLs to always be the same for a shortened address. However, I doubt there will be many cases of the exact same trip getting shared, so I'm not sure how useful that would be.
