### PR TITLE
Feature/waypoints urls

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions-list.js
+++ b/src/app/scripts/cac/control/cac-control-directions-list.js
@@ -102,9 +102,25 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social, UserPreferen
 
         $container.append($html);
 
+        /*
         var params = $.extend({itineraryIndex: itinerary.id}, itinerary.requestParameters);
         var directionsUrl = '/directions/?' + Utils.encodeUrlParams(params);
+        console.log(directionsUrl);
+        console.log(itinerary.requestParameters);
+        */
 
+        // share link to directions list page, which is relative to the current URL,
+        // has all of the current URL's parameters,
+        // does *not* have the map path (just directions, with a trailing slash),
+        // and has an added parameter for the selected itinerary
+        var href = window.location.href;
+        var directionsUrl = ['/directions/',
+                             href.slice(href.indexOf('/map/directions') + '/map/directions'.length),
+                             '&',
+                             $.param({itineraryIndex: itinerary.id})
+                            ].join('');
+
+        // TODO: postpone shortening link until user chooses to share directions
         socialSharing.shortenLink(directionsUrl).then(function(shortened) {
             // set up click handlers for social sharing with shortened link
             $(options.selectors.twitterShareButton).on('click',

--- a/src/app/scripts/cac/control/cac-control-directions-list.js
+++ b/src/app/scripts/cac/control/cac-control-directions-list.js
@@ -3,7 +3,7 @@
  *  View control for the sidebar directions list
  *
  */
-CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social, UserPreferences, Utils) {
+CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social) {
 
     'use strict';
 
@@ -102,17 +102,10 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social, UserPreferen
 
         $container.append($html);
 
-        /*
-        var params = $.extend({itineraryIndex: itinerary.id}, itinerary.requestParameters);
-        var directionsUrl = '/directions/?' + Utils.encodeUrlParams(params);
-        console.log(directionsUrl);
-        console.log(itinerary.requestParameters);
-        */
-
-        // share link to directions list page, which is relative to the current URL,
+        // Share link to directions list page, which is relative to the current URL,
         // has all of the current URL's parameters,
         // does *not* have the map path (just directions, with a trailing slash),
-        // and has an added parameter for the selected itinerary
+        // and has an added parameter for the selected itinerary.
         var href = window.location.href;
         var directionsUrl = ['/directions/',
                              href.slice(href.indexOf('/map/directions') + '/map/directions'.length),
@@ -175,4 +168,4 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social, UserPreferen
         }
     }
 
-})(_, jQuery, CAC.Map.Templates, CAC.Share.Social, CAC.User.Preferences, CAC.Utils);
+})(_, jQuery, CAC.Map.Templates, CAC.Share.Social);

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -170,11 +170,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
         // add intermediatePlaces if user edited route
         var waypoints = UserPreferences.getPreference('waypoints');
         if (waypoints && waypoints.length) {
-            // intermediatePlaces parameter is to be passed multiple times for each waypoint.
-            // Since we can only set the parameter key once on the object, build out the string.
-            otpOptions.intermediatePlaces = _.map(waypoints, function(waypoint) {
-                return $.param({intermediatePlaces: waypoint.join(',')});
-            }).join('&');
+            otpOptions.waypoints = waypoints;
         }
 
         if (mode.indexOf('BICYCLE') > -1) {
@@ -272,8 +268,6 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
     function onDirectionsBackClicked() {
         // show the other itineraries again
         UserPreferences.setPreference('waypoints', undefined);
-        // TODO: replace
-        //mapControl.cleanUpItineraryEditEnd(true);
         itineraryListControl.showItineraries(true);
         currentItinerary.highlight(true);
         directionsListControl.hide();

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -418,7 +418,8 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _, UserPreferences
                 var startDragPoint = null;
                 lastItineraryHoverMarker = new cartodb.L.Marker(e.latlng, {
                         draggable: true,
-                        icon: highlightIcon
+                        icon: highlightIcon,
+                        title: 'Drag marker to change route' // tooltip
                     }).on('dragstart', function(e) {
                         dragging = true;
                         startDragPoint = e.target.getLatLng();
@@ -430,6 +431,10 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _, UserPreferences
                         startDragPoint = null;
                     }).on('mouseout', function() {
                         // hide marker after awhile if not dragging
+                        if (dragging) {
+                            return;
+                        }
+
                         setTimeout(function() {
                             if (lastItineraryHoverMarker && !dragging) {
                                 map.removeLayer(lastItineraryHoverMarker);
@@ -437,7 +442,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _, UserPreferences
                                 dragging = false;
                                 startDragPoint = null;
                             }
-                        }, 2000);
+                        }, 3000);
                     });
                 map.addLayer(lastItineraryHoverMarker);
             }

--- a/src/app/scripts/cac/pages/cac-pages-directions.js
+++ b/src/app/scripts/cac/pages/cac-pages-directions.js
@@ -1,4 +1,4 @@
-CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings, UserPreferences) {
+CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings) {
     'use strict';
 
     var center = [39.95, -75.1667];
@@ -24,8 +24,7 @@ CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings, Use
 
     Directions.prototype.initialize = function () {
 
-        // FIXME: date/time does not get passed and so defaults to now
-        // TODO: what if arriveBy is true?
+        // Note: date/time does not get passed and so always defaults to departing now
 
         var rawParams = location.search.slice(1).split('&');
         var itineraryIndex = -1; // initialize to flag value for missing index parameter
@@ -68,7 +67,7 @@ CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings, Use
             }
         }).join('&');
 
-        if (itineraryIndex === -1) {
+        if (itineraryIndex < 0) {
             console.error('Must specify itineraryIndex URL parameter');
             return;
         }
@@ -92,8 +91,7 @@ CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings, Use
         }).then(function(data) {
             var itineraries = data.plan.itineraries;
             var itinerary = new Itinerary(itineraries[itineraryIndex],
-                                          itineraryIndex,
-                                          otpParams);
+                                          itineraryIndex);
             setMapItinerary(itinerary);
             directionsListControl.setItinerary(itinerary);
         }, function (error) {
@@ -149,4 +147,4 @@ CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings, Use
 
     return Directions;
 
-})(jQuery, _, CAC.Control.DirectionsList, CAC.Routing.Itinerary, CAC.Settings, CAC.User.Preferences);
+})(jQuery, _, CAC.Control.DirectionsList, CAC.Routing.Itinerary, CAC.Settings);

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -1,4 +1,4 @@
-CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder) {
+CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
     'use strict';
 
     /**
@@ -6,7 +6,7 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder) {
      *
      * @param {object} otpItinerary OTP itinerary
      * @param {integer} index integer to uniquely identify itinerary
-     * @param {object} parameters used for the OTP request
+     * @param {string} encoded parameters used for the OTP request
      */
     function Itinerary(otpItinerary, index, requestParameters) {
         this.id = index.toString();
@@ -25,8 +25,11 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder) {
         this.geojson = cartodb.L.geoJson({type: 'FeatureCollection',
                                           features: getFeatures(otpItinerary.legs)});
         this.geojson.setStyle(getStyle(true, false));
-        this.fromText = requestParameters.fromText;
-        this.toText = requestParameters.toText;
+
+        // extract reverse-geocoded start and end addresses
+        var params = Utils.getUrlParams();
+        this.fromText = params.originText;
+        this.toText = params.destinationText;
 
         // expose functions
         this.getStyle = getStyle;
@@ -198,4 +201,4 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder) {
         return defaultStyle;
     }
 
-})(jQuery, cartodb, L, _, moment, CAC.Search.Geocoder);
+})(jQuery, cartodb, L, _, moment, CAC.Search.Geocoder, CAC.Utils);

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -6,11 +6,9 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
      *
      * @param {object} otpItinerary OTP itinerary
      * @param {integer} index integer to uniquely identify itinerary
-     * @param {string} encoded parameters used for the OTP request
      */
-    function Itinerary(otpItinerary, index, requestParameters) {
+    function Itinerary(otpItinerary, index) {
         this.id = index.toString();
-        this.requestParameters = requestParameters;
         this.via = getVia(otpItinerary.legs);
         this.modes = getModes(otpItinerary.legs);
         this.distanceMiles = getDistanceMiles(otpItinerary.legs);

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -78,10 +78,7 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
         // build out the waypoints portion of the encoded URL string here.
         var intermediatePlaces = '';
         if (extraOptions.hasOwnProperty('waypoints')) {
-            console.log(extraOptions.waypoints);
             intermediatePlaces = _.map(extraOptions.waypoints, function(waypoint) {
-                console.log('one waypoint is:');
-                console.log(waypoint);
                 return $.param({intermediatePlaces: waypoint.join(',')});
             }).join('&');
 

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -67,17 +67,25 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
      * @param {Array} coordsFrom The coords in lat-lng which we would like to travel from
      * @param {Array} coordsTo The coords in lat-lng which we would like to travel to
      * @param {Object} when Moment.js object for date/time of travel
-     * @param {Object} extraOptions Other parameters to pass to OpenTripPlanner as-is
+     * @param {Object} extraOptions Other parameters to pass to OpenTripPlanner
      *
      * @return {string} URL-encoded GET parameters
      */
     function prepareParams(coordsFrom, coordsTo, when, extraOptions) {
 
-        // exclude pre-formatted intermediatePlaces
+        // intermediatePlaces parameter is to be passed multiple times for each waypoint.
+        // Since we can only set the parameter key once on the options object,
+        // build out the waypoints portion of the encoded URL string here.
         var intermediatePlaces = '';
-        if (extraOptions.hasOwnProperty('intermediatePlaces')) {
-            intermediatePlaces = extraOptions.intermediatePlaces;
-            delete extraOptions.intermediatePlaces;
+        if (extraOptions.hasOwnProperty('waypoints')) {
+            console.log(extraOptions.waypoints);
+            intermediatePlaces = _.map(extraOptions.waypoints, function(waypoint) {
+                console.log('one waypoint is:');
+                console.log(waypoint);
+                return $.param({intermediatePlaces: waypoint.join(',')});
+            }).join('&');
+
+            delete extraOptions.waypoints;
         }
 
         var formattedOpts = {
@@ -90,9 +98,12 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
         };
 
         var params = $.param($.extend(formattedOpts, extraOptions));
+
+        // append pre-formatted string for waypoints
         if (intermediatePlaces) {
             params += '&' + intermediatePlaces;
         }
+
         return  params;
     }
 

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -49,7 +49,7 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
 
                 // return the Itinerary objects for the unique collection
                 var itineraries = _(planItineraries).map(function(itinerary, i) {
-                    return new Itinerary(itinerary, i, urlParams);
+                    return new Itinerary(itinerary, i);
                 }).value();
                 deferred.resolve(itineraries);
             } else {

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -49,7 +49,7 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
 
                 // return the Itinerary objects for the unique collection
                 var itineraries = _(planItineraries).map(function(itinerary, i) {
-                    return new Itinerary(itinerary, i, data.requestParameters);
+                    return new Itinerary(itinerary, i, urlParams);
                 }).value();
                 deferred.resolve(itineraries);
             } else {
@@ -87,9 +87,7 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
 
         var formattedOpts = {
             fromPlace: coordsFrom.join(','),
-            fromText: extraOptions.fromText,
             toPlace: coordsTo.join(','),
-            toText: extraOptions.toText,
             time: when.format('hh:mma'),
             date: when.format('MM-DD-YYYY'),
         };

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -9,9 +9,6 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
 
     'use strict';
 
-    // Write lat/lon with ~1cm precision. should be sufficient and makes URLs nicer.
-    const COORDINATE_ROUND = 7;
-
     // User pref parameters for different views
     var SHARED_ENCODE = ['origin', 'originText', 'mode'];
     var SHARED_READ = ['maxWalk', 'wheelchair', 'bikeTriangle'];
@@ -119,6 +116,9 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
      * encoded as empty string.
      */
     function buildUrlParamsFromPrefs(fields) {
+        // Write lat/lon with ~1cm precision. should be sufficient and makes URLs nicer.
+        var COORDINATE_ROUND = 7;
+
         var opts = {};
         _.forEach(fields, function(field) {
             if (field === 'origin' || field === 'destination') {


### PR DESCRIPTION
Retain waypoints in URL and handle parsing them. Closes #516.

To test, create a trip with waypoints, click to share link, and open the shortened shareable URL in another browser or incognito tab (that does not have site settings in local storage). Trip directions should load with waypoints showing, and from/to text correctly displayed.