### PR TITLE
Upgrade OTP to 0.20.0 but stick with Trusty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,8 @@ nosetests.xml
 # Ansible roles
 deployment/ansible/roles/azavea.*
 
+# Ansible retry files
+*.retry
+
 # AWS stack launching parameters
 deployment/default.yaml

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -3,15 +3,10 @@ app_username: "vagrant"
 
 packer_version: "0.7.5"
 
-# open trip planner vars
-otp_version: "0.15.0"
-
 # used by nginx and gunicorn to set timeouts; OTP defaults to 30s
 otp_session_timeout_s: 30
 
 s3_otp_data: cleanair-otp-data
-
-postgresql_support_libpq_version: 9.5.*
 
 papertrail_log_files:
     - "/var/log/cac-tripplanner-app.log"

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -7,6 +7,5 @@ azavea.packer,0.2.0
 azavea.papertrail,1.1.1
 azavea.pip,0.1.1
 azavea.python,0.1.0
-azavea.ruby,0.3.0
 azavea.virtualenv,0.1.0
 azavea.postgresql-support,0.3.0

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -1,6 +1,6 @@
 azavea.git,0.1.0
 azavea.java,0.2.6
-azavea.opentripplanner,0.4.0
+azavea.opentripplanner,1.0.0
 azavea.nginx,0.2.1
 azavea.nodejs,0.4.0
 azavea.packer,0.2.0

--- a/deployment/ansible/roles/cac-tripplanner.app/meta/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/meta/main.yml
@@ -5,5 +5,4 @@
     - { role: "azavea.nodejs", nodejs_npm_version: "2.1.5" }
     - { role: "azavea.packer" }
     - { role: "cac-tripplanner.papertrail", when: production }
-    - { role: "azavea.ruby", ruby_development: True }
     - { role: "azavea.virtualenv" }

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/jslibs.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/jslibs.yml
@@ -1,15 +1,4 @@
 ---
-- name: Install Sass
-  gem: name=sass
-       version={{ app_sass_version }}
-       user_install=no
-       state=present
-
-- name: Install Compass
-  gem: name=compass
-       user_install=no
-       state=present
-
 - name: Clear out the NPM artifacts when in production (want a fresh set)
   file: path="{{ root_src_dir }}/node_modules" state=absent
   sudo: yes

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Install pip packages
   pip: name={{ item.name }} version={{ item.version }}
-  with_items: cac_python_dependencies
+  with_items: "{{ cac_python_dependencies }}"
 
   # Putting 'editable: false' in the entry in cac_python_dependencies should make it install
   # non-editable, but it's getting ignored
@@ -26,12 +26,8 @@
            creates=/usr/local/lib/python2.7/dist-packages/majorkirby/__init__.py
   when: develop
 
-- name: Touch log file if it does not exist
-  command: touch {{ app_log }}
-           creates={{ app_log }}
-
-- name: Set log file permissions
-  file: path={{ app_log }} owner={{ app_username }} group={{ app_username }} mode=0664
+- name: Touch log file and set permissions
+  file: path={{ app_log }} state=touch owner={{ app_username }} group={{ app_username }} mode=0664
 
 - name: Create configuration file directory
   file: path={{ root_conf_dir }}
@@ -74,8 +70,9 @@
   command: touch {{ app_cron_event_feed_log }}
            creates={{ app_cron_event_feed_log }}
 
-- name: Set cron job log file permissions
-  file: path={{ app_cron_event_feed_log }} owner={{ app_username }} group={{ app_username }} mode=0664
+- name: Touch cron job log file if it does not exist, and set permissions
+  file: path={{ app_cron_event_feed_log}} state=touch
+        owner={{ app_username }} group={{ app_username }} mode=0664
 
 # TODO: Add logic in production to only run on a single webserver
 - name: Add cron job for RSS events feed

--- a/deployment/ansible/roles/cac-tripplanner.database/meta/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.database/meta/main.yml
@@ -1,3 +1,3 @@
 ---
   dependencies:
-    - { role: "azavea.postgresql-support" }
+    - { role: "azavea.postgresql-support", postgresql_support_libpq_version: 9.5.* }

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create Directory for OSM and GTFS
-  file: path={{ otp_data_dir }} state=directory
+  file: path={{ otp_data_dir }} state=directory owner={{ otp_user }}
 
 - name: Copy Feed Validator
   copy: src=validate_feed.py dest="{{ otp_data_dir }}"
@@ -9,8 +9,7 @@
   apt: pkg=authbind state=present
 
 - name: Touch AuthBind file if it does not exist
-  command: touch /etc/authbind/byport/80
-           creates=/etc/authbind/byport/80
+  file: path=/etc/authbind/byport/80 state=touch
 
 - name: Change owner and mode of byport file
   file: path=/etc/authbind/byport/80 owner={{ otp_user }} mode=0755
@@ -18,33 +17,33 @@
 - name: Overwrite upstart service
   template: src=otp.conf.j2 dest=/etc/init/otp.conf
 
-- name: Download OTP Data
+- name: Download OTP Data (test)
   local_action: command aws s3 sync s3://cleanair-otp-data/ ../../otp_data/
   sudo: no
   when: test
 
-- name: Copy OTP Data
+- name: Copy OTP Data (test/develop)
   copy: src=./otp_data/ dest="{{ otp_data_dir }}/" owner={{ansible_ssh_user}} group={{ansible_ssh_user}} mode=0664
   when: develop or test
 
-- name: Build OTP Graph
-  command: /usr/bin/java -Xmx{{ otp_process_mem }} -jar {{ otp_bin_dir }}/otp-{{ otp_version }}.jar --build {{ otp_data_dir }}
+- name: Build OTP Graph (test/develop)
+  command: /usr/bin/java -Xmx{{ otp_process_mem }} -jar {{ otp_bin_dir }}/{{ otp_jar_name }} --build {{ otp_data_dir }}
   args:
     chdir: "{{ otp_bin_dir }}"
   when: develop or test
 
-- name: Copy Built OTP Graph to Host
+- name: Copy Built OTP Graph to Host (develop)
   fetch: src={{ otp_data_dir }}/Graph.obj dest=../../otp_data/ fail_on_missing=yes flat=yes
   when: develop
 
 - name: Create Graph Directory
   file: path="{{ otp_data_dir}}/{{ otp_router }}" state=directory
 
-- name: Move Graph to Graph Directory
+- name: Move Graph to Graph Directory (test/develop)
   command: mv {{ otp_data_dir }}/Graph.obj {{ otp_data_dir }}/{{ otp_router }}
   notify: Restart OpenTripPlanner
   when: develop or test
 
-- name: Move Local Graph to Graph Directory
+- name: Copy Local Graph to Graph Directory (production)
   copy: src=./otp_data/Graph.obj dest="{{ otp_data_dir }}/{{ otp_router }}/Graph.obj" owner={{ansible_ssh_user}} group={{ansible_ssh_user}} mode=0664
   when: production

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/templates/otp.conf.j2
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/templates/otp.conf.j2
@@ -1,13 +1,14 @@
 ## NOTICE: This file is written by ansible, and any changes made here will be overwritten on next provision.
-#           Modify cac-tripplanner.otp-data/templates/otp.conf.j2 to make changes stick.
-description "start OpenTripPlanner process"
+#          Modify cac-tripplanner.otp-data/templates/otp.conf.j2 to make changes stick.
+description "OpenTripPlanner"
 
-start on {{ upstart_start_on }}
-stop on runlevel [!2345]
+start on {{ otp_upstart_start_on }}
+stop on shutdown
 
+respawn
 setuid {{ otp_user }}
-
 chdir {{ otp_bin_dir }}
+
 script
-    exec /usr/bin/authbind /usr/bin/java -Xmx{{otp_process_mem}} -jar {{ otp_bin_dir }}/otp-{{ otp_version }}.jar --server --analyst --port 80 --basePath {{ otp_data_dir}} --graphs {{ otp_data_dir }} --router default
+    exec /usr/bin/authbind /usr/bin/java -Xmx{{otp_process_mem}} -jar {{ otp_bin_dir }}/{{ otp_jar_name }} --server --analyst --port 80 --basePath {{ otp_data_dir}} --graphs {{ otp_data_dir }} --router default
 end script

--- a/deployment/ansible/roles/cac-tripplanner.transitfeed/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.transitfeed/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
-- name: Install transitfeed
+- name: Install pytz
   pip: name=pytz
+
+- name: Install transitfeed
   pip: name='git+https://github.com/google/transitfeed@1.2.15#egg=transitfeed'

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -154,12 +154,12 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder) {
      */
     function getLegs(legs) {
         return _.map(legs, function(leg) {
-            if (leg.from.name.indexOf('osm:node') > -1) {
+            if (leg.from.name.indexOf('Start point 0.') > -1) {
                 getOsmNodeName(leg.from).then(function(name) {
                     leg.from.name = name;
                 });
             }
-            if (leg.to.name.indexOf('osm:node') > -1) {
+            if (leg.to.name.indexOf('Start point 0.') > -1) {
                 getOsmNodeName(leg.to).then(function(name) {
                     leg.to.name = name;
                 });

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -7,6 +7,7 @@ var debug = require('gulp-debug');
 var del = require('del');
 var gulp = require('gulp');
 var gulpFilter = require('gulp-filter');
+var sass = require('gulp-sass');
 var jshintXMLReporter = require('gulp-jshint-xml-file-reporter');
 var karma = require('karma').server;
 var mainBower = require('main-bower-files');
@@ -165,10 +166,7 @@ gulp.task('jshint:jenkins', function () {
 gulp.task('sass', function () {
     return gulp.src('app/styles/main.scss')
         .pipe(plumber())
-        .pipe($.rubySass({
-            style: 'expanded',
-            precision: 10
-        }))
+        .pipe(sass({outputStyle: 'expanded'}).on('error', sass.logError))
         .pipe(filterCSS)
         .pipe($.autoprefixer({browsers: ['last 2 versions'], cascade: false}))
         .pipe(filterCSS.restore())

--- a/src/package.json
+++ b/src/package.json
@@ -27,7 +27,7 @@
     "gulp-order": "~1.1.1",
     "gulp-plumber": "~1.1.0",
     "gulp-replace": "~0.4.0",
-    "gulp-ruby-sass": "~0.7.1",
+    "gulp-sass": "~2.3.2",
     "gulp-run": "~1.7.1",
     "gulp-sequence": "~0.3.2",
     "gulp-shell": "~0.2.11",


### PR DESCRIPTION
Retreat!

The move to Xenial in PR #478 is causing all sorts of annoying problems, and as @hectcastro pointed out on https://github.com/azavea/ansible-opentripplanner/pull/15 and proved in https://github.com/azavea/ansible-opentripplanner/tree/feature/hmc/upgrade-otp, OTP 0.20.0 can be run on Trusty using Oracle Java 8.

So this is PR #478 without all the Xenial-related changes (which was most of the substance, but there are still small improvements) and it seems to be fully working, for me, with Hector's branch of the OTP role.  I think we should do this instead.