### PR TITLE
Fix bike share data parsing.

### DIFF
--- a/src/app/scripts/cac/map/cac-map-overlays.js
+++ b/src/app/scripts/cac/map/cac-map-overlays.js
@@ -22,7 +22,6 @@ CAC.Map.OverlaysControl = (function ($, cartodb, L, Utils) {
             contentType: 'application/json',
             url: 'https://api.phila.gov/bike-share-stations/v1',
             success: function (data) {
-                data = JSON.parse(data);
                 $.each(data.features, function (i, share) {
                     bikeShareFeatureGroup.addLayer(getBikeShareMarker(share));
                 });


### PR DESCRIPTION
Enpoint now has proper content type set for JSON response.