### PR TITLE
Unset destination after loading it in explore tab.

### DIFF
--- a/src/app/scripts/cac/control/cac-control-sidebar-explore.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-explore.js
@@ -446,6 +446,9 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
             // show destination details if destination selected on homepage
             if (_.has(destination, 'id')) {
                 selectedDestination = destination;
+                // unset selected destination in preferences
+                UserPreferences.setPreference('destination', null);
+                UserPreferences.setPreference('destinationText', null);
             } else {
                 selectedDestination = null;
             }


### PR DESCRIPTION
Fixes #397.
Caused by switch in preference key in #322.