### PR TITLE
Additive waypoint editing

### DIFF
--- a/src/app/scripts/cac/pages/cac-pages-directions.js
+++ b/src/app/scripts/cac/pages/cac-pages-directions.js
@@ -56,7 +56,7 @@ CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings, Use
             setMapItinerary(itinerary);
             directionsListControl.setItinerary(itinerary);
         }, function (error) {
-            console.log('error: ', error);
+            console.error(error);
         });
 
         function loadMap() {

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -30,7 +30,6 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder) {
 
         // expose functions
         this.getStyle = getStyle;
-        this.getTurnPoints = getTurnPoints;
     }
 
     Itinerary.prototype.highlight = function (isHighlighted) {
@@ -54,28 +53,6 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder) {
      */
     function getTransitAgencies(legs) {
         return _.chain(legs).map('agencyName').uniq().without(undefined).value();
-    }
-
-    /**
-     * Get the points for trip start, end, and turn points (step start points).
-     * Not all step start points are necessarily turns; some may be to 'continue on'.
-     * Exposed as a method rather than set as a property during initialization, as
-     * these points are not needed until user chooses to edit the itinerary,
-     * at which point they can be loaded lazily.
-     */
-    function getTurnPoints() {
-        if (!this._turnPoints) {
-            this._turnPoints = _.chain(this.legs).map('steps').flatten().map(function(step) {
-                return [step.lon, step.lat];
-            }).value();
-        }
-
-        // append end point
-        if (this.to) {
-            this._turnPoints.push([this.to.lon, this.to.lat]);
-        }
-
-        return this._turnPoints;
     }
 
     /**

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -14,8 +14,8 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
     var SHARED_READ = ['maxWalk', 'wheelchair', 'bikeTriangle'];
     var EXPLORE_ENCODE = SHARED_ENCODE.concat(['placeId', 'exploreTime']);
     var EXPLORE_READ = EXPLORE_ENCODE.concat(SHARED_READ);
-    var DIRECTIONS_ENCODE = SHARED_ENCODE.concat(['destination', 'destinationText', 'waypoints']);
-    var DIRECTIONS_READ = DIRECTIONS_ENCODE.concat(SHARED_READ).concat(['arriveBy']);
+    var DIRECTIONS_ENCODE = SHARED_ENCODE.concat(['destination', 'destinationText']);
+    var DIRECTIONS_READ = DIRECTIONS_ENCODE.concat(SHARED_READ).concat(['arriveBy', 'waypoints']);
 
     var router = null;
 

--- a/src/app/scripts/cac/user/cac-user-preferences.js
+++ b/src/app/scripts/cac/user/cac-user-preferences.js
@@ -40,7 +40,7 @@ CAC.User.Preferences = (function($, _) {
         originText: cityHall.name,
         destination: undefined,
         destinationText: '',
-        waypoints: undefined,
+        waypoints: [],
         wheelchair: false
     };
 


### PR DESCRIPTION
Edit route by starting with straight line from origin to destination, then add in waypoints to it, using previously added waypoints on successive edits.

Decided to break up work on #502 into two parts, since the remaining UI aspects I think will require forking Leaflet Draw. (Do not display edit toolbar and redraw on mouse release.)