### PR TITLE
Keep OTP timeout var.

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -4,6 +4,9 @@ app_username: "vagrant"
 # open trip planner vars
 otp_version: "0.15.0"
 
+# used by nginx and gunicorn to set timeouts; OTP defaults to 30s
+otp_session_timeout_s: 30
+
 s3_otp_data: cleanair-otp-data
 
 postgresql_support_libpq_version: 9.4.*


### PR DESCRIPTION
Used by nginx and gunicorn.