### PR TITLE
Remove contingency alert

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions-list.js
+++ b/src/app/scripts/cac/control/cac-control-directions-list.js
@@ -100,16 +100,6 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social, UserPreferen
 
         $container.empty();
 
-        // TODO: remove this SEPTA rail warning when contingency plan ends and/or update
-        // when modified rail schedule published.
-
-        // Show alert regarding current SEPTA rail status
-        if (_.some(itinerary.legs, function(leg) {
-            return leg.transitLeg && leg.mode === 'RAIL' && leg.agencyName === 'SEPTA';
-        })) {
-            $container.append(MapTemplates.septaRailWarningAlert());
-        }
-
         // Show alert with link to transit agency bicycle policy for bike+transit itineraries
         if (_.includes(itinerary.modes, 'BICYCLE') && itinerary.agencies.length) {
             var $alert = MapTemplates.bicycleWarningAlert(itinerary.agencies);

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -11,8 +11,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
         destinationDetail: destinationDetail,
         eventPopup: eventPopup,
         itinerary: itinerary,
-        itineraryList: itineraryList,
-        septaRailWarningAlert: septaRailWarningAlert
+        itineraryList: itineraryList
     };
 
     // Only register these once, when the module loads
@@ -77,34 +76,6 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                         '</a>, '].join('');
         });
         msg = msg.substring(0, msg.length - 2); // trim off trailing comma
-
-        // message is not templated, so we can embed links
-        var source = [
-            '<div class="alert-container">',
-            '<div class="alert alert-{{type}} alert-dismissible" role="alert">',
-            '<button type="button" class="close" data-dismiss="alert" aria-label="Close">',
-            '<span aria-hidden="true">&times;</span></button>',
-            msg,
-            '</div></div>'
-        ].join('');
-        var template = Handlebars.compile(source);
-        var html = template({type: 'warning'});
-        return html;
-    }
-
-    /**
-     * Build an HTML snippet for an alert with link to SEPTA rail alert
-     *
-     * @returns {String} Compiled Handlebars template for the Bootstrap alert
-     */
-    function septaRailWarningAlert() {
-        var msg = ['Until further notice, SEPTA will be operating an interim weekday schedule ',
-                'during the week. For more details and up to date information please consult ',
-                '<a class="alert-link" target="_blank" href="',
-                'http://www.septa.org/service/contingency.html',
-                '">SEPTA\'s contingency plan',
-                '</a>.'
-            ].join('');
 
         // message is not templated, so we can embed links
         var source = [


### PR DESCRIPTION
Remove contingency plan alert for SEPTA rail, now that regular service has resumed.

Supersedes #512, which was against the wrong branch.