### PR TITLE
Override URL for openlayers.js

### DIFF
--- a/python/cac_tripplanner/destinations/admin.py
+++ b/python/cac_tripplanner/destinations/admin.py
@@ -18,6 +18,10 @@ class DestinationAdmin(admin.OSMGeoAdmin):
     # Override map_template for custom address geocoding behavior
     map_template = 'admin/cac-geocoding-map.html'
 
+    # Override configurable URL for openlayers.js to support SSL
+    # default is: 'http://openlayers.org/api/2.13.1/OpenLayers.js'
+    openlayers_url = 'https://cdnjs.cloudflare.com/ajax/libs/openlayers/2.13.1/OpenLayers.js'
+
     # Include geocoder dependencies
     jquery = 'https://code.jquery.com/jquery-2.1.3.min.js'
     if settings.DEBUG:

--- a/python/cac_tripplanner/destinations/admin.py
+++ b/python/cac_tripplanner/destinations/admin.py
@@ -29,6 +29,7 @@ class DestinationAdmin(admin.OSMGeoAdmin):
             jquery,
             '/static/scripts/vendor/lodash.js',
             '/static/scripts/main/cac/cac.js',
+            '/static/scripts/main/cac/search/cac-search-params.js',
             '/static/scripts/main/cac/search/cac-geocoder.js'
         ]
     else:

--- a/python/cac_tripplanner/templates/admin/cac-geocoding-map.html
+++ b/python/cac_tripplanner/templates/admin/cac-geocoding-map.html
@@ -1,4 +1,4 @@
-{% extends 'gis/admin/osm.html' %}
+{% extends "gis/admin/openlayers.html" %}
 
 {% block openlayers %}
 {% include 'admin/cac-geocoding-map.js' %}

--- a/python/cac_tripplanner/templates/admin/cac-geocoding-map.js
+++ b/python/cac_tripplanner/templates/admin/cac-geocoding-map.js
@@ -1,4 +1,12 @@
-{% extends 'gis/admin/osm.js' %}
+{% extends "gis/admin/openlayers.js" %}
+{% block base_layer %}
+// explicitly load via SSL to deal with redirect to HTTPS
+new OpenLayers.Layer.OSM("OpenStreetMap", [
+    'https://a.tile.openstreetmap.org/${z}/${x}/${y}.png',
+    'https://b.tile.openstreetmap.org/${z}/${x}/${y}.png',
+    'https://c.tile.openstreetmap.org/${z}/${x}/${y}.png'
+]);
+{% endblock %}
 
 {% block extra_layers %}
 


### PR DESCRIPTION
Fixes #489. The URL for openlayers.js in GeoDjango defaults to HTTP, but is configurable.