### PR TITLE
Fix error when end_date is missing

### DIFF
--- a/python/cac_tripplanner/destinations/management/commands/load_events.py
+++ b/python/cac_tripplanner/destinations/management/commands/load_events.py
@@ -86,7 +86,7 @@ class Command(BaseCommand):
 
         publication_date = self.parse_date(self.get_property(item, 'pubDate'))
         end_date = self.parse_date(self.get_property(item, 'fieldtrip:endDate'))
-        if end_date < self.now or publication_date is None or end_date is None:
+        if  publication_date is None or end_date is None or end_date < self.now:
             # Skip event if in past or bad/empty dates
             return
 


### PR DESCRIPTION
Noticed the following error in the server logs:
```
Jun 15 06:44:42 ip-10-0-1-25 event-feed.log:      if end_date < self.now or publication_date is None or end_date is None:
Jun 15 06:44:42 ip-10-0-1-25 event-feed.log:  TypeError: can't compare datetime.datetime to NoneType
```