### PR TITLE
Fixes #349.

### DIFF
--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -219,10 +219,6 @@ CAC.Control.SidebarDirections = (function ($, Control, BikeModeOptions, Geocoder
 
             // put markers at start and end
             mapControl.setOriginDestinationMarkers(directions.origin, directions.destination);
-
-            // Update map bounds
-            mapControl.setBounds(currentItinerary.getBounds(0.1));
-
             itineraryListControl.setItineraries(itineraries);
             $(options.selectors.directions).addClass(options.selectors.resultsClass);
             itineraryListControl.show();

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -118,7 +118,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, _) {
     MapControl.prototype.clearIsochrone = clearIsochrone;
     MapControl.prototype.clearDiscoverPlaces = clearDiscoverPlaces;
     MapControl.prototype.fetchIsochrone = fetchIsochrone;
-    MapControl.prototype.setBounds = setBounds;
     MapControl.prototype.locateUser = locateUser;
     MapControl.prototype.drawDestinations = drawDestinations;
     MapControl.prototype.plotItinerary = plotItinerary;
@@ -373,23 +372,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, _) {
     }
 
     /**
-     * Set the map bounds, optionally setting options
-     * @param {[L.LatLngBounds]} bounds
-     * @param {[L.fitBoundsOptions]} options
-     */
-    function setBounds(bounds, options) {
-        var defaults = {
-            // TODO: Figure out why allowing animation causes the map to get all weird
-            // test case: 450 market st -> 200 chestnut st
-            animate: false,
-            maxZoom: maxZoom,
-            // So that origin/dest don't show under the sidebar
-            paddingTopLeft: [400, 0]
-        };
-        map.fitBounds(bounds, $.extend({}, defaults, options));
-    }
-
-    /**
      * Plots an itinerary on a map, optionally zooming to fit.
      *
      * @param {Object} itinerary CAC.Routing.Itinerary object with geojson to draw
@@ -480,7 +462,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, _) {
             var position = marker.getLatLng();
             var latlng = new cartodb.L.LatLng(position.lat, position.lng);
             marker.setLatLng(latlng, {draggable: true});
-            map.panTo(latlng); // allow user to drag marker off map
 
             var trigger = (marker.options.title === 'origin') ?
                             eventNames.originMoved : eventNames.destinationMoved;
@@ -535,7 +516,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, _) {
             originMarker.on('dragend', markerDrag);
             destinationMarker.on('dragend', markerDrag);
         }
-        map.panTo(origin);
     }
 
     function highlightDestination(destinationId, opts) {

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -35,25 +35,6 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder) {
         this.geojson.setStyle(getStyle(isShown, false));
     };
 
-    /**
-     * Get Itinerary bounds, based on the origin/dest lat/lngs
-     * @param  {[number]} bufferRatio optionally buffer the returned bounds object
-     * @return {[L.LatLngBounds]}
-     */
-    Itinerary.prototype.getBounds = function(bufferRatio) {
-        var sw = cartodb.L.latLng(
-            Math.min(this.from.lat, this.to.lat),
-            Math.min(this.from.lon, this.to.lon)
-        );
-        var ne = cartodb.L.latLng(
-            Math.max(this.from.lat, this.to.lat),
-            Math.max(this.from.lon, this.to.lon)
-        );
-        var bounds = cartodb.L.latLngBounds(sw, ne);
-        bufferRatio = bufferRatio || 0;
-        return bounds.pad(bufferRatio);
-    };
-
     // cache of geocoded OSM nodes (node name mapped to reverse geocode name)
     var nodeCache = {};
 


### PR DESCRIPTION
Remove second pan/zoom of map when directions retrieved. Do not pan to moved directions marker.

Also fixes issue with directions fit sometimes seemingly to not take sidebar into account.