### PR TITLE
Increase max walk distance to 2 miles.

### DIFF
--- a/python/cac_tripplanner/templates/map.html
+++ b/python/cac_tripplanner/templates/map.html
@@ -89,7 +89,7 @@
                         <h6>Maximum walking distance</h6>
                         <div class="input-group">
                             <input type="number" class="form-control isochrone-input"
-                                placeholder="0.5" value="0.5" min="0.1" step="0.1" >
+                                placeholder="2" value="2" min="0.1" step="0.1" >
                             <span class="input-group-addon">miles</span>
                         </div>
                     </div>
@@ -164,7 +164,7 @@
                         <h6>Maximum walking distance</h6>
                         <div class="input-group">
                             <input type="number" class="form-control direction-input"
-                                placeholder="0.5" value="" min="0.1" step="0.1" />
+                                placeholder="2" value="" min="2" step="0.1" />
                             <span class="input-group-addon">miles</span>
                         </div>
                     </div>

--- a/src/app/scripts/cac/user/cac-user-preferences.js
+++ b/src/app/scripts/cac/user/cac-user-preferences.js
@@ -33,7 +33,7 @@ CAC.User.Preferences = (function($) {
         arriveBy: false, // depart at set time, by default
         bikeTriangle: 'neutral',
         exploreTime: 20,
-        maxWalk: undefined, // no max
+        maxWalk: 2,
         method: 'explore',
         mode: 'TRANSIT,WALK',
         origin: cityHall,


### PR DESCRIPTION
Otherwise Palmyra Cove Nature Park appears inaccessible with defaults, as getting there with walk+transit requires over 1.5 mi of walking.