### PR TITLE
Feature/blank origin or destination links

### DIFF
--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -59,8 +59,6 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
     var typeaheadDest = null;
     var typeaheadOrigin = null;
 
-    var initialLoad = true;
-
     function SidebarDirectionsControl(params) {
         options = $.extend({}, defaults, params);
         mapControl = options.mapControl;
@@ -115,7 +113,9 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
                 mapControl.displayPoint(lon, lat);
             });
 
-        setFromUserPreferences();
+        if (tabControl.isTabShowing('directions')) {
+            setFromUserPreferences();
+        }
 
         // Respond to changes on all direction input fields
         $(options.selectors.directionInput).on('input change', planTrip);
@@ -430,7 +430,6 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
      * When first navigating to this page, check for user preferences to load.
      */
     function setFromUserPreferences() {
-        var method = UserPreferences.getPreference('method');
         var mode = UserPreferences.getPreference('mode');
         var arriveBy = UserPreferences.getPreference('arriveBy');
         var bikeTriangle = UserPreferences.getPreference('bikeTriangle');
@@ -469,12 +468,6 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
             directions.origin = [origin.feature.geometry.y, origin.feature.geometry.x];
             typeaheadOrigin.setValue(originText);
         }
-
-        if (initialLoad && method === 'directions') {
-            // switch to this tab if it's set as active in UserPreferences
-            tabControl.setTab('directions');
-        }
-        initialLoad = false;
 
         if (tabControl.isTabShowing('directions')) {
             if (origin && destination) {

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -141,6 +141,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
         if (!(directions.origin && directions.destination)) {
             setDirectionsError('origin');
             setDirectionsError('destination');
+            updateUrl();  // Still update the URL if they request one-sided directions
             return;
         }
 
@@ -194,8 +195,8 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
         UserPreferences.setPreference('mode', mode);
         UserPreferences.setPreference('arriveBy', arriveBy);
 
-        // Update URL to match choices
-        urlRouter.updateUrl(urlRouter.buildDirectionsUrlFromPrefs());
+        // Most changes trigger this function, so doing this here keeps the URL mostly in sync
+        updateUrl();
 
         var params = {
             fromText: UserPreferences.getPreference('originText'),
@@ -223,7 +224,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
             });
 
             // put markers at start and end
-            mapControl.setOriginDestinationMarkers(directions.origin, directions.destination);
+            mapControl.setDirectionsMarkers(directions.origin, directions.destination);
             itineraryListControl.setItineraries(itineraries);
             $(options.selectors.directions).addClass(options.selectors.resultsClass);
             itineraryListControl.show();
@@ -244,7 +245,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
     }
 
     function clearDirections() {
-        mapControl.setOriginDestinationMarkers(null, null);
+        mapControl.setDirectionsMarkers(null, null);
         urlRouter.clearUrl();
         clearItineraries();
     }
@@ -255,7 +256,6 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
         directionsListControl.hide();
         $(options.selectors.directions).removeClass(options.selectors.resultsClass);
     }
-
 
     function onDirectionsBackClicked() {
         // show the other itineraries again
@@ -304,6 +304,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
         clearItineraries();
         directions[key] = null;
         UserPreferences.clearLocation(key);
+        mapControl.clearDirectionsMarker(key);
     }
 
     function onTypeaheadSelected(event, key, location) {
@@ -426,6 +427,12 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
         }
     }
 
+    // Updates the URL to match the currently-selected options
+    function updateUrl() {
+        urlRouter.updateUrl(urlRouter.buildDirectionsUrlFromPrefs());
+    }
+
+
     /**
      * When first navigating to this page, check for user preferences to load.
      */
@@ -473,9 +480,12 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
         if (tabControl.isTabShowing('directions')) {
             if (origin && destination) {
                 planTrip();
+            } else if (origin || destination) {
+                mapControl.setDirectionsMarkers(directions.origin, directions.destination, true);
+                clearItineraries();
             } else {
                 clearDirections();
-            }  
+            }
         }
     }
 

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -430,13 +430,14 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
      * When first navigating to this page, check for user preferences to load.
      */
     function setFromUserPreferences() {
+        // Look up origin with setDefault=false to allow it to be blank
+        var origin = UserPreferences.getPreference('origin', false);
+        var originText = UserPreferences.getPreference('originText', false);
+        var destination = UserPreferences.getPreference('destination');
+        var destinationText = UserPreferences.getPreference('destinationText');
         var mode = UserPreferences.getPreference('mode');
         var arriveBy = UserPreferences.getPreference('arriveBy');
         var bikeTriangle = UserPreferences.getPreference('bikeTriangle');
-        var origin = UserPreferences.getPreference('origin');
-        var originText = UserPreferences.getPreference('originText');
-        var destination = UserPreferences.getPreference('destination');
-        var destinationText = UserPreferences.getPreference('destinationText');
         var maxWalk = UserPreferences.getPreference('maxWalk');
         var wheelchair = UserPreferences.getPreference('wheelchair');
 

--- a/src/app/scripts/cac/control/cac-control-sidebar-explore.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-explore.js
@@ -43,6 +43,7 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
     var bikeModeOptions = null;
     var datepicker = null;
     var mapControl = null;
+    var tabControl = null;
     var urlRouter = null;
     var typeahead = null;
     var exploreLatLng = null;
@@ -52,6 +53,7 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
     function SidebarExploreControl(params) {
         options = $.extend({}, defaults, params);
         mapControl = options.mapControl;
+        tabControl = options.tabControl;
         urlRouter = options.urlRouter;
         bikeModeOptions = new BikeModeOptions();
 
@@ -85,7 +87,9 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
         typeahead.events.on(typeahead.eventNames.selected, onTypeaheadSelected);
         typeahead.events.on(typeahead.eventNames.cleared, onTypeaheadCleared);
 
-        setFromUserPreferences();
+        if (tabControl.isTabShowing('explore')) {
+            setFromUserPreferences();
+        }
 
         // Respond to changes on all isochrone input fields
         $(options.selectors.isochroneInput).on('input change', clickedExplore);

--- a/src/app/scripts/cac/control/cac-control-sidebar-tab.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-tab.js
@@ -5,7 +5,7 @@
  *  @event cac:control:sidebartab:shown
  *  @property {string} tabId The tab id that was selected
  */
-CAC.Control.SidebarTab = (function ($) {
+CAC.Control.SidebarTab = (function ($, UserPreferences) {
 
     'use strict';
 
@@ -23,7 +23,6 @@ CAC.Control.SidebarTab = (function ($) {
     var $wrapper = null;
 
     function SidebarTabControl(options) {
-
         var self = this;
 
         self.options = $.extend({}, defaults, options);
@@ -35,6 +34,9 @@ CAC.Control.SidebarTab = (function ($) {
             var $element = $(this);
             self.setTab($element.data('tab'));
         });
+
+        currentTab = UserPreferences.getPreference('method');
+        self.setTab(currentTab);
     }
 
     SidebarTabControl.prototype.isTabShowing = isTabShowing;
@@ -61,4 +63,4 @@ CAC.Control.SidebarTab = (function ($) {
         this.events.trigger(eventNames.tabShown, tabId);
     }
 
-})(jQuery);
+})(jQuery, CAC.User.Preferences);

--- a/src/app/scripts/cac/pages/cac-pages-map.js
+++ b/src/app/scripts/cac/pages/cac-pages-map.js
@@ -31,13 +31,6 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl, UserPreferences
             tabControl: sidebarTabControl
         });
 
-        sidebarExploreControl = new CAC.Control.SidebarExplore({
-            mapControl: mapControl,
-            urlRouter: urlRouter
-        });
-        sidebarExploreControl.events.on(sidebarExploreControl.eventNames.destinationDirections,
-                                        $.proxy(getDestinationDirections, this));
-
         mapControl.events.on(mapControl.eventNames.destinationPopupClick,
                              $.proxy(getDestinationDirections, this));
 
@@ -49,6 +42,14 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl, UserPreferences
 
         mapControl.events.on(mapControl.eventNames.geocodeMarkerMoved,
                              $.proxy(moveIsochrone, this));
+
+        sidebarExploreControl = new CAC.Control.SidebarExplore({
+            mapControl: mapControl,
+            tabControl: sidebarTabControl,
+            urlRouter: urlRouter
+        });
+        sidebarExploreControl.events.on(sidebarExploreControl.eventNames.destinationDirections,
+                                        $.proxy(getDestinationDirections, this));
 
         sidebarDirectionsControl = new CAC.Control.SidebarDirections({
             mapControl: mapControl,

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -10,9 +10,12 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
     'use strict';
 
     // User pref parameters for different views
-    var SHARED_PREFS = ['origin', 'originText', 'mode', 'maxWalk', 'wheelchair', 'bikeTriangle'];
-    var DIRECTIONS_PREFS = SHARED_PREFS.concat([ 'destination', 'destinationText', 'arriveBy']);
-    var EXPLORE_PREFS = SHARED_PREFS.concat(['placeId', 'exploreTime']);
+    var SHARED_ENCODE = ['origin', 'originText', 'mode'];
+    var SHARED_READ = ['maxWalk', 'wheelchair', 'bikeTriangle'];
+    var EXPLORE_ENCODE = SHARED_ENCODE.concat(['placeId', 'exploreTime']);
+    var EXPLORE_READ = EXPLORE_ENCODE.concat(SHARED_READ);
+    var DIRECTIONS_ENCODE = SHARED_ENCODE.concat(['destination', 'destinationText']);
+    var DIRECTIONS_READ = DIRECTIONS_ENCODE.concat(SHARED_READ).concat(['arriveBy']);
 
     var router = null;
 
@@ -47,20 +50,20 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
 
     function setExplorePrefsFromUrl() {
         UserPreferences.setPreference('method', 'explore');
-        setPrefsFromUrl(EXPLORE_PREFS);
+        setPrefsFromUrl(EXPLORE_READ);
     }
 
     function buildExploreUrlFromPrefs() {
-        return '/places?' + buildUrlParamsFromPrefs(EXPLORE_PREFS);
+        return '/places?' + buildUrlParamsFromPrefs(EXPLORE_ENCODE);
     }
 
     function setDirectionsPrefsFromUrl() {
         UserPreferences.setPreference('method', 'directions');
-        setPrefsFromUrl(DIRECTIONS_PREFS);
+        setPrefsFromUrl(DIRECTIONS_READ);
     }
 
     function buildDirectionsUrlFromPrefs() {
-        return '/directions?' + buildUrlParamsFromPrefs(DIRECTIONS_PREFS);
+        return '/directions?' + buildUrlParamsFromPrefs(DIRECTIONS_ENCODE);
     }
 
 

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -91,18 +91,22 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
     /* Reads values for the given fields from local storage and composes a URL query string
      * from them.
      *
-     * Fields with no value given in the URL will be skipped (not overwritten with nothing)
+     * Only fields for which the preference value is defined will be included, and it won't set
+     * undefined fields to default values during lookup.
      */
     function buildUrlParamsFromPrefs(fields) {
         var opts = {};
         _.forEach(fields, function(field) {
             if (field === 'origin' || field === 'destination') {
-                var location = UserPreferences.getPreference(field);
+                var location = UserPreferences.getPreference(field, false);
                 if (location && location.feature && location.feature.geometry) {
                     opts[field] = [location.feature.geometry.y, location.feature.geometry.x].join(',');
                 }
             } else {
-                opts[field] = UserPreferences.getPreference(field);
+                var val = UserPreferences.getPreference(field, false);
+                if (!_.isUndefined(val)) {
+                    opts[field] = val;
+                }
             }
         });
         return Utils.encodeUrlParams(opts);

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -100,7 +100,9 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
             if (field === 'origin' || field === 'destination') {
                 var location = UserPreferences.getPreference(field, false);
                 if (location && location.feature && location.feature.geometry) {
-                    opts[field] = [location.feature.geometry.y, location.feature.geometry.x].join(',');
+                    // Write lat/lon with ~1cm precision. should be sufficient and makes URLs nicer.
+                    opts[field] = [_.round(location.feature.geometry.y, 7),
+                                   _.round(location.feature.geometry.x, 7)].join(',');
                 }
             } else {
                 var val = UserPreferences.getPreference(field, false);

--- a/src/app/scripts/cac/user/cac-user-preferences.js
+++ b/src/app/scripts/cac/user/cac-user-preferences.js
@@ -55,16 +55,20 @@ CAC.User.Preferences = (function($, _) {
      * Fetch stored setting.
      *
      * @param {String} preference Name of setting to fetch
+     * @param {Boolean} [setDefault=true] If false, don't set the default value if no value is set
      * @return {Object} setting found in storage, or default if none found
      */
-    function getPreference(preference) {
+    function getPreference(preference, setDefault) {
         var val = storage.get(preference);
         if (val) {
             val = JSON.parse(val);
         }
 
+        // Default to true
+        setDefault = _.isUndefined(setDefault) || setDefault;
+
         // If a typeahead is cleared, we want to grab the default
-        if (!val || val === '') {
+        if (setDefault && !val || val === '') {
             val = defaults[preference];
             setPreference(preference, val);
         }

--- a/src/bower.json
+++ b/src/bower.json
@@ -12,7 +12,7 @@
     "Leaflet.encoded": "~0.0.7",
     "moment": "~2.10.3",
     "moment-duration-format": "~1.3.0",
-    "lodash": "~3.9.0",
+    "lodash": "~3.10.1",
     "spinkit": "~1.0.1",
     "typeahead.js": "~0.10.5",
     "Leaflet.awesome-markers": "~2.0.2",


### PR DESCRIPTION
Main item: showing map markers for one-sided destinations.  Formerly it was both-or-nothing, so loading a link to directions with only an origin or a destination would show a blank map.  Now it will draw the marker it has and zoom to it.

[Example](http://localhost:8024/map/directions?mode=TRANSIT%2CWALK&destination=39.9611421%2C-75.1546293&destinationText=N%2010th%20St%20%26%20Nectarine%20St%2C%20Philadelphia%2C%20Pennsylvania%2C%2019123)

Other changes made on the way:
- Changed how the map and map page initialize so that it only triggers full initialization for the sidebar that's active, rather than doing the whole process for both.  This fixed some unwelcome interactions.
- Changed the URL encoding to not include undefined local preferences in the URL and to not cause local preferences to be initialized to default values if they're not set.
- Removed some parameters from the URL, on the theory that shorter URLs might be better and on the off-chance that someone has overridden their own bike triangle or max walking distance, it wouldn't necessarily be polite for shared URLs to force it to a different value.  (Not totally sure what's best for this situation. Nor sure it matters too much. "Include in URL if different from default value" would be another possible approach, maybe the optimal one.)