### PR TITLE
Upgrade to django 1.8

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -33,4 +33,4 @@ cac_python_dependencies:
     - { name: 'psycopg2', version: '2.6.1' }
     - { name: 'pytz', version: '2016.4' }
     - { name: 'pyyaml', version: '3.11' }
-    - { name: 'troposphere', version: '1.6.0'}
+    - { name: 'troposphere', version: '0.7.2'}

--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -26,7 +26,7 @@ cac_python_dependencies:
     - { name: 'django-ckeditor', version: '5.0.3' }
     - { name: 'django-extensions', version: '1.6.7' }
     - { name: 'django-storages-redux', version: '1.3.2' }
-    - { name: 'django-wpadmin', version: '1.7.4'}
+    - { name: 'git+https://github.com/azavea/django-wpadmin@v1.8.13#egg=django-wpadmin', version: ''}
     - { name: 'gunicorn', version: '19.6.0'}
     - { name: 'ipython', version: '4.2.1' }
     - { name: 'pillow', version: '3.3.0' }

--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -20,17 +20,17 @@ root_media_dir: "/media/cac"
 app_cron_event_feed: "cd {{ root_app_dir }} && python manage.py load_events >> {{ app_cron_event_feed_log }} 2>&1"
 
 cac_python_dependencies:
-    - { name: 'base58', version: '0.2.1' }
-    - { name: 'boto', version: '2.38.0' }
-    - { name: 'django', version: '1.7.8' }
-    - { name: 'django-ckeditor', version: '4.4.7' }
-    - { name: 'django-extensions', version: '1.5.3' }
-    - { name: 'django-storages-redux', version: '1.2.3' }
-    - { name: 'django-wpadmin', version: '1.7.2'}
-    - { name: 'gunicorn', version: '19.3.0'}
-    - { name: 'ipython', version: '2.3.1' }
-    - { name: 'pillow', version: '2.8.1' }
-    - { name: 'psycopg2', version: '2.5.4' }
-    - { name: 'pytz', version: '2015.2' }
+    - { name: 'base58', version: '0.2.3' }
+    - { name: 'boto', version: '2.41.0' }
+    - { name: 'django', version: '1.8.13' }
+    - { name: 'django-ckeditor', version: '5.0.3' }
+    - { name: 'django-extensions', version: '1.6.7' }
+    - { name: 'django-storages-redux', version: '1.3.2' }
+    - { name: 'django-wpadmin', version: '1.7.4'}
+    - { name: 'gunicorn', version: '19.6.0'}
+    - { name: 'ipython', version: '4.2.1' }
+    - { name: 'pillow', version: '3.3.0' }
+    - { name: 'psycopg2', version: '2.6.1' }
+    - { name: 'pytz', version: '2016.4' }
     - { name: 'pyyaml', version: '3.11' }
-    - { name: 'troposphere', version: '0.7.2'}
+    - { name: 'troposphere', version: '1.6.0'}

--- a/python/cac_tripplanner/cac_tripplanner/settings.py
+++ b/python/cac_tripplanner/cac_tripplanner/settings.py
@@ -63,8 +63,6 @@ SECRET_KEY = secrets['secret_key']
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = not secrets['production']
 
-TEMPLATE_DEBUG = not secrets['production']
-
 ALLOWED_HOSTS = secrets['allowed_hosts']
 
 INTERNAL_IPS = tuple(secrets['internal_ips'])
@@ -142,28 +140,29 @@ MEDIA_ROOT = '/media/cac/'
 MEDIA_URL = '/media/'
 
 # TEMPLATE CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#template-context-processors
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.core.context_processors.tz',
-    'django.contrib.messages.context_processors.messages',
-    'django.core.context_processors.request',
-)
-
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#template-loaders
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
-
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#template-dirs
-TEMPLATE_DIRS = (
-    os.path.normpath(os.path.join(BASE_DIR, 'templates')),
-)
+# See https://docs.djangoproject.com/en/1.8/ref/settings/#templates
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            os.path.normpath(os.path.join(BASE_DIR, 'templates')),
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'debug': DEBUG,
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+                'django.template.context_processors.request',
+            ],
+        },
+    },
+]
 
 CKEDITOR_UPLOAD_PATH = 'uploads/'
 CKEDITOR_IMAGE_BACKEND = 'pillow'

--- a/python/cac_tripplanner/cac_tripplanner/urls.py
+++ b/python/cac_tripplanner/cac_tripplanner/urls.py
@@ -3,46 +3,43 @@ from django.contrib.gis import admin
 
 from django.contrib.staticfiles import views as staticviews
 
-from cms.views import AllArticles
-from destinations.views import FindReachableDestinations, SearchDestinations, FeedEvents
+from cms import views as cms_views
+from destinations.views import (FindReachableDestinations, SearchDestinations, FeedEvents,
+                                map as map_view, directions as directions_view)
 import settings
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     # Home
-    url(r'^$', 'cms.views.home', name='home'),
+    url(r'^$', cms_views.home, name='home'),
 
     # Map
     url(r'^api/destinations/search$', SearchDestinations.as_view(), name='api_destinations_search'),
     url(r'^api/feedevents$', FeedEvents.as_view(), name='api_feedevents'),
     url(r'^map/reachable$', FindReachableDestinations.as_view(), name='reachable'),
-    url(r'^map/', 'destinations.views.map', name='map'),
-    url(r'^directions/', 'destinations.views.directions', name='directions'),
+    url(r'^map/', map_view, name='map'),
+    url(r'^directions/', directions_view, name='directions'),
 
     # About and FAQ
-    url(r'^info/(?P<slug>[\w-]+)/$',
-        'cms.views.about_faq',
-        name='about-faq'),
+    url(r'^info/(?P<slug>[\w-]+)/$', cms_views.about_faq, name='about-faq'),
 
     # All Published Articles
-    url(r'^api/articles$', AllArticles.as_view(), name='api_articles'),
+    url(r'^api/articles$', cms_views.AllArticles.as_view(), name='api_articles'),
 
     # Community Profiles
     url(r'^community-profile/(?P<slug>[\w-]+)/$',
-        'cms.views.community_profile_detail',
+        cms_views.community_profile_detail,
         name='community-profile-detail'),
 
     # Tips and Tricks
     url(r'^tips-and-tricks/(?P<slug>[\w-]+)/$',
-        'cms.views.tips_and_tricks_detail',
+        cms_views.tips_and_tricks_detail,
         name='tips-and-tricks-detail'),
 
     # Link Shortening
     url(r'^link/', include('shortlinks.urls')),
 
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^ckeditor/', include('ckeditor.urls')),
-)
+]
 
 if settings.DEBUG:
     urlpatterns += [

--- a/python/cac_tripplanner/cms/migrations/0005_add_default_admin_user.py
+++ b/python/cac_tripplanner/cms/migrations/0005_add_default_admin_user.py
@@ -32,6 +32,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('CMS', '0004_add_image_fields'),
+        ('auth', '0005_alter_user_last_login_null'),
     ]
 
     operations = [

--- a/python/cac_tripplanner/cms/views.py
+++ b/python/cac_tripplanner/cms/views.py
@@ -3,8 +3,7 @@ from random import shuffle
 
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
-from django.shortcuts import render_to_response, get_object_or_404
-from django.template import RequestContext
+from django.shortcuts import render, get_object_or_404
 from django.views.generic import View
 
 from .models import AboutFaq, Article
@@ -25,19 +24,18 @@ def home(request):
     shuffle(destination_ids)
     destinations = Destination.objects.filter(id__in=destination_ids[:4])
 
-    context = RequestContext(request,
-                             dict(community_profile=community_profile,
-                                  tips_and_tricks=tips_and_tricks,
-                                  destinations=destinations,
-                                  fb_app_id=FB_APP_ID,
-                                  debug=DEBUG))
-    return render_to_response('home.html', context_instance=context)
+    context = dict(community_profile=community_profile,
+                   tips_and_tricks=tips_and_tricks,
+                   destinations=destinations,
+                   fb_app_id=FB_APP_ID,
+                   debug=DEBUG)
+    return render(request, 'home.html', context=context)
 
 
 def about_faq(request, slug):
     page = get_object_or_404(AboutFaq.objects.all(), slug=slug)
-    context = RequestContext(request, {'page': page, 'debug': DEBUG})
-    return render_to_response('about-faq.html', context_instance=context)
+    context = {'page': page, 'debug': DEBUG}
+    return render(request, 'about-faq.html', context=context)
 
 
 def community_profile_detail(request, slug):
@@ -47,9 +45,8 @@ def community_profile_detail(request, slug):
     """
     community_profile = get_object_or_404(Article.profiles.published(),
                                           slug=slug)
-    context = RequestContext(request, {'article': community_profile, 'debug': DEBUG})
-    return render_to_response('community-profile-detail.html',
-                              context_instance=context)
+    context = {'article': community_profile, 'debug': DEBUG}
+    return render(request, 'community-profile-detail.html', context=context)
 
 
 def tips_and_tricks_detail(request, slug):
@@ -59,9 +56,8 @@ def tips_and_tricks_detail(request, slug):
     """
     tips_and_tricks = get_object_or_404(Article.tips.published(),
                                         slug=slug)
-    context = RequestContext(request, {'article': tips_and_tricks, 'debug': DEBUG})
-    return render_to_response('tips-and-tricks-detail.html',
-                              context_instance=context)
+    context = {'article': tips_and_tricks, 'debug': DEBUG}
+    return render(request, 'tips-and-tricks-detail.html', context=context)
 
 class AllArticles(View):
     """ API endpoint for the Articles model """

--- a/python/cac_tripplanner/shortlinks/test/urls.py
+++ b/python/cac_tripplanner/shortlinks/test/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
+from shortlinks.test.views import stub_view
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^link/', include('shortlinks.urls')),
-    url(r'^$', 'shortlinks.test.views.stub_view', name='test-home'),
-)
+    url(r'^$', stub_view, name='test-home'),
+]

--- a/python/cac_tripplanner/shortlinks/tests.py
+++ b/python/cac_tripplanner/shortlinks/tests.py
@@ -2,7 +2,7 @@ import json
 import urlparse
 
 from django.core.urlresolvers import reverse
-from django.test import TestCase, Client
+from django.test import TestCase, Client, override_settings
 from django.utils import timezone
 
 from .forms import ShortenedLinkForm
@@ -93,6 +93,7 @@ class ShortenedLinkFormTestCase(TestCase):
 
 class ShortenedLinkViewsTestCase(TestCase):
     def setUp(self):
+        urls = 'shortlinks.test.urls'
         self.client = Client()
 
     def test_methods_and_url_resolution(self):
@@ -123,9 +124,8 @@ class ShortenedLinkCreateTestCase(TestCase):
         self.assertEqual(response.status_code, 201, response.content)
 
 
+@override_settings(ROOT_URLCONF='shortlinks.test.urls')
 class ShortenedLinkRedirectTestCase(TestCase):
-    urls = 'shortlinks.test.urls'
-
     def setUp(self):
         self.client = Client()
         self.path = '/?but=with&some=params'

--- a/python/cac_tripplanner/shortlinks/urls.py
+++ b/python/cac_tripplanner/shortlinks/urls.py
@@ -1,12 +1,11 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.decorators.csrf import csrf_exempt
 
 from .views import ShortenedLinkRedirectView, ShortenedLinkCreateView
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^(?P<key>[1-9A-Za-z]{15,30})$', ShortenedLinkRedirectView.as_view(),
         name='dereference-shortened'),
     url(r'^shorten/$', csrf_exempt(ShortenedLinkCreateView.as_view()),
         name='shorten-link')
-)
+]

--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -142,7 +142,7 @@
                       {% if community_profile %}
                         <div class="col-sm-6">
                           <a class="block block-spotlight"
-                             href="{% url 'cms.views.community_profile_detail' community_profile.slug %}">
+                             href="{% url 'community-profile-detail' community_profile.slug %}">
                                 <h3 class="destination-name">{{ community_profile.title }}</h3>
                                 <h5>Community Profile</h5>
                                 {% if community_profile.narrow_image %}
@@ -156,7 +156,7 @@
                         {% if tips_and_tricks %}
                         <div class="col-sm-6">
                           <a class="block block-spotlight"
-                             href="{% url 'cms.views.tips_and_tricks_detail' tips_and_tricks.slug %}">
+                             href="{% url 'tips-and-tricks-detail' tips_and_tricks.slug %}">
                                 <h3 class="destination-name">{{ tips_and_tricks.title }}</h3>
                                 <h5>Tips & Tricks</h5>
                                 {% if tips_and_tricks.wide_image %}


### PR DESCRIPTION
Upgrades Django to 1.8.13 and the other python packages to the current default versions.

A couple changes for brokenness and a few for deprecation warnings.

The squirrelly part of this is the `django-wpadmin` package, which has gone stale (https://github.com/barszczmm/django-wpadmin).  But it still seems to work fine, so I forked it to deal with the version warning.  Voila: https://github.com/azavea/django-wpadmin
Not sure if that's the best strategy, but the interface is notably nicer than the default, and I didn't find a ready alternative nice admin skin in my (brief) searching.