### PR TITLE
URLs for "Discover Places" list and locations

### DIFF
--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -95,51 +95,33 @@
                 <div class="sk-bounce3"></div>
             </div>
             <div class="row destinations">
+                {% for destination in destinations|slice:":2" %}
+                    <div class="col-sm-6 col-md-4">
+                        <a class="block block-destination" data-destination-id="{{ destination.id }}" href="#">
+                            <h3 class="destination-name">{{ destination.name }}</h3>
+                            <h5 class="destination-address">{{ destination.address }}</h5>
+                            <h5 class="destination-address-2">{{ destination.city }}, {{ destination.state }} {{ destination.zip }}</h5>
+                            {% if destination.image %}
+                            <img src="{{ destination.image.url }}" width="400" height="400"/>
+                            {% else %}
+                            <img src="https://placehold.it/400x400.jpg" />
+                            {% endif %}
+                        </a>
+                    </div>
+                {% endfor %}
                 <div class="col-sm-6 col-md-4">
-                    <a class="block block-destination" href="#">
-                        <h3 class="destination-name">{{ destinations.0.name }}</h3>
-                        <h5 class="destination-address">{{ destinations.0.address }}</h5>
-                        <h5 class="destination-address-2">{{ destinations.0.city }}, {{ destinations.0.state }} {{ destinations.0.zip }}</h5>
-                        {% if destinations.0.image %}
-                        <img src="{{ destinations.0.image.url }}" width="400" height="400"/>
-                        {% else %}
-                        <img src="https://placehold.it/400x400.jpg" />
-                        {% endif %}
-                    </a>
-                </div>
-                <div class="col-sm-6 col-md-4">
-                    <a class="block block-destination" href="#">
-                        <h3 class="destination-name">{{ destinations.1.name }}</h3>
-                        <h5 class="destination-address">{{ destinations.1.address }}</h5>
-                        <h5 class="destination-address-2">{{ destinations.1.city }}, {{ destinations.1.state }} {{ destinations.1.zip }}</h5>
-                        {% if destinations.1.image %}
-                        <img src="{{ destinations.1.image.url }}" width="400" height="400"/>
-                        {% else %}
-                        <img src="https://placehold.it/400x400.jpg" />
-                        {% endif %}
-                    </a>
-                </div>
-                <div class="col-sm-6 col-md-4">
-                    <a class="block block-destination block-half" href="#">
-                        <h3 class="destination-name">{{ destinations.2.name }}</h3>
-                        <h5 class="destination-address">{{ destinations.2.address }}</h5>
-                        <h5 class="destination-address-2">{{ destinations.2.city }}, {{ destinations.2.state }} {{ destinations.2.zip }}</h5>
-                        {% if destinations.2.wide_image %}
-                        <img src="{{ destinations.2.wide_image.url }}" width="400" height="200"/>
-                        {% else %}
-                        <img src="https://placehold.it/400x400.jpg" />
-                        {% endif %}
-                    </a>
-                    <a class="block block-destination block-half" href="#">
-                        <h3 class="destination-name">{{ destinations.3.name }}</h3>
-                        <h5 class="destination-address">{{ destinations.3.address }}</h5>
-                        <h5 class="destination-address-2">{{ destinations.3.city }}, {{ destinations.3.state }} {{ destinations.3.zip }}</h5>
-                        {% if destinations.3.wide_image %}
-                        <img src="{{ destinations.3.wide_image.url }}" width="400" height="200"/>
-                        {% else %}
-                        <img src="https://placehold.it/400x400.jpg" />
-                        {% endif %}
-                    </a>
+                    {% for destination in destinations|slice:"2:4" %}
+                        <a class="block block-destination block-half" data-destination-id="{{ destination.id }}" href="#">
+                            <h3 class="destination-name">{{ destination.name }}</h3>
+                            <h5 class="destination-address">{{ destination.address }}</h5>
+                            <h5 class="destination-address-2">{{ destination.city }}, {{ destination.state }} {{ destination.zip }}</h5>
+                            {% if destination.wide_image %}
+                            <img src="{{ destination.wide_image.url }}" width="400" height="200"/>
+                            {% else %}
+                            <img src="https://placehold.it/400x400.jpg" />
+                            {% endif %}
+                        </a>
+                    {% endfor %}
                 </div>
             </div>
         </div>

--- a/src/app/scripts/cac/.jshintrc
+++ b/src/app/scripts/cac/.jshintrc
@@ -29,6 +29,7 @@
     "_": true,
     "cartodb": true,
     "L": true,
-    "turf": true
+    "turf": true,
+    "Navigo": true
   }
 }

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -471,17 +471,18 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
         }
 
         if (initialLoad && method === 'directions') {
-            // switch tabs
+            // switch to this tab if it's set as active in UserPreferences
             tabControl.setTab('directions');
+        }
+        initialLoad = false;
 
+        if (tabControl.isTabShowing('directions')) {
             if (origin && destination) {
                 planTrip();
             } else {
                 clearDirections();
-            }
+            }  
         }
-
-        initialLoad = false;
     }
 
 })(_, jQuery, CAC.Control, CAC.Control.BikeModeOptions, CAC.Search.Geocoder,

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -303,21 +303,18 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
     function onTypeaheadCleared(event, key) {
         clearItineraries();
         directions[key] = null;
-        UserPreferences.setPreference(key, undefined);
-        UserPreferences.setPreference(key + 'Text', undefined);
+        UserPreferences.clearLocation(key);
     }
 
     function onTypeaheadSelected(event, key, location) {
         if (!location) {
-            UserPreferences.setPreference(key, undefined);
-            UserPreferences.setPreference(key + 'Text', undefined);
+            UserPreferences.clearLocation(key);
             setDirections(key, null);
             return;
         }
 
         // save text for address to preferences
-        UserPreferences.setPreference(key, location);
-        UserPreferences.setPreference(key + 'Text', location.name);
+        UserPreferences.setLocation(key, location);
         setDirections(key, [location.feature.geometry.y, location.feature.geometry.x]);
 
         planTrip();
@@ -356,8 +353,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
                 planTrip();
             } else {
                 // unset location and show error
-                UserPreferences.setPreference(key, undefined);
-                UserPreferences.setPreference(key + 'Text', undefined);
+                UserPreferences.clearLocation(key);
                 typeahead.setValue('');
                 setDirections(key, null);
                 $(options.selectors.spinner).addClass('hidden');
@@ -399,8 +395,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
         $('select', options.selectors.bikeTriangleDiv).val(bikeTriangle);
 
         // Save selections to user preferences
-        UserPreferences.setPreference('destination', destination);
-        UserPreferences.setPreference('destinationText', destinationText);
+        UserPreferences.setLocation('destination', destination, destinationText);
 
         // Get directions
         planTrip();

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -133,7 +133,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
      * Set user preferences before planning trip.
      * Throttled to cut down on requests.
      */
-    var planTrip = _.throttle(function() {
+    var planTrip = _.throttle(function() {  // jshint ignore:line
         if (!tabControl.isTabShowing('directions')) {
             return;
         }

--- a/src/app/scripts/cac/control/cac-control-sidebar-explore.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-explore.js
@@ -363,7 +363,6 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
             setDestinationSidebarDetail(selectedDestination);
             // also highlight it on the map and pan to it
             mapControl.highlightDestination(selectedDestination.id, { panTo: true });
-            selectedDestination = null;
         }
     }
 
@@ -376,6 +375,8 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
     }
 
     function setDestinationSidebarDetail(destination) {
+        selectedDestination = destination;
+        UserPreferences.setLocation('destination', destination);
         var $detail = $(MapTemplates.destinationDetail(destination));
         $detail.find('.back').on('click', onDestinationDetailBackClicked);
         $detail.find('.getdirections').on('click', function() {
@@ -385,6 +386,8 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
     }
 
     function onDestinationDetailBackClicked() {
+        selectedDestination = null;
+        UserPreferences.clearLocation('destination');
         setDestinationSidebar(destinationsCache);
         mapControl.highlightDestination(null);
     }
@@ -443,9 +446,6 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
             // show destination details if destination selected on homepage
             if (_.has(destination, 'id')) {
                 selectedDestination = destination;
-                // unset selected destination in preferences
-                UserPreferences.setPreference('destination', undefined);
-                UserPreferences.setPreference('destinationText', '');
             } else {
                 selectedDestination = null;
             }

--- a/src/app/scripts/cac/control/cac-control-sidebar-explore.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-explore.js
@@ -46,7 +46,7 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
     var urlRouter = null;
     var typeahead = null;
     var exploreLatLng = null;
-    var selectedDestination = null;
+    var selectedPlaceId = null;
     var destinationsCache = [];
 
     function SidebarExploreControl(params) {
@@ -201,7 +201,7 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
         $(options.selectors.spinner).removeClass('hidden');
 
         // do not zoom to fit isochrone if going to highlight a selected destination
-        var zoomToFit = !selectedDestination;
+        var zoomToFit = !selectedPlaceId;
 
         mapControl.fetchIsochrone(exploreLatLng, when, exploreMinutes, otpOptions, zoomToFit).then(
             function (destinations) {
@@ -223,20 +223,20 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
     function onTypeaheadCleared() {
         UserPreferences.clearLocation('origin');
         exploreLatLng = null;
-        selectedDestination = null;
+        selectedPlaceId = null;
         mapControl.clearDiscoverPlaces();
     }
 
     function onTypeaheadSelected(event, key, location) {
         if (!location) {
-            UserPreferences.clearLocation(key);
+            UserPreferences.clearLocation('origin');
             setAddress(null);
             return;
         }
 
         UserPreferences.setLocation('origin', location);
         setAddress(location);
-        selectedDestination = null;
+        selectedPlaceId = null;
         clickedExplore();
     }
 
@@ -347,7 +347,7 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
         $.each(destinations, function (i, destination) {
             var $destination = $(MapTemplates.destinationBlock(destination));
             $destination.click(function () {
-                setDestinationSidebarDetail(destination);
+                setDestinationSidebarDetail(destination.id);
                 mapControl.highlightDestination(destination.id, { panTo: true });
             });
             $destination.hover(function () {
@@ -365,10 +365,10 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
         $(options.selectors.sidebarContainer).height(400);
 
         // show destination details if destination is selected
-        if (selectedDestination) {
-            setDestinationSidebarDetail(selectedDestination);
+        if (selectedPlaceId) {
+            setDestinationSidebarDetail(selectedPlaceId);
             // also highlight it on the map and pan to it
-            mapControl.highlightDestination(selectedDestination.id, { panTo: true });
+            mapControl.highlightDestination(selectedPlaceId, { panTo: true });
         }
     }
 
@@ -380,21 +380,25 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
         $(options.selectors.sidebarContainer).height(200);
     }
 
-    function setDestinationSidebarDetail(destination) {
-        selectedDestination = destination;
-        UserPreferences.setLocation('destination', destination);
-        updateUrl();
-        var $detail = $(MapTemplates.destinationDetail(destination));
-        $detail.find('.back').on('click', onDestinationDetailBackClicked);
-        $detail.find('.getdirections').on('click', function() {
-            events.trigger(eventNames.destinationDirections, destination);
-        });
-        $(options.selectors.destinations).html($detail);
+    function setDestinationSidebarDetail(selectedPlaceId) {
+        var selectedPlace = _.find(destinationsCache, {id: parseInt(selectedPlaceId)});
+        if (selectedPlace && selectedPlace.name) {
+            UserPreferences.setPreference('placeId', selectedPlaceId);
+            updateUrl();
+            var $detail = $(MapTemplates.destinationDetail(selectedPlace));
+            $detail.find('.back').on('click', onDestinationDetailBackClicked);
+            $detail.find('.getdirections').on('click', function() {
+                events.trigger(eventNames.destinationDirections, selectedPlace);
+            });
+            $(options.selectors.destinations).html($detail);
+        } else {
+            onDestinationDetailBackClicked();
+        }
     }
 
     function onDestinationDetailBackClicked() {
-        selectedDestination = null;
-        UserPreferences.clearLocation('destination');
+        selectedPlaceId = null;
+        UserPreferences.setPreference('placeId', undefined);
         updateUrl();
         setDestinationSidebar(destinationsCache);
         mapControl.highlightDestination(null);
@@ -413,12 +417,13 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
         var method = UserPreferences.getPreference('method');
         var mode = UserPreferences.getPreference('mode');
         var bikeTriangle = UserPreferences.getPreference('bikeTriangle');
-        var destination = UserPreferences.getPreference('destination');
         var exploreOrigin = UserPreferences.getPreference('origin');
         var originText = UserPreferences.getPreference('originText');
         var exploreTime = UserPreferences.getPreference('exploreTime');
         var maxWalk = UserPreferences.getPreference('maxWalk');
         var wheelchair = UserPreferences.getPreference('wheelchair');
+
+        selectedPlaceId = UserPreferences.getPreference('placeId');
 
         if (exploreOrigin) {
             exploreLatLng = [exploreOrigin.feature.geometry.y,
@@ -460,12 +465,6 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
         }
 
         if (method === 'explore' && exploreLatLng) {
-            // show destination details if destination selected on homepage
-            if (_.has(destination, 'id')) {
-                selectedDestination = destination;
-            } else {
-                selectedDestination = null;
-            }
             fetchIsochrone(when, exploreTime, otpOptions);
         }
     }

--- a/src/app/scripts/cac/control/cac-control-sidebar-explore.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-explore.js
@@ -215,8 +215,7 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
     }
 
     function onTypeaheadCleared() {
-        UserPreferences.setPreference('origin', undefined);
-        UserPreferences.setPreference('originText', undefined);
+        UserPreferences.clearLocation('origin');
         exploreLatLng = null;
         selectedDestination = null;
         mapControl.clearDiscoverPlaces();
@@ -224,14 +223,12 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
 
     function onTypeaheadSelected(event, key, location) {
         if (!location) {
-            UserPreferences.setPreference(key, undefined);
-            UserPreferences.setPreference(key + 'Text', undefined);
+            UserPreferences.clearLocation(key);
             setAddress(null);
             return;
         }
 
-        UserPreferences.setPreference('origin', location);
-        UserPreferences.setPreference('originText', location.name);
+        UserPreferences.setLocation('origin', location);
         setAddress(location);
         selectedDestination = null;
         clickedExplore();
@@ -251,8 +248,7 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
             return false;
         } else {
             exploreLatLng = null;
-            UserPreferences.setPreference('origin', undefined);
-            UserPreferences.setPreference('originText', undefined);
+            UserPreferences.clearLocation('origin');
             $input.addClass(options.selectors.errorClass);
             mapControl.clearDiscoverPlaces();
             return true;
@@ -306,11 +302,8 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
         // distance not cached; go query for it
         var mode = UserPreferences.getPreference('mode');
         var picker = $(options.selectors.datepicker).data('DateTimePicker');
-        var date = picker.date();
-        if (!date) {
-            // use current date/time if none set
-            date = moment();
-        }
+        // use current date/time if none set
+        var date = picker.date() || moment();
         // only request one itinerary (first returned is the shortest)
         var otpOptions = { mode: mode, numItineraries: 1 };
         if (mode.indexOf('BICYCLE') > -1) {

--- a/src/app/scripts/cac/control/cac-control-sidebar-explore.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-explore.js
@@ -132,7 +132,7 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
      * Set user preferences before fetching isochrone.
      * This function has been debounced to cut down on requests.
      */
-    var clickedExplore = _.debounce(function() {
+    var clickedExplore = _.debounce(function() {  // jshint ignore:line
         if (addressHasError(exploreLatLng)) {
             return;
         }

--- a/src/app/scripts/cac/home/cac-home-templates.js
+++ b/src/app/scripts/cac/home/cac-home-templates.js
@@ -18,7 +18,7 @@ CAC.Home.Templates = (function (Handlebars) {
         var source = [
             '{{#each destinations}}',
             '<div class="col-sm-6 col-md-4">',
-            '<a class="block block-destination block-half" href="#">',
+            '<a class="block block-destination block-half" data-destination-id="{{this.id}}" href="#">',
             '<h3 class="destination-name">{{this.name}}</h3>',
             '<h5 class="destination-address">{{this.address}}</h5>',
             '<h5 class="destination-address-2">{{this.city}}, {{this.state}} {{this.zip}}</h5>',

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -362,7 +362,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, _) {
                                      '</div>',
                                      '<a href="{{geojson.properties.website_url}}" ',
                                      'target="_blank">{{geojson.properties.website_url}}</a>',
-                                     '<a href="#" class="destination-directions-link pull-right" ',
+                                     '<a class="destination-directions-link pull-right" ',
                                      'id="{{geojson.properties.id}}">Get Directions</a>'
                                     ].join('');
                 var template = Handlebars.compile(popupTemplate);

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -39,33 +39,6 @@ CAC.Pages.Home = (function ($, BikeModeOptions, Templates, UserPreferences) {
         bikeModeOptions = new BikeModeOptions();
     }
 
-    Home.prototype.initialize = function () {
-        this.destinations = null;
-        $(options.selectors.toggleButton).on('click', function(){
-            var id = $(this).attr('id');
-            setTab(id);
-        });
-
-        $.each(['Explore', 'From', 'To'], $.proxy(function(i, id) {
-            var typeaheadName = 'typeahead' + id;
-            var typeahead = new CAC.Search.Typeahead(options.selectors[typeaheadName]);
-            typeahead.events.on(typeahead.eventNames.selected, $.proxy(onTypeaheadSelected, this));
-            typeahead.events.on(typeahead.eventNames.cleared, $.proxy(onTypeaheadCleared, this));
-            typeaheads[typeaheadName] = this[typeaheadName] = typeahead;
-        }, this));
-
-        // save form data and redirect to map when 'go' button clicked
-        $(options.selectors.exploreForm).submit(submitExplore);
-        $(options.selectors.directionsForm).submit(submitDirections);
-
-        $(options.selectors.viewAllArticles).click($.proxy(clickedViewAllArticles, this));
-        $(options.selectors.viewAllDestinations).click($.proxy(clickedViewAllDestinations, this));
-        $(options.selectors.destinationsContainer).on('click', options.selectors.destinationBlock,
-                                                      $.proxy(clickedDestination, this));
-
-        $(document).ready(loadFromPreferences);
-    };
-
     var submitDirections = function(event) {
         event.preventDefault();
         var mode = bikeModeOptions.getMode(options.selectors.directionsMode);
@@ -138,6 +111,33 @@ CAC.Pages.Home = (function ($, BikeModeOptions, Templates, UserPreferences) {
         typeaheads.typeaheadFrom.setValue(originText);
         typeaheads.typeaheadTo.setValue(destinationText);
         bikeModeOptions.setMode(options.selectors.directionsMode, mode);
+    };
+
+    Home.prototype.initialize = function () {
+        this.destinations = null;
+        $(options.selectors.toggleButton).on('click', function(){
+            var id = $(this).attr('id');
+            setTab(id);
+        });
+
+        $.each(['Explore', 'From', 'To'], $.proxy(function(i, id) {
+            var typeaheadName = 'typeahead' + id;
+            var typeahead = new CAC.Search.Typeahead(options.selectors[typeaheadName]);
+            typeahead.events.on(typeahead.eventNames.selected, $.proxy(onTypeaheadSelected, this));
+            typeahead.events.on(typeahead.eventNames.cleared, $.proxy(onTypeaheadCleared, this));
+            typeaheads[typeaheadName] = this[typeaheadName] = typeahead;
+        }, this));
+
+        // save form data and redirect to map when 'go' button clicked
+        $(options.selectors.exploreForm).submit(submitExplore);
+        $(options.selectors.directionsForm).submit(submitDirections);
+
+        $(options.selectors.viewAllArticles).click($.proxy(clickedViewAllArticles, this));
+        $(options.selectors.viewAllDestinations).click($.proxy(clickedViewAllDestinations, this));
+        $(options.selectors.destinationsContainer).on('click', options.selectors.destinationBlock,
+                                                      $.proxy(clickedDestination, this));
+
+        $(document).ready(loadFromPreferences);
     };
 
     return Home;

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -5,9 +5,6 @@ CAC.Pages.Home = (function ($, BikeModeOptions, Templates, UserPreferences) {
         selectors: {
             articlesContainer: '.articles',
             articlesSpinner: '#articlesSpinner',
-            destinationAddress: '.destination-address',
-            destinationAddressLineTwo: '.destination-address-2',
-            destinationName: '.destination-name',
             destinationBlock: '.block-destination',
             destinationsContainer: '.destinations',
             destinationsSpinner: '#destinationsSpinner',
@@ -63,7 +60,8 @@ CAC.Pages.Home = (function ($, BikeModeOptions, Templates, UserPreferences) {
 
         $(options.selectors.viewAllArticles).click($.proxy(clickedViewAllArticles, this));
         $(options.selectors.viewAllDestinations).click($.proxy(clickedViewAllDestinations, this));
-        $(options.selectors.destinationBlock).click($.proxy(clickedDestination, this));
+        $(options.selectors.destinationsContainer).on('click', options.selectors.destinationBlock,
+                                                      $.proxy(clickedDestination, this));
 
         $(document).ready(loadFromPreferences);
     };
@@ -196,9 +194,6 @@ CAC.Pages.Home = (function ($, BikeModeOptions, Templates, UserPreferences) {
                 var html = Templates.destinations(data.destinations);
                 $(options.selectors.destinationsContainer).html(html);
 
-                // set click event on added features
-                $(options.selectors.destinationBlock).click($.proxy(clickedDestination, this));
-
                 // hide 'view all' button and spinner, and show features again
                 $(options.selectors.viewAllDestinations).addClass('hidden');
                 $(options.selectors.destinationsSpinner).addClass('hidden');
@@ -215,35 +210,16 @@ CAC.Pages.Home = (function ($, BikeModeOptions, Templates, UserPreferences) {
      */
     function clickedDestination(event) {
         event.preventDefault();
-        var block = $(event.target).closest(options.selectors.destinationBlock);
-        var destName = block.children(options.selectors.destinationName).text();
         var mode = bikeModeOptions.getMode(options.selectors.exploreMode);
         var exploreTime = $(options.selectors.exploreTime).val();
-        var addr = [destName + ',',
-                    block.children(options.selectors.destinationAddress).text(),
-                    block.children(options.selectors.destinationAddressLineTwo).text()
-                    ].join(' ');
-        var payload = { 'text': destName };
+        UserPreferences.setPreference('method', 'explore');
+        UserPreferences.setPreference('exploreTime', exploreTime);
+        UserPreferences.setPreference('mode', mode);
 
-        $.ajax({
-            type: 'GET',
-            data: payload,
-            cache: true,
-            url: destinationSearchUrl,
-            contentType: 'application/json'
-        }).then(function(data) {
-            if (data.destinations && data.destinations.length) {
-                var destination = data.destinations[0];
-                UserPreferences.setPreference('destinationText', addr);
-                UserPreferences.setPreference('destination', destination);
-                UserPreferences.setPreference('method', 'explore');
-                UserPreferences.setPreference('exploreTime', exploreTime);
-                UserPreferences.setPreference('mode', mode);
-                window.location = '/map';
-            } else {
-                console.error('Could not find destination ' + destName);
-            }
-        });
+        var block = $(event.target).closest(options.selectors.destinationBlock);
+        var placeId = block.data('destination-id');
+        UserPreferences.setPreference('placeId', placeId);
+        window.location = '/map';
     }
 
     function onTypeaheadCleared(event, key) {

--- a/src/app/scripts/cac/pages/cac-pages-map.js
+++ b/src/app/scripts/cac/pages/cac-pages-map.js
@@ -32,7 +32,8 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl, UserPreferences
         });
 
         sidebarExploreControl = new CAC.Control.SidebarExplore({
-            mapControl: mapControl
+            mapControl: mapControl,
+            urlRouter: urlRouter
         });
         sidebarExploreControl.events.on(sidebarExploreControl.eventNames.destinationDirections,
                                         $.proxy(getDestinationDirections, this));
@@ -104,6 +105,8 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl, UserPreferences
     }
 
     function onSidebarTabShown(event, tabId) {
+        urlRouter.clearUrl();
+
         // close any open map popups on tab switch
         _.each($(this.options.selectors.leafletPopups), function(closeBtn) {
             closeBtn.click();
@@ -111,12 +114,14 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl, UserPreferences
 
         // Load user preferences on tab switch in order to easily keep the pages in sync
         if (tabId === 'directions') {
+            UserPreferences.setPreference('method', 'directions');
             mapControl.clearIsochrone();
             mapControl.setGeocodeMarker(null);
             if (sidebarDirectionsControl) {
                 sidebarDirectionsControl.setFromUserPreferences();
             }
         } else {
+            UserPreferences.setPreference('method', 'explore');
             sidebarDirectionsControl.clearDirections();
             sidebarExploreControl.setFromUserPreferences();
         }

--- a/src/app/scripts/cac/pages/cac-pages-map.js
+++ b/src/app/scripts/cac/pages/cac-pages-map.js
@@ -88,8 +88,8 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl, UserPreferences
         mapControl.clearIsochrone();
         sidebarDirectionsControl.clearDirections();
         mapControl.setGeocodeMarker(null);
-        sidebarTabControl.setTab('directions');
         sidebarDirectionsControl.setDestination(destination);
+        sidebarTabControl.setTab('directions');
     }
 
     function moveOrigin(event, position) {

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -10,10 +10,9 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
     'use strict';
 
     // User pref parameters for different views
-    var SHARED_PREFS = ['origin', 'originText', 'method', 'mode', 'maxWalk',
-                         'wheelchair', 'bikeTriangle'];
-    var DIRECTIONS_PREFS = SHARED_PREFS.concat(['destination', 'destinationText', 'arriveBy']);
-    var EXPLORE_PREFS = SHARED_PREFS.concat(['exploreTime']);
+    var SHARED_PREFS = ['origin', 'originText', 'mode', 'maxWalk', 'wheelchair', 'bikeTriangle'];
+    var DIRECTIONS_PREFS = SHARED_PREFS.concat([ 'destination', 'destinationText', 'arriveBy']);
+    var EXPLORE_PREFS = SHARED_PREFS.concat(['placeId', 'exploreTime']);
 
     var router = null;
 
@@ -80,7 +79,8 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
                 // Special handling for origin and destination, which are stored as GeoJSON
                 if (field === 'origin' || field === 'destination') {
                     var coords = _.map(params[field].split(','), parseFloat);
-                    UserPreferences.setPreference(field, makeFeature(coords, params[field + 'Text']));
+                    var feature = makeFeature(coords, params[field + 'Text']);
+                    UserPreferences.setPreference(field, feature);
                 } else {
                     UserPreferences.setPreference(field, params[field]);
                 }

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -9,25 +9,29 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
 
     'use strict';
 
-    // UserPreferences fields that can get written and read from the URL without transformation
-    // So NOT including origin and destination, which are coords in URL but objects in storage
-    var PREF_FIELDS = ['originText', 'destinationText', 'method', 'mode', 'arriveBy', 'maxWalk',
-                       'wheelchair', 'bikeTriangle'];
+    // User pref parameters for different views
+    var SHARED_PREFS = ['origin', 'originText', 'method', 'mode', 'maxWalk',
+                         'wheelchair', 'bikeTriangle'];
+    var DIRECTIONS_PREFS = SHARED_PREFS.concat(['destination', 'destinationText', 'arriveBy']);
+    var EXPLORE_PREFS = SHARED_PREFS.concat(['exploreTime']);
 
     var router = null;
 
     function UrlRouter() {
         router = new Navigo('/map');
 
-        router.on(new RegExp('/directions/?\?'), setPrefsFromDirectionsUrl);
+        router.on(new RegExp('/places/?\?'), setExplorePrefsFromUrl);
+        router.on(new RegExp('/directions/?\?'), setDirectionsPrefsFromUrl);
 
         router.resolve();
     }
 
     UrlRouter.prototype.updateUrl = updateUrl;
     UrlRouter.prototype.clearUrl = clearUrl;
+    UrlRouter.prototype.setExplorePrefsFromUrl = setExplorePrefsFromUrl;
+    UrlRouter.prototype.buildExploreUrlFromPrefs = buildExploreUrlFromPrefs;
+    UrlRouter.prototype.setDirectionsPrefsFromUrl = setDirectionsPrefsFromUrl;
     UrlRouter.prototype.buildDirectionsUrlFromPrefs = buildDirectionsUrlFromPrefs;
-    UrlRouter.prototype.setPrefsFromDirectionsUrl = setPrefsFromDirectionsUrl;
 
     return UrlRouter;
 
@@ -42,48 +46,66 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
         updateUrl('');
     }
 
-    // Builds a URL to the directions view by reading the values in local storage
-    function buildDirectionsUrlFromPrefs() {
-        var opts = {};
-        var origin = UserPreferences.getPreference('origin');
-        if (origin && origin.feature && origin.feature.geometry) {
-            opts.origin = [origin.feature.geometry.y, origin.feature.geometry.x].join(',');
-        }
-
-        var destination = UserPreferences.getPreference('destination');
-        if (destination && destination.feature && destination.feature.geometry) {
-            opts.destination = [
-                destination.feature.geometry.y,
-                destination.feature.geometry.x
-            ].join(',');
-        }
-
-        _.forEach(PREF_FIELDS, function(field) {
-            opts[field] = UserPreferences.getPreference(field);
-        });
-
-        var url = '/directions?' + Utils.encodeUrlParams(opts);
-        return url;
+    function setExplorePrefsFromUrl() {
+        UserPreferences.setPreference('method', 'explore');
+        setPrefsFromUrl(EXPLORE_PREFS);
     }
 
-    // Parses the URL and saves the directions parameters in local storage
-    function setPrefsFromDirectionsUrl() {
+    function buildExploreUrlFromPrefs() {
+        return '/places?' + buildUrlParamsFromPrefs(EXPLORE_PREFS);
+    }
+
+    function setDirectionsPrefsFromUrl() {
         UserPreferences.setPreference('method', 'directions');
+        setPrefsFromUrl(DIRECTIONS_PREFS);
+    }
+
+    function buildDirectionsUrlFromPrefs() {
+        return '/directions?' + buildUrlParamsFromPrefs(DIRECTIONS_PREFS);
+    }
+
+
+    /* Parses the URL and saves parameter values into local storage
+     *
+     * Field names in the URL must match those in UserPreferences
+     * 'origin' and 'destination' get special handling to convert from coordinates to GeoJSON
+     *
+     * @param {List[String]} fields : The field names to store values from
+     */
+    function setPrefsFromUrl(fields) {
         var params = Utils.getUrlParams();
-        if (params.destination) {
-            var destCoords = _.map(params.destination.split(','), parseFloat);
-            UserPreferences.setPreference('destination',
-                                          makeFeature(destCoords, params.destinationText));
-        }
-        if (params.origin) {
-            var originCoords = _.map(params.origin.split(','), parseFloat);
-            UserPreferences.setPreference('origin', makeFeature(originCoords, params.originText));
-        }
-        _.forEach(PREF_FIELDS, function(field) {
+        _.forEach(fields, function(field) {
+            // Only set values actually given, don't clobber fields that weren't provided
             if (!_.isUndefined(params[field])) {
-                UserPreferences.setPreference(field, params[field]);
+                // Special handling for origin and destination, which are stored as GeoJSON
+                if (field === 'origin' || field === 'destination') {
+                    var coords = _.map(params[field].split(','), parseFloat);
+                    UserPreferences.setPreference(field, makeFeature(coords, params[field + 'Text']));
+                } else {
+                    UserPreferences.setPreference(field, params[field]);
+                }
             }
         });
+    }
+
+    /* Reads values for the given fields from local storage and composes a URL query string
+     * from them.
+     *
+     * Fields with no value given in the URL will be skipped (not overwritten with nothing)
+     */
+    function buildUrlParamsFromPrefs(fields) {
+        var opts = {};
+        _.forEach(fields, function(field) {
+            if (field === 'origin' || field === 'destination') {
+                var location = UserPreferences.getPreference(field);
+                if (location && location.feature && location.feature.geometry) {
+                    opts[field] = [location.feature.geometry.y, location.feature.geometry.x].join(',');
+                }
+            } else {
+                opts[field] = UserPreferences.getPreference(field);
+            }
+        });
+        return Utils.encodeUrlParams(opts);
     }
 
     function makeFeature(coords, name) {

--- a/src/app/scripts/cac/user/cac-user-preferences.js
+++ b/src/app/scripts/cac/user/cac-user-preferences.js
@@ -1,4 +1,4 @@
-CAC.User.Preferences = (function($) {
+CAC.User.Preferences = (function($, _) {
     'use strict';
 
     // set up local storage
@@ -45,7 +45,9 @@ CAC.User.Preferences = (function($) {
 
     var module = {
         getPreference: getPreference,
-        setPreference: setPreference
+        setPreference: setPreference,
+        setLocation: setLocation,
+        clearLocation: clearLocation
     };
     return module;
 
@@ -79,4 +81,25 @@ CAC.User.Preferences = (function($) {
         storage.set(preference, JSON.stringify(val));
     }
 
-})(jQuery);
+    /**
+     * Convenience method to avoid having to manually set both preferences for 'origin' and
+     * destination.
+     *
+     * 'text' is optional and defaults to location.name if omitted
+     */
+    function setLocation(key, location, text) {
+        setPreference(key, location);
+        if (!_.isUndefined(text)) {
+            setPreference(key + 'Text', text);
+        } else {
+            setPreference(key + 'Text', location.name);
+        }
+    }
+
+    // Convenience method to clear 'origin' and 'destination'
+    function clearLocation(key) {
+        setPreference(key, undefined);
+        setPreference(key + 'Text', undefined);
+    }
+
+})(jQuery, _);

--- a/src/app/styles/templates/_app.scss
+++ b/src/app/styles/templates/_app.scss
@@ -73,6 +73,10 @@
     p.bikeshare {
         line-height: 20%;
     }
+
+    a {
+        cursor: pointer;
+    }
 }
 
 .leaflet-popup-content-wrapper {

--- a/src/bower.json
+++ b/src/bower.json
@@ -17,6 +17,6 @@
     "typeahead.js": "~0.10.5",
     "Leaflet.awesome-markers": "~2.0.2",
     "material-design-iconic-font": "~1.1.1",
-    "navigo": "master"
+    "navigo": "~2.1.1"
   }
 }


### PR DESCRIPTION
Gives the "Discover Places" (aka "explore") tab the same treatment as the directions tab got in PR #464: parameterized URLs pointing to `map/places?` will now load a location list or a specific location, and changing your choices in the tab updates the URL.

Also some incidental fixes and little refactors that came up in the course of getting it working.

The questions of what parameters to include (all probably isn't the right answer. There might not be a single right answer for all users/use cases) and whether to always show it in the address bar (nice to have a bookmarkable/shareable link without having to find the right button, but then again the full URL is so long as to be not really shareable) are related, and also related to the question of how the directions URLs interact with the social media sharing feature on directions.

My current hypothesis is that there should be one social media sharing button that's available on directions, location list, and individual locations and that if we want to give users choices about what parameters to encode in the URL (where omitted parameters would fall back to defaults or local storage for the person who follows the link) the modal that the social media button produces should provide for those options.