### PR TITLE
Remove nearby events layer from map.

### DIFF
--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -160,8 +160,10 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, _) {
     function initializeOverlays() {
         overlays['Bike Share Locations'] = overlaysControl.bikeShareOverlay();
         overlays['Bike Routes'] = overlaysControl.bikeRoutesOverlay(map);
-        overlays['Nearby Events'] = overlaysControl.nearbyEventsOverlay();
-        overlays['Nearby Events'].addTo(map);
+
+        // TODO: re-enable when Uwishunu feed returns
+        //overlays['Nearby Events'] = overlaysControl.nearbyEventsOverlay();
+        //overlays['Nearby Events'].addTo(map);
     }
 
     function initializeLayerControl() {


### PR DESCRIPTION
To be added back when Uwishunu feed with event coordinates returns; see #459.