### PR TITLE
Remove pip install of requests

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -33,5 +33,4 @@ cac_python_dependencies:
     - { name: 'psycopg2', version: '2.5.4' }
     - { name: 'pytz', version: '2015.2' }
     - { name: 'pyyaml', version: '3.11' }
-    - { name: 'requests', version: '2.7.0' }
     - { name: 'troposphere', version: '0.7.2'}


### PR DESCRIPTION
The install of a newer requests library seems to cause problems with pip itself. When it moves on and tries to install troposphere, it gets the error: ImportError: cannot import name IncompleteRead.

From some digging, it seems our version of pip may need to be upgraded in order to work with newer versions of requests. We don't actually need this newer version, so just going to remove it for now.

Trivial, merging.