### PR TITLE
Feature/fix getbounds error

### DIFF
--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -30,7 +30,7 @@
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.14/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css" />
     <link href="{% static 'styles/vendor.css' %}" rel="stylesheet">
     <link href="{% static 'styles/main.css' %}" rel="stylesheet">
 
@@ -69,7 +69,6 @@
     {% block jsimports %}
 
     <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-    <script type="text/javascript" src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.14/cartodb.js"></script>
 
     {% if debug %}
 
@@ -86,6 +85,7 @@
     }(document, 'script', 'facebook-jssdk'));</script>
     {% endif %}
 
+    <script src="{% static 'scripts/vendor/cartodb.js' %}"></script>
     <script src="{% static 'scripts/vendor/bootstrap.js' %}"></script>
     <script src="{% static 'scripts/vendor/jquery.storageapi.js' %}"></script>
     <script src="{% static 'scripts/vendor/lodash.js' %}"></script>
@@ -98,7 +98,6 @@
     <script src="{% static 'scripts/vendor/bootstrap-datetimepicker.min.js' %}"></script>
     <script src="{% static 'scripts/vendor/bootstrap-select.js' %}"></script>
     <script src="{% static 'scripts/vendor/navigo.js' %}"></script>
-
 
     <script src="{% static 'scripts/main/cac/cac.js' %}"></script>
     <script src="{% static 'scripts/main/cac/utils.js' %}"></script>

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -530,7 +530,12 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, _) {
 
         var markers = _.compact(_.values(directionsMarkers));
         if (zoomToFit && !_.isEmpty(markers)) {
-            map.fitBounds(L.featureGroup(markers).getBounds(), { maxZoom: defaults.zoom });
+            // zoom to fit all markers if several, or if there's only one, center on it
+            if (markers.length > 1) {
+                map.fitBounds(L.latLngBounds(markers), { maxZoom: defaults.zoom });
+            } else {
+                map.setView(markers[0].getLatLng());
+            }
         }
     }
 

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -219,22 +219,32 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, _) {
      * Add isochrone outline to map
      */
     function drawIsochrone(isochrone, zoomToFit) {
-        isochroneLayer = cartodb.L.geoJson(isochrone, {
-            clickable: false,
-            style: {
+        try {
+            isochroneLayer = cartodb.L.geoJson(isochrone, {
                 clickable: false,
-                color: '#5c2482',
-                fillColor: '#5c2482',
-                lineCap: 'round',
-                lineJoin: 'round',
-                opacity: 0.4,
-                fillOpacity: 0.3,
-                stroke: true,
-                weight: 2
+                style: {
+                    clickable: false,
+                    color: '#5c2482',
+                    fillColor: '#5c2482',
+                    lineCap: 'round',
+                    lineJoin: 'round',
+                    opacity: 0.4,
+                    fillOpacity: 0.3,
+                    stroke: true,
+                    weight: 2
+                }
+            });
+        } catch (err) {
+            console.log('isochrone layer failed to load from GeoJSON');
+            console.log(err);
+            isochroneLayer = null;
+        }
+
+        if (isochroneLayer) {
+            isochroneLayer.addTo(map);
+            if (zoomToFit) {
+                map.fitBounds(isochroneLayer.getBounds());
             }
-        }).addTo(map);
-        if (zoomToFit) {
-            map.fitBounds(isochroneLayer.getBounds());
         }
     }
 

--- a/src/bower.json
+++ b/src/bower.json
@@ -8,7 +8,7 @@
     "handlebars": "~3.0.3",
     "jquery": "~2.1.4",
     "jQuery-Storage-API": "~1.7.4",
-    "cartodb.js": "~3.15.9",
+    "cartodb.js": "~3.15",
     "Leaflet.encoded": "~0.0.7",
     "moment": "~2.10.3",
     "moment-duration-format": "~1.3.0",

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -85,7 +85,7 @@ gulp.task('minify:scripts', function() {
 });
 
 gulp.task('minify:vendor-scripts', function() {
-    return copyBowerFiles(['**/*.js', '!**/leaflet.js', '!**/jquery.js', '!**/jquery.min.js'], [])
+    return copyBowerFiles(['**/*.js', '!**/leaflet.js', '!**/leaflet-src.js', '!**/jquery.js', '!**/jquery.min.js'], [])
         .pipe(concat('vendor.js'))
         .pipe(uglify())
         .pipe(gulp.dest(stat.scripts));
@@ -139,7 +139,7 @@ gulp.task('copy:app-images', function() {
 });
 
 gulp.task('copy:vendor-scripts', function() {
-    return copyBowerFiles('**/*.js', [])
+    return copyBowerFiles(['**/*.js', '!**/leaflet.js', '!**/leaflet-src.js'], [])
         .pipe(gulp.dest(stat.scripts + '/vendor'));
 });
 


### PR DESCRIPTION
Fixes #470 by only attempting to zoom to fit all markers if more than one marker loaded. Also sorts out build issues with loading cartodb.js and properly excluding Leaflet (which is included in cartodb.js).

Also adds more graceful handling in case of the isochrone geojson not loading properly by allowing the locations list to populate.