### PR TITLE
Feature/store waypoints

### DIFF
--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -58,7 +58,6 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
     var itineraryListControl = null;
     var typeaheadDest = null;
     var typeaheadOrigin = null;
-    var waypoints = null;
 
     function SidebarDirectionsControl(params) {
         options = $.extend({}, defaults, params);
@@ -172,14 +171,13 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
         };
 
         // add intermediatePlaces if user edited route
-        if (waypoints) {
+        var waypoints = UserPreferences.getPreference('waypoints');
+        if (waypoints && waypoints.length) {
             // intermediatePlaces parameter is to be passed multiple times for each waypoint.
             // Since we can only set the parameter key once on the object, build out the string.
             otpOptions.intermediatePlaces = _.map(waypoints, function(waypoint) {
                 return $.param({intermediatePlaces: waypoint.reverse().join(',')});
             }).join('&');
-
-            waypoints = null; // discard waypoints once built into a single query
         }
 
         if (mode.indexOf('BICYCLE') > -1) {
@@ -267,6 +265,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
     }
 
     function clearItineraries() {
+        UserPreferences.setPreference('waypoints', undefined);
         mapControl.clearItineraries();
         itineraryListControl.hide();
         directionsListControl.hide();
@@ -275,6 +274,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
 
     function onDirectionsBackClicked() {
         // show the other itineraries again
+        UserPreferences.setPreference('waypoints', undefined);
         mapControl.cleanUpItineraryEditEnd(true);
         itineraryListControl.showItineraries(true);
         currentItinerary.highlight(true);
@@ -328,7 +328,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
      * Initiate a trip plan when user finishes editing a route.
      */
     function queryWithWaypoints(event, points) {
-        waypoints = points.waypoints;
+        UserPreferences.setPreference('waypoints', points.waypoints);
         planTrip();
     }
 

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -173,13 +173,6 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
 
         // add intermediatePlaces if user edited route
         if (waypoints) {
-            // intermediatePlaces are ordered. see comment on `getGraphPathsConsideringIntermediates`:
-            // https://github.com/opentripplanner/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java#L241
-            // if `arriveBy` is `true`, places are expected to be ordered right-to-left.
-            if (arriveBy) {
-                waypoints.reverse();
-            }
-
             // intermediatePlaces parameter is to be passed multiple times for each waypoint.
             // Since we can only set the parameter key once on the object, build out the string.
             otpOptions.intermediatePlaces = _.map(waypoints, function(waypoint) {

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -507,6 +507,9 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, _) {
             return first[0] === second[0] && first[1] === second[1];
         });
 
+        // TODO: with change to additive waypoint editing, preserve unchanged,
+        // pre-existing waypoints in the set of waypoints sent in the trigger event.
+
         // requery with the changed points as waypoints, if any changes made
         if (changed.length) {
             events.trigger(eventNames.waypointsSet, {waypoints: changed});

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -14,7 +14,7 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
     var SHARED_READ = ['maxWalk', 'wheelchair', 'bikeTriangle'];
     var EXPLORE_ENCODE = SHARED_ENCODE.concat(['placeId', 'exploreTime']);
     var EXPLORE_READ = EXPLORE_ENCODE.concat(SHARED_READ);
-    var DIRECTIONS_ENCODE = SHARED_ENCODE.concat(['destination', 'destinationText']);
+    var DIRECTIONS_ENCODE = SHARED_ENCODE.concat(['destination', 'destinationText', 'waypoints']);
     var DIRECTIONS_READ = DIRECTIONS_ENCODE.concat(SHARED_READ).concat(['arriveBy']);
 
     var router = null;

--- a/src/app/scripts/cac/user/cac-user-preferences.js
+++ b/src/app/scripts/cac/user/cac-user-preferences.js
@@ -40,6 +40,7 @@ CAC.User.Preferences = (function($, _) {
         originText: cityHall.name,
         destination: undefined,
         destinationText: '',
+        waypoints: undefined,
         wheelchair: false
     };
 


### PR DESCRIPTION
Closes #499.

Stores user-added waypoints (modified places on an edited route) in local storage.
Puts waypoints in the URL also. Cleared on origin or destination change,
or other events that cause all itineraries to be cleared from the map.

To test, edit a route. New `waypoints` should be set in local storage and in URL; edited route should be preserved on page refresh. Shortened link URL should contain `intermediatePlaces` parameter.

Does not yet preserve previously edited waypoints on subsequent route edits, as we will need to implement #502 to be able to easily get the ordering right.