### PR TITLE
Only load jQuery once in production.

### DIFF
--- a/python/cac_tripplanner/templates/contact-form-mixin.html
+++ b/python/cac_tripplanner/templates/contact-form-mixin.html
@@ -1,7 +1,7 @@
 <script src="https://d2g9qbzl5h49rh.cloudfront.net/static/prototype.forms.js" type="text/javascript"></script>
 <script src="https://d2g9qbzl5h49rh.cloudfront.net/static/jotform.forms.js?3.2.6775" type="text/javascript"></script>
 <script type="text/javascript">
-    JotForm.init(function(){
+    JotForm.init(function() {
         JotForm.onSubmissionError="jumpToSubmit";
     });
 

--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -222,7 +222,7 @@
 {%block jspage %}
 <script type="text/javascript">
 jQuery.noConflict(); // because JotForms.
-$(document).ready(function () {
+jQuery(document).ready(function ($) {
     CAC.Settings.fbAppId = '{{ fb_app_id }}';
     var home = new CAC.Pages.Home();
     home.initialize();

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -84,7 +84,7 @@ gulp.task('minify:scripts', function() {
 });
 
 gulp.task('minify:vendor-scripts', function() {
-    return copyBowerFiles(['**/*.js', '!**/leaflet.js'], [])
+    return copyBowerFiles(['**/*.js', '!**/leaflet.js', '!**/jquery.js', '!**/jquery.min.js'], [])
         .pipe(concat('vendor.js'))
         .pipe(uglify())
         .pipe(gulp.dest(stat.scripts));


### PR DESCRIPTION
Fixes issue with jQuery/JotForms prototype conflict in production.
jQuery was loaded twice, once from bower, once from CDN.