### PR TITLE
Feature/intermediate places

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -3,6 +3,10 @@ app_username: "vagrant"
 
 packer_version: "0.7.5"
 
+otp_version: "1.0.0"
+otp_jar_sha1: "aeed6df0e72b331fd2ea18ea03651384fa83e534"
+otp_router: "default"
+
 # used by nginx and gunicorn to set timeouts; OTP defaults to 30s
 otp_session_timeout_s: 30
 

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -3,8 +3,6 @@ app_username: "vagrant"
 
 packer_version: "0.7.5"
 
-otp_version: "1.0.0"
-otp_jar_sha1: "aeed6df0e72b331fd2ea18ea03651384fa83e534"
 otp_router: "default"
 
 # used by nginx and gunicorn to set timeouts; OTP defaults to 30s

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -5,7 +5,7 @@
   version: 0.2.6
 
 - src: azavea.opentripplanner
-  version: 1.0.1
+  version: 1.0.2
 
 - src: azavea.nginx
   version: 0.2.2

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/defaults/main.yml
@@ -1,5 +1,0 @@
----
-# defined in azavea.opentripplanner
-#otp_bin_dir: /opt/opentripplanner
-#otp_data_dir: /var/otp
-otp_router: "default"

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -186,13 +186,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
                 return $.param({intermediatePlaces: waypoint.reverse().join(',')});
             }).join('&');
 
-            console.log('encode already:');
-            console.log(otpOptions.intermediatePlaces);
-            ////////////////////////////////////////
-
             waypoints = null; // discard waypoints once built into a single query
-        } else {
-            console.log('no waypoints here');
         }
 
         if (mode.indexOf('BICYCLE') > -1) {

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -501,11 +501,8 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, _) {
             return first[0] === second[0] && first[1] === second[1];
         });
 
-        // TODO: requery with the changed points as waypoints
-        console.log(changed);
-
+        // requery with the changed points as waypoints, if any changes made
         if (changed.length) {
-            // TODO: trigger waypoint set event with waypoints
             events.trigger(eventNames.waypointsSet, {waypoints: changed});
         }
     }

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -27,7 +27,8 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, _) {
         currentLocationClick: 'cac:map:control:currentlocation',
         originMoved: 'cac:map:control:originmoved',
         destinationMoved: 'cac:map:control:destinationmoved',
-        geocodeMarkerMoved: 'cac:map:control:geocodemoved'
+        geocodeMarkerMoved: 'cac:map:control:geocodemoved',
+        waypointsSet: 'cac:map:control:waypointsset'
     };
     var basemaps = {};
     var overlays = {};
@@ -502,6 +503,11 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, _) {
 
         // TODO: requery with the changed points as waypoints
         console.log(changed);
+
+        if (changed.length) {
+            // TODO: trigger waypoint set event with waypoints
+            events.trigger(eventNames.waypointsSet, {waypoints: changed});
+        }
     }
 
     /**

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -463,6 +463,12 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, _) {
         // https://github.com/Leaflet/Leaflet.draw/issues/555
         L.EditToolbar.Edit.prototype._editStyle = function() {};
 
+        // customize text
+        L.drawLocal.edit.handlers.edit.tooltip = {
+            text: 'Click cancel to undo',
+            subtext: 'Drag a box to add a waypoint' // this is actually the header
+        };
+
         drawControl = new L.Control.Draw({
             edit: {
                 featureGroup: editLayer,

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -21,11 +21,15 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
     function planTrip(coordsFrom, coordsTo, when, extraOptions) {
         var deferred = $.Deferred();
         var urlParams = prepareParams(coordsFrom, coordsTo, when, extraOptions);
+
+        console.log(urlParams);
+
         $.ajax({
             url: Settings.routingUrl,
             type: 'GET',
             crossDomain: true,
-            data: urlParams
+            data: urlParams,
+            processData: false
         }).then(function(data) {
             if (data.plan) {
                 // Ensure unique itineraries.
@@ -60,16 +64,24 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
     }
 
     /**
-     * Helper function to prepare the parameter string for consumption by the OTP api
+     * Helper function to prepare the parameter string for consumption by the OTP API
      *
      * @param {Array} coordsFrom The coords in lat-lng which we would like to travel from
      * @param {Array} coordsTo The coords in lat-lng which we would like to travel to
      * @param {Object} when Moment.js object for date/time of travel
      * @param {Object} extraOptions Other parameters to pass to OpenTripPlanner as-is
      *
-     * @return {Object} Get parameters, ready for consumption
+     * @return {string} URL-encoded GET parameters
      */
     function prepareParams(coordsFrom, coordsTo, when, extraOptions) {
+
+        // exclude pre-formatted intermediatePlaces
+        var intermediatePlaces = '';
+        if (extraOptions.hasOwnProperty('intermediatePlaces')) {
+            intermediatePlaces = extraOptions.intermediatePlaces;
+            delete extraOptions.intermediatePlaces;
+        }
+
         var formattedOpts = {
             fromPlace: coordsFrom.join(','),
             fromText: extraOptions.fromText,
@@ -79,7 +91,7 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
             date: when.format('MM-DD-YYYY'),
         };
 
-        return $.extend(formattedOpts, extraOptions);
+        return $.param($.extend(formattedOpts, extraOptions)) + '&' + intermediatePlaces;
     }
 
 })(jQuery, moment, _, CAC.User.Preferences, CAC.Routing.Itinerary, CAC.Settings);

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -22,8 +22,6 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
         var deferred = $.Deferred();
         var urlParams = prepareParams(coordsFrom, coordsTo, when, extraOptions);
 
-        console.log(urlParams);
-
         $.ajax({
             url: Settings.routingUrl,
             type: 'GET',


### PR DESCRIPTION
Closes #495.

Finish implementing route editing by re-querying with waypoints when user saves edits to a route. Follow-up to #496. After editing a route and clicking 'save', the app re-queries. The new route that then displays should include the added waypoints.

Required updating to OTP 1.0, as waypoint (`intermediatePlaces`) queries are broken on 0.20 (see opentripplanner/OpenTripPlanner#1784.)

Also customized the tooltip text shown in edit mode.

As `intermediatePlaces` are passed by repeating the parameter, multiple waypoints could not be passed with our existing dictionary of parameters, so the waypoint parameter substring gets built separately.k

Note that if the `toText` and `fromText` extraneous parameters passed for URL routing are too long, the link shortener may error when `intermediatePlaces` are added if the resultant URL is more than 512 characters. (Created issue #497 for that.)