### PR TITLE
Feature/cleared typeahead

### DIFF
--- a/python/cac_tripplanner/templates/map.html
+++ b/python/cac_tripplanner/templates/map.html
@@ -12,7 +12,7 @@
         </div>
         <section class="explore" data-sidebar-tab="true">
             <div class="sidebar-block sidebar-search">
-                <input id="exploreOrigin" class="typeahead" data-typeahead-key="search"
+                <input class="typeahead search" data-typeahead-key="search"
                     type="search" placeholder="Search by location" />
                 <button type="submit"><span class="glyphicon glyphicon-search"></span></button>
             </div>

--- a/src/app/scripts/cac/user/cac-user-preferences.js
+++ b/src/app/scripts/cac/user/cac-user-preferences.js
@@ -6,42 +6,13 @@ CAC.User.Preferences = (function($) {
     var namespaceStorage = $.initNamespaceStorage(namespace);
     var storage = namespaceStorage.localStorage;
 
-    // store to use for default location
-    var cityHall = {
-        name: 'Philadelphia City Hall',
-        extent: {
-            xmax: -75.158978,
-            xmin: -75.168978,
-            ymax: 39.958449,
-            ymin: 39.948449
-        },
-        feature: {
-            attributes: {
-                City: 'Philadelphia',
-                Postal: '',
-                Region: 'Pennsylvania',
-                StAddr: '1450 John F Kennedy Blvd'
-            },
-            geometry: {
-                x: -75.16397666699964,
-                y: 39.95344911900048
-            }
-        }
-    };
-
     var defaults = {
         arriveBy: false, // depart at set time, by default
         bikeTriangle: 'neutral',
         exploreTime: 20,
-        from: undefined, // use current location for directions origin if none set
-        fromText: 'Current Location',
         maxWalk: undefined, // no max
         method: 'explore',
         mode: 'TRANSIT,WALK',
-        origin: cityHall,
-        originText: 'City Hall, Philadelphia, Pennsylvania, USA',
-        to: cityHall,
-        toText: 'City Hall, Philadelphia, Pennsylvania, USA',
         wheelchair: false
     };
 

--- a/src/app/styles/atoms/_twitter-typeahead.scss
+++ b/src/app/styles/atoms/_twitter-typeahead.scss
@@ -3,6 +3,16 @@
  * https://github.com/twitter/typeahead.js/blob/master/doc/jquery_typeahead.md#look-and-feel
  */
 .twitter-typeahead {
+    &::-webkit-input-placeholder {
+        color: gray;
+        opacity: 0.75;
+        font-style: italic;
+    }
+    &:-moz-placeholder,
+    &::-moz-placeholder
+    &:-ms-input-placeholder {
+        color: gray;
+    }
     input:focus::-webkit-input-placeholder { color:transparent; }
     input:focus:-moz-placeholder { color:transparent; } /* FF 4-18 */
     input:focus::-moz-placeholder { color:transparent; } /* FF 19+ */
@@ -11,7 +21,6 @@
     .tt-dropdown-menu {
         background-color: white;
         border: 1px solid #ccc;
-        color: black;
         min-width: 100%;
         text-align: left;
         margin-top: 5px;
@@ -26,4 +35,8 @@
             padding: 10px 15px;
         }
     }
+}
+
+.tt-hint {
+    color: #999;
 }

--- a/src/app/styles/atoms/_twitter-typeahead.scss
+++ b/src/app/styles/atoms/_twitter-typeahead.scss
@@ -3,7 +3,10 @@
  * https://github.com/twitter/typeahead.js/blob/master/doc/jquery_typeahead.md#look-and-feel
  */
 .twitter-typeahead {
-    
+    input:focus::-webkit-input-placeholder { color:transparent; }
+    input:focus:-moz-placeholder { color:transparent; } /* FF 4-18 */
+    input:focus::-moz-placeholder { color:transparent; } /* FF 19+ */
+    input:focus:-ms-input-placeholder { color:transparent; } /* IE 10+ */
 
     .tt-dropdown-menu {
         background-color: white;

--- a/src/app/styles/components/_blocks.scss
+++ b/src/app/styles/components/_blocks.scss
@@ -13,7 +13,7 @@
             &:first-of-type {
                 margin-bottom: 15px;
             }
-            
+
             h3 { font-size: 2.1rem; bottom: 65px; }
             h5 { font-size: 1.4rem; bottom: 45px; }
             h5.destination-address-2 {

--- a/src/app/styles/components/_search.scss
+++ b/src/app/styles/components/_search.scss
@@ -28,14 +28,14 @@
         vertical-align: middle;
 
         &::-webkit-input-placeholder {
-            color: white;
+            color: gray;
             opacity: 0.75;
             font-style: italic;
         }
         &:-moz-placeholder,
         &::-moz-placeholder
         &:-ms-input-placeholder {
-            color: white;
+            color: gray;
         }
 
         &[type="number"] {
@@ -50,8 +50,7 @@
         margin: 0 0 0 15px;
         height: 70px;
         padding: 7px 0;
-        vertical-align: middle;    
-    
+        vertical-align: middle;
         .btn-transit {
             font-size: 21px;
             background: transparent;

--- a/src/app/styles/components/_search.scss
+++ b/src/app/styles/components/_search.scss
@@ -52,6 +52,9 @@
         &[type="text"]:not(.form-control) {
             width: 260px;
         }
+        &.error {
+            border: solid 1px blue;
+        }
     }
     .transit-types-container {
         display: inline-block;

--- a/src/app/styles/components/_search.scss
+++ b/src/app/styles/components/_search.scss
@@ -14,18 +14,6 @@
     span.twitter-typeahead {
         vertical-align: middle;
         margin: 0 15px;
-    }
-    input[type="number"] {
-        margin: 0 15px;
-    }
-    input:not([type="checkbox"]) {
-        background: white;
-        border: none;
-        color: black;
-        padding: 17px 14px;
-        height: 60px;
-        border-radius: 9px;
-        vertical-align: middle;
 
         &::-webkit-input-placeholder {
             color: gray;
@@ -37,6 +25,26 @@
         &:-ms-input-placeholder {
             color: gray;
         }
+
+        focus::-webkit-input-placeholder { color:transparent; }
+        focus:-moz-placeholder { color:transparent; } /* FF 4-18 */
+        focus::-moz-placeholder { color:transparent; } /* FF 19+ */
+        focus:-ms-input-placeholder { color:transparent; } /* IE 10+ */
+
+        .tt-hint {
+            color: #999;
+        }
+    }
+    input[type="number"] {
+        margin: 0 15px;
+    }
+    input:not([type="checkbox"]) {
+        background: white;
+        border: none;
+        padding: 17px 14px;
+        height: 60px;
+        border-radius: 9px;
+        vertical-align: middle;
 
         &[type="number"] {
             width: 70px;

--- a/src/app/styles/templates/_homepage.scss
+++ b/src/app/styles/templates/_homepage.scss
@@ -51,6 +51,17 @@
         input:focus:-moz-placeholder { color:transparent; } /* FF 4-18 */
         input:focus::-moz-placeholder { color:transparent; } /* FF 19+ */
         input:focus:-ms-input-placeholder { color:transparent; } /* IE 10+ */
+
+         &::-webkit-input-placeholder {
+            color: gray;
+            opacity: 0.75;
+            font-style: italic;
+        }
+        &:-moz-placeholder,
+        &::-moz-placeholder
+        &:-ms-input-placeholder {
+            color: gray;
+        }
     }
     .content {
         padding: 80px 0;

--- a/src/app/styles/templates/_homepage.scss
+++ b/src/app/styles/templates/_homepage.scss
@@ -33,6 +33,7 @@
                 }
             }
         }
+
         & > .search {
             position: absolute;
             width: 100%;

--- a/src/app/styles/templates/_homepage.scss
+++ b/src/app/styles/templates/_homepage.scss
@@ -45,6 +45,13 @@
             }
         }
     }
+
+    .twitter-typeahead {
+        input:focus::-webkit-input-placeholder { color:transparent; }
+        input:focus:-moz-placeholder { color:transparent; } /* FF 4-18 */
+        input:focus::-moz-placeholder { color:transparent; } /* FF 19+ */
+        input:focus:-ms-input-placeholder { color:transparent; } /* IE 10+ */
+    }
     .content {
         padding: 80px 0;
 


### PR DESCRIPTION
* Trigger event when typeahead input field cleared
* Listen to event and delete location object associated with field (do not use default or previous location)
* Handle missing locations (clear results; do not attempt to fetch results; set error class on input)
* Fix styling issues with typeahead, placeholder text, and input error class

Addresses one of the issues in #248.