### PR TITLE
URL for map directions

### DIFF
--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -97,6 +97,8 @@
     <script src="{% static 'scripts/vendor/moment-duration-format.js' %}"></script>
     <script src="{% static 'scripts/vendor/bootstrap-datetimepicker.min.js' %}"></script>
     <script src="{% static 'scripts/vendor/bootstrap-select.js' %}"></script>
+    <script src="{% static 'scripts/vendor/navigo.js' %}"></script>
+
 
     <script src="{% static 'scripts/main/cac/cac.js' %}"></script>
     <script src="{% static 'scripts/main/cac/utils.js' %}"></script>
@@ -107,6 +109,7 @@
     <script src="{% static 'scripts/main/cac/share/cac-social-sharing.js' %}"></script>
     <script src="{% static 'scripts/main/cac/routing/cac-routing-itinerary.js' %}"></script>
     <script src="{% static 'scripts/main/cac/routing/cac-routing-plans.js' %}"></script>
+    <script src="{% static 'scripts/main/cac/urlrouting/cac-urlrouting.js' %}"></script>
     <script src="{% static 'scripts/main/cac/map/cac-map-control.js' %}"></script>
     <script src="{% static 'scripts/main/cac/map/cac-map-overlays.js' %}"></script>
     <script src="{% static 'scripts/main/cac/map/cac-map-templates.js' %}"></script>

--- a/src/app/scripts/cac/cac.js
+++ b/src/app/scripts/cac/cac.js
@@ -10,6 +10,7 @@ CAC = (function () {
         Search: {},
         Share: {},
         Settings: {},
+        UrlRouting: {},
         User: {},
         Utils: {}
     };

--- a/src/app/scripts/cac/control/cac-control-directions-list.js
+++ b/src/app/scripts/cac/control/cac-control-directions-list.js
@@ -3,7 +3,7 @@
  *  View control for the sidebar directions list
  *
  */
-CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social, UserPreferences) {
+CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social, UserPreferences, Utils) {
 
     'use strict';
 
@@ -101,19 +101,8 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social, UserPreferen
 
         $container.append($html);
 
-        // get URL for sharing
-        var paramString = decodeURIComponent($.param(itinerary.requestParameters));
-        var index = itinerary.id;
-        var directionsUrl = ['/directions/?',
-                             paramString,
-                             '&itineraryIndex=',
-                             index,
-                             '&fromText=',
-                             UserPreferences.getPreference('originText'),
-                             '&toText=',
-                             UserPreferences.getPreference('destinationText')
-                            ].join('');
-        directionsUrl = encodeURI(directionsUrl);
+        var params = $.extend({itineraryIndex: itinerary.id}, itinerary.requestParameters);
+        var directionsUrl = '/directions/?' + Utils.encodeUrlParams(params);
 
         socialSharing.shortenLink(directionsUrl).then(function(shortened) {
             // set up click handlers for social sharing with shortened link
@@ -140,11 +129,11 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social, UserPreferen
             showBackButton: options.showBackButton,
             showShareButton: options.showShareButton,
             start: {
-                text:  UserPreferences.getPreference('originText'),
+                text: itinerary.fromText,
                 time: itinerary.startTime
             },
             end: {
-                text:  UserPreferences.getPreference('destinationText'),
+                text: itinerary.toText,
                 time: itinerary.endTime
             },
             legs: itinerary.legs
@@ -169,4 +158,4 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social, UserPreferen
         }
     }
 
-})(_, jQuery, CAC.Map.Templates, CAC.Share.Social, CAC.User.Preferences);
+})(_, jQuery, CAC.Map.Templates, CAC.Share.Social, CAC.User.Preferences, CAC.Utils);

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -154,9 +154,6 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
         var date = picker.date() || moment();
 
         var mode = bikeModeOptions.getMode(options.selectors.modeSelectors);
-        var origin = directions.origin;
-        var destination = directions.destination;
-
         var arriveBy = false; // depart at time by default
         if ($(options.selectors.departAtSelect).val() === 'arriveBy') {
             arriveBy = true;
@@ -197,9 +194,17 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
         UserPreferences.setPreference('mode', mode);
         UserPreferences.setPreference('arriveBy', arriveBy);
 
+        // Update URL to match choices
         urlRouter.updateUrl(urlRouter.buildDirectionsUrlFromPrefs());
 
-        Routing.planTrip(origin, destination, date, otpOptions).then(function (itineraries) {
+        var params = {
+            fromText: UserPreferences.getPreference('originText'),
+            toText: UserPreferences.getPreference('destinationText')
+        };
+        $.extend(params, otpOptions);
+
+        Routing.planTrip(directions.origin, directions.destination, date, params)
+        .then(function (itineraries) {
             $(options.selectors.spinner).addClass('hidden');
             if (!tabControl.isTabShowing('directions')) {
                 // if user has switched away from the directions tab, do not show trip

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -2,7 +2,7 @@
  *  View control for the sidebar directions tab
  *
  */
-CAC.Control.SidebarDirections = (function ($, Control, BikeModeOptions, Geocoder,
+CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geocoder,
                                  Routing, Typeahead, UserPreferences, Utils) {
 
     'use strict';
@@ -53,6 +53,7 @@ CAC.Control.SidebarDirections = (function ($, Control, BikeModeOptions, Geocoder
     var bikeModeOptions = null;
     var mapControl = null;
     var tabControl = null;
+    var urlRouter = null;
     var directionsListControl = null;
     var itineraryListControl = null;
     var typeaheadDest = null;
@@ -64,6 +65,7 @@ CAC.Control.SidebarDirections = (function ($, Control, BikeModeOptions, Geocoder
         options = $.extend({}, defaults, params);
         mapControl = options.mapControl;
         tabControl = options.tabControl;
+        urlRouter = options.urlRouter;
         bikeModeOptions = new BikeModeOptions();
 
         // Plan a trip using information provided
@@ -148,11 +150,8 @@ CAC.Control.SidebarDirections = (function ($, Control, BikeModeOptions, Geocoder
         $(options.selectors.spinner).removeClass('hidden');
 
         var picker = $(options.selectors.datepicker).data('DateTimePicker');
-        var date = picker.date();
-        if (!date) {
-            // use current date/time if none set
-            date = moment();
-        }
+        // use current date/time if none set
+        var date = picker.date() || moment();
 
         var mode = bikeModeOptions.getMode(options.selectors.modeSelectors);
         var origin = directions.origin;
@@ -198,8 +197,9 @@ CAC.Control.SidebarDirections = (function ($, Control, BikeModeOptions, Geocoder
         UserPreferences.setPreference('mode', mode);
         UserPreferences.setPreference('arriveBy', arriveBy);
 
-        Routing.planTrip(origin, destination, date, otpOptions).then(function (itineraries) {
+        urlRouter.updateUrl(urlRouter.buildDirectionsUrlFromPrefs());
 
+        Routing.planTrip(origin, destination, date, otpOptions).then(function (itineraries) {
             $(options.selectors.spinner).addClass('hidden');
             if (!tabControl.isTabShowing('directions')) {
                 // if user has switched away from the directions tab, do not show trip
@@ -240,6 +240,7 @@ CAC.Control.SidebarDirections = (function ($, Control, BikeModeOptions, Geocoder
 
     function clearDirections() {
         mapControl.setOriginDestinationMarkers(null, null);
+        urlRouter.clearUrl();
         clearItineraries();
     }
 
@@ -454,7 +455,7 @@ CAC.Control.SidebarDirections = (function ($, Control, BikeModeOptions, Geocoder
 
         if (arriveBy) {
             $(options.selectors.departAtSelect).val('arriveBy');
-         }
+        }
 
         if (destination && destination.feature && destination.feature.geometry) {
             directions.destination = [
@@ -483,5 +484,5 @@ CAC.Control.SidebarDirections = (function ($, Control, BikeModeOptions, Geocoder
         initialLoad = false;
     }
 
-})(jQuery, CAC.Control, CAC.Control.BikeModeOptions, CAC.Search.Geocoder,
+})(_, jQuery, CAC.Control, CAC.Control.BikeModeOptions, CAC.Search.Geocoder,
     CAC.Routing.Plans, CAC.Search.Typeahead, CAC.User.Preferences, CAC.Utils);

--- a/src/app/scripts/cac/control/cac-control-sidebar-explore.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-explore.js
@@ -330,8 +330,7 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
 
         var dest = [destination.point.coordinates[1], destination.point.coordinates[0]];
 
-        Routing.planTrip(exploreLatLng, dest, date, otpOptions)
-            .then(function (itineraries) {
+        Routing.planTrip(exploreLatLng, dest, date, otpOptions).then(function (itineraries) {
             if (itineraries.length) {
                 var distance = itineraries[0].formattedDuration;
                 destination.formattedDuration = distance;

--- a/src/app/scripts/cac/pages/cac-pages-directions.js
+++ b/src/app/scripts/cac/pages/cac-pages-directions.js
@@ -30,22 +30,9 @@ CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings, Use
             return;
         }
 
-        // pull out the parameters not intended for OTP
+        // pull out itinerary index, since it's not needed down the line
         var itineraryIndex = params.itineraryIndex;
-        var originText = params.fromText;
-        var destinationText = params.toText;
-
         delete params.itineraryIndex;
-        delete params.fromText;
-        delete params.toText;
-
-        // set into storage the origin and destination text for the directions list control
-        UserPreferences.setPreference('originText', originText);
-        UserPreferences.setPreference('destinationText', destinationText);
-
-        // unset the origin/destination objects
-        UserPreferences.setPreference('origin', undefined);
-        UserPreferences.setPreference('destination', undefined);
 
         var directionsListControl = new DirectionsList({
             showBackButton: false,

--- a/src/app/scripts/cac/pages/cac-pages-map.js
+++ b/src/app/scripts/cac/pages/cac-pages-map.js
@@ -1,4 +1,4 @@
-CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl) {
+CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl, UserPreferences, UrlRouter) {
     'use strict';
 
     var defaults = {
@@ -12,12 +12,14 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl) {
     var sidebarExploreControl = null;
     var sidebarDirectionsControl = null;
     var sidebarTabControl = null;
+    var urlRouter = null;
 
     function Map(options) {
         this.options = $.extend({}, defaults, options);
     }
 
     Map.prototype.initialize = function () {
+        urlRouter = new UrlRouter();
 
         sidebarTabControl = new CAC.Control.SidebarTab();
         window.stc = sidebarTabControl;
@@ -49,7 +51,8 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl) {
 
         sidebarDirectionsControl = new CAC.Control.SidebarDirections({
             mapControl: mapControl,
-            tabControl: sidebarTabControl
+            tabControl: sidebarTabControl,
+            urlRouter: urlRouter
         });
     };
 
@@ -119,4 +122,4 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl) {
         }
     }
 
-})(jQuery, Handlebars, _, moment, CAC.Map.Control);
+})(jQuery, Handlebars, _, moment, CAC.Map.Control, CAC.User.Preferences, CAC.UrlRouting.UrlRouter);

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -25,6 +25,8 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder) {
         this.geojson = cartodb.L.geoJson({type: 'FeatureCollection',
                                           features: getFeatures(otpItinerary.legs)});
         this.geojson.setStyle(getStyle(true, false));
+        this.fromText = requestParameters.fromText;
+        this.toText = requestParameters.toText;
     }
 
     Itinerary.prototype.highlight = function (isHighlighted) {

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -72,7 +72,9 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
     function prepareParams(coordsFrom, coordsTo, when, extraOptions) {
         var formattedOpts = {
             fromPlace: coordsFrom.join(','),
+            fromText: extraOptions.fromText,
             toPlace: coordsTo.join(','),
+            toText: extraOptions.toText,
             time: when.format('hh:mma'),
             date: when.format('MM-DD-YYYY'),
         };

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -1,0 +1,102 @@
+/**
+ * A basic URL router and related utilities.
+ *
+ * The app is still based on local storage, but this enables some URL navigation and facilitates
+ * the interaction between that and local storage.
+ */
+
+CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
+
+    'use strict';
+
+    // UserPreferences fields that can get written and read from the URL without transformation
+    // So NOT including origin and destination, which are coords in URL but objects in storage
+    var PREF_FIELDS = ['originText', 'destinationText', 'method', 'mode', 'arriveBy', 'maxWalk',
+                       'wheelchair', 'bikeTriangle'];
+
+    var router = null;
+
+    function UrlRouter() {
+        router = new Navigo('/map');
+
+        router.on(new RegExp('/directions/?\?'), setPrefsFromDirectionsUrl);
+
+        router.resolve();
+    }
+
+    UrlRouter.prototype.updateUrl = updateUrl;
+    UrlRouter.prototype.clearUrl = clearUrl;
+    UrlRouter.prototype.buildDirectionsUrlFromPrefs = buildDirectionsUrlFromPrefs;
+    UrlRouter.prototype.setPrefsFromDirectionsUrl = setPrefsFromDirectionsUrl;
+
+    return UrlRouter;
+
+    // Updates the displayed URL without triggering any routing callbacks
+    function updateUrl(url) {
+        router.pause(true);
+        router.navigate(url);
+        router.pause(false);
+    }
+
+    function clearUrl() {
+        updateUrl('');
+    }
+
+    // Builds a URL to the directions view by reading the values in local storage
+    function buildDirectionsUrlFromPrefs() {
+        var opts = {};
+        var origin = UserPreferences.getPreference('origin');
+        if (origin && origin.feature && origin.feature.geometry) {
+            opts.origin = [origin.feature.geometry.y, origin.feature.geometry.x].join(',');
+        }
+
+        var destination = UserPreferences.getPreference('destination');
+        if (destination && destination.feature && destination.feature.geometry) {
+            opts.destination = [
+                destination.feature.geometry.y,
+                destination.feature.geometry.x
+            ].join(',');
+        }
+
+        _.forEach(PREF_FIELDS, function(field) {
+            opts[field] = UserPreferences.getPreference(field);
+        });
+
+        var url = '/directions?' + _.map(opts, function(val, key) {
+            return encodeURIComponent(key) + '=' + encodeURIComponent(val); }).join('&');
+        return url;
+    }
+
+    // Parses the URL and saves the directions parameters in local storage
+    function setPrefsFromDirectionsUrl() {
+        UserPreferences.setPreference('method', 'directions');
+        var params = Utils.getUrlParams();
+        if (params.destination) {
+            var destCoords = _.map(params.destination.split(','), parseFloat);
+            UserPreferences.setPreference('destination',
+                                          makeFeature(destCoords, params.destinationText));
+        }
+        if (params.origin) {
+            var originCoords = _.map(params.origin.split(','), parseFloat);
+            UserPreferences.setPreference('origin', makeFeature(originCoords, params.originText));
+        }
+        _.forEach(PREF_FIELDS, function(field) {
+            if (!_.isUndefined(params[field])) {
+                UserPreferences.setPreference(field, params[field]);
+            }
+        });
+    }
+
+    function makeFeature(coords, name) {
+        return {
+            name: name,
+            feature: {
+                geometry: {
+                    x: coords[1],
+                    y: coords[0]
+                }
+            }
+        };
+    }
+
+})(_, jQuery, CAC.User.Preferences, CAC.Utils, Navigo);

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -62,8 +62,7 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
             opts[field] = UserPreferences.getPreference(field);
         });
 
-        var url = '/directions?' + _.map(opts, function(val, key) {
-            return encodeURIComponent(key) + '=' + encodeURIComponent(val); }).join('&');
+        var url = '/directions?' + Utils.encodeUrlParams(opts);
         return url;
     }
 

--- a/src/app/scripts/cac/utils.js
+++ b/src/app/scripts/cac/utils.js
@@ -6,6 +6,7 @@ CAC.Utils = (function (_) {
         getImageUrl: getImageUrl,
         abbrevStreetName: abbrevStreetName,
         getUrlParams: getUrlParams,
+        encodeUrlParams: encodeUrlParams,
         modeStringHelper: modeStringHelper
     };
 
@@ -167,6 +168,12 @@ CAC.Utils = (function (_) {
             .object()
             // Return the value of the chain operation
             .value();
+    }
+
+    function encodeUrlParams(params) {
+        return _.map(params, function(val, key) {
+            return encodeURIComponent(key) + '=' + encodeURIComponent(val);
+        }).join('&');
     }
 
     function modeStringHelper(modeString) {

--- a/src/app/scripts/cac/utils.js
+++ b/src/app/scripts/cac/utils.js
@@ -150,6 +150,12 @@ CAC.Utils = (function (_) {
                     if (itm.length > 1) {
                         // decode parameters before passing them on to OTP
                         itm[1] = decodeURIComponent(itm[1]);
+                        // convert boolean values stored as strings back to booleans
+                        if (itm[1] === 'false') {
+                            itm[1] = false;
+                        } else if (itm[1] === 'true') {
+                            itm[1] = true;
+                        }
                     }
                     return itm;
                 }

--- a/src/bower.json
+++ b/src/bower.json
@@ -16,6 +16,7 @@
     "spinkit": "~1.0.1",
     "typeahead.js": "~0.10.5",
     "Leaflet.awesome-markers": "~2.0.2",
-    "material-design-iconic-font": "~1.1.1"
+    "material-design-iconic-font": "~1.1.1",
+    "navigo": "master"
   }
 }

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -49,6 +49,7 @@ var scriptOrder = [
     '**/cac/user/*.js',
     '**/cac/search/*.js',
     '**/cac/routing/*.js',
+    '**/cac/urlrouting/*.js',
     '**/cac/control/*.js',
     '**/cac/map/*.js',
     '**/cac/home/*.js',


### PR DESCRIPTION
Adds a URL router that only does one thing: reads and writes directions URLs in the map view. Since all of the interaction is built around local storage, this also works through local storage--updating stored values from the URL when a matching URL is loaded and keeping the URL in sync by updating it from local storage when the parameters change.

I'm not really clear on how these URLs are to be used and how this interacts with the existing share button.  The share button produces a (printable) directions page for a specific itinerary; the URLs I've added point to the map view with a specific set of options selected but no itinerary chosen.  So it's less specific but it enables exploration and modification whereas the existing directions link doesn't.

In the course of looking at map-view directions and share-link directions I ran into some weird behavior, hence the second commit making itineraries fully (rather than just almost-fully) independent of local storage.

Note: the routing package I found, [Navigo](https://github.com/krasimir/navigo), is small but seems useful.  Unfortunately bower versioning doesn't work because the author hasn't seen fit to create any tags in the repo, even though he's got a version number in the `package.json`.  Not sure what the best way to deal with that is.  It's active, so we could just ask him to start tagging versions...