### PR TITLE
Handle variable-length shortened URLs

### DIFF
--- a/python/cac_tripplanner/shortlinks/migrations/0003_auto_20150513_1039.py
+++ b/python/cac_tripplanner/shortlinks/migrations/0003_auto_20150513_1039.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shortlinks', '0002_auto_20150507_1413'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='shortenedlink',
+            name='key',
+            field=models.CharField(max_length=30, db_index=True),
+            preserve_default=True,
+        ),
+    ]

--- a/python/cac_tripplanner/shortlinks/models.py
+++ b/python/cac_tripplanner/shortlinks/models.py
@@ -3,7 +3,7 @@ from django.db import models
 
 class ShortenedLink(models.Model):
     """Represents a shortened URL used to share routes"""
-    key = models.CharField(max_length=22, db_index=True)  # base-58-encoded UUID
+    key = models.CharField(max_length=30, db_index=True)  # base-58-encoded UUID
     destination = models.CharField(max_length=512)
     create_date = models.DateTimeField(auto_now_add=True)
     is_public = models.BooleanField(default=True)

--- a/python/cac_tripplanner/shortlinks/urls.py
+++ b/python/cac_tripplanner/shortlinks/urls.py
@@ -5,7 +5,7 @@ from .views import ShortenedLinkRedirectView, ShortenedLinkCreateView
 
 urlpatterns = patterns(
     '',
-    url(r'^(?P<key>[1-9A-Za-z]{22})$', ShortenedLinkRedirectView.as_view(),
+    url(r'^(?P<key>[1-9A-Za-z]{15,30})$', ShortenedLinkRedirectView.as_view(),
         name='dereference-shortened'),
     url(r'^shorten/$', csrf_exempt(ShortenedLinkCreateView.as_view()),
         name='shorten-link')


### PR DESCRIPTION
Shortened base 58-encoded trip plan URLs, although usually 22 characters, are not always that length.  This allows for a range of shortened URL lengths.