### PR TITLE
Install wpadmin manually to work around pip issue

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -26,7 +26,6 @@ cac_python_dependencies:
     - { name: 'django-ckeditor', version: '5.0.3' }
     - { name: 'django-extensions', version: '1.6.7' }
     - { name: 'django-storages-redux', version: '1.3.2' }
-    - { name: 'git+https://github.com/azavea/django-wpadmin@v1.8.13#egg=django-wpadmin', version: ''}
     - { name: 'gunicorn', version: '19.6.0'}
     - { name: 'ipython', version: '4.2.1' }
     - { name: 'pillow', version: '3.3.0' }
@@ -34,3 +33,5 @@ cac_python_dependencies:
     - { name: 'pytz', version: '2016.4' }
     - { name: 'pyyaml', version: '3.11' }
     - { name: 'troposphere', version: '0.7.2'}
+    # Note: django-wpadmin is installed manually to work around the fact that ansible-pip
+    # ignores editable=False

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -13,6 +13,11 @@
   pip: name={{ item.name }} version={{ item.version }}
   with_items: cac_python_dependencies
 
+  # Putting 'editable: false' in the entry in cac_python_dependencies should make it install
+  # non-editable, but it's getting ignored
+- name: Install django-wpadmin manually to work around ansible bug
+  command: pip install 'git+https://github.com/azavea/django-wpadmin@v1.8.13#egg=django-wpadmin'
+
 # TODO: peg this to a version, rather than a commit, when released
 # ansible pip module installs this in /tmp/src for some reason, so we use the
 # command instead


### PR DESCRIPTION
Ansible's pip module seems to be ignoring the 'editable' option, and
setting it to True by default for packages installed from git links.
Which puts a .egg-link file in /usr/local/lib/python2.7/dist-packages and
installs the actual package in /tmp.  Which means it's gone the next time
you reload the machine.

This works around the issue by just directly running a pip command that
does the right thing.