### PR TITLE
Change icons and colors

### DIFF
--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -38,15 +38,15 @@ CAC.Map.Control = (function ($, Handlebars, L, _) {
     var tabControl = null;
 
     var destinationIcon = L.AwesomeMarkers.icon({
-        icon: 'plane',
-        prefix: 'fa',
-        markerColor: 'blue'
+        icon: 'beenhere',
+        prefix: 'md',
+        markerColor: 'green'
     });
     var highlightIcon = L.AwesomeMarkers.icon({
-        icon: 'plane',
-        prefix: 'fa',
+        icon: 'beenhere',
+        prefix: 'md',
         iconColor: 'black',
-        markerColor: 'lightblue'
+        markerColor: 'lightgreen'
     });
 
     var esriSatelliteAttribution = [
@@ -525,7 +525,7 @@ CAC.Map.Control = (function ($, Handlebars, L, _) {
             var originIcon = L.AwesomeMarkers.icon({
                 icon: 'home',
                 prefix: 'fa',
-                markerColor: 'green'
+                markerColor: 'purple'
             });
 
             var destIcon = L.AwesomeMarkers.icon({

--- a/src/app/scripts/cac/map/cac-map-overlays.js
+++ b/src/app/scripts/cac/map/cac-map-overlays.js
@@ -58,7 +58,7 @@ CAC.Map.OverlaysControl = (function ($, L) {
         var latLng = L.latLng(share.geometry.coordinates[1], share.geometry.coordinates[0]);
         var icon = L.AwesomeMarkers.icon({
             icon: 'directions-bike',
-            markerColor: 'green',
+            markerColor: 'blue',
             prefix: 'md'
         });
         var marker = new L.marker(latLng, { icon: icon });
@@ -70,7 +70,7 @@ CAC.Map.OverlaysControl = (function ($, L) {
         var latLng = L.latLng(event.point.coordinates[1], event.point.coordinates[0]);
         var icon = L.AwesomeMarkers.icon({
             icon: 'calendar',
-            markerColor: 'gray',
+            markerColor: 'orange',
             prefix: 'fa'
         });
         var marker = new L.marker(latLng, { icon: icon });


### PR DESCRIPTION
Changes suggested by #156 and #267.

Changes featured location icon, and switches around icon colors: featured locations are green, bike share stations are blue, home is purple, and Uwishunu events are orange.

![image](https://cloud.githubusercontent.com/assets/960264/7545290/85ef233e-f5a2-11e4-8089-7f1c5b0ac7d1.png)
