### PR TITLE
Change leaflet references.

### DIFF
--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -1,4 +1,4 @@
-CAC.Routing.Itinerary = (function ($, L, _, moment, Geocoder) {
+CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder) {
     'use strict';
 
     /**
@@ -22,7 +22,7 @@ CAC.Routing.Itinerary = (function ($, L, _, moment, Geocoder) {
         this.to = _.last(otpItinerary.legs).to;
         this.agencies = getTransitAgencies(otpItinerary.legs);
 
-        this.geojson = L.geoJson({type: 'FeatureCollection',
+        this.geojson = cartodb.L.geoJson({type: 'FeatureCollection',
                                   features: getFeatures(otpItinerary.legs)});
         this.geojson.setStyle(getStyle(true, false));
     }
@@ -41,15 +41,15 @@ CAC.Routing.Itinerary = (function ($, L, _, moment, Geocoder) {
      * @return {[L.LatLngBounds]}
      */
     Itinerary.prototype.getBounds = function(bufferRatio) {
-        var sw = L.latLng(
+        var sw = cartodb.L.latLng(
             Math.min(this.from.lat, this.to.lat),
             Math.min(this.from.lon, this.to.lon)
         );
-        var ne = L.latLng(
+        var ne = cartodb.L.latLng(
             Math.max(this.from.lat, this.to.lat),
             Math.max(this.from.lon, this.to.lon)
         );
-        var bounds = L.latLngBounds(sw, ne);
+        var bounds = cartodb.L.latLngBounds(sw, ne);
         bufferRatio = bufferRatio || 0;
         return bounds.pad(bufferRatio);
     };
@@ -212,4 +212,4 @@ CAC.Routing.Itinerary = (function ($, L, _, moment, Geocoder) {
         return defaultStyle;
     }
 
-})(jQuery, L, _, moment, CAC.Search.Geocoder);
+})(jQuery, cartodb, L, _, moment, CAC.Search.Geocoder);

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -1,4 +1,4 @@
-CAC.Routing.Plans = (function($, L, moment, _, UserPreferences, Itinerary, Settings) {
+CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings) {
     'use strict';
 
     var module = {
@@ -80,4 +80,4 @@ CAC.Routing.Plans = (function($, L, moment, _, UserPreferences, Itinerary, Setti
         return $.extend(formattedOpts, extraOptions);
     }
 
-})(jQuery, L, moment, _, CAC.User.Preferences, CAC.Routing.Itinerary, CAC.Settings);
+})(jQuery, moment, _, CAC.User.Preferences, CAC.Routing.Itinerary, CAC.Settings);


### PR DESCRIPTION
Use `cartodb.L` instead of `L`, except when referencing libraries built against leaflet (Polyline and AwesomeMarkers).