### PR TITLE
Use command ansible module instead of pip for majorkirby install

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -14,8 +14,11 @@
   with_items: cac_python_dependencies
 
 # TODO: peg this to a version, rather than a commit, when released
+# ansible pip module installs this in /tmp/src for some reason, so we use the
+# command instead
 - name: Install majorkirby
-  pip: name="git+https://github.com/azavea/majorkirby@7688e19e61bf9d218c03a2af6d469d0626b86918#egg=majorkirby"
+  command: pip install "git+https://github.com/azavea/majorkirby@7688e19e61bf9d218c03a2af6d469d0626b86918#egg=majorkirby"
+           creates=/usr/local/lib/python2.7/dist-packages/majorkirby/__init__.py
   when: develop
 
 - name: Touch log file if it does not exist


### PR DESCRIPTION
Ansible's pip module installs to /tmp/src for some reason so call the
command directly instead