### PR TITLE
Feature/waypoint editing

### DIFF
--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -275,6 +275,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
 
     function onDirectionsBackClicked() {
         // show the other itineraries again
+        mapControl.clearItineraryHoverListener();
         UserPreferences.setPreference('waypoints', undefined);
         itineraryListControl.showItineraries(true);
         currentItinerary.highlight(true);

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -230,6 +230,14 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
                 }
             });
 
+            // If there is only one itinerary, make it draggable.
+            // Only one itinerary is returned if there are waypoints, so this
+            // lets the user to continue to add or modify waypoints without
+            // having to select it in the list.
+            if (itineraries.length === 1) {
+                mapControl.draggableItinerary(currentItinerary);
+            }
+
             // put markers at start and end
             mapControl.setDirectionsMarkers(directions.origin, directions.destination);
             itineraryListControl.setItineraries(itineraries);
@@ -283,6 +291,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
             itineraryListControl.showItineraries(false);
             itinerary.show(true);
             itinerary.highlight(true);
+            mapControl.draggableItinerary(itinerary);
             currentItinerary = itinerary;
 
             directionsListControl.setItinerary(itinerary);

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -275,8 +275,6 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
 
     function onDirectionsBackClicked() {
         // show the other itineraries again
-        mapControl.clearWaypointInteractivity();
-        UserPreferences.setPreference('waypoints', undefined);
         itineraryListControl.showItineraries(true);
         currentItinerary.highlight(true);
         directionsListControl.hide();
@@ -294,9 +292,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
             itinerary.highlight(true);
             mapControl.draggableItinerary(itinerary);
             currentItinerary = itinerary;
-
             directionsListControl.setItinerary(itinerary);
-
             itineraryListControl.hide();
             directionsListControl.show();
         }

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -275,7 +275,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
 
     function onDirectionsBackClicked() {
         // show the other itineraries again
-        mapControl.clearItineraryHoverListener();
+        mapControl.clearWaypointInteractivity();
         UserPreferences.setPreference('waypoints', undefined);
         itineraryListControl.showItineraries(true);
         currentItinerary.highlight(true);

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -125,6 +125,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
     MapControl.prototype.drawDestinations = drawDestinations;
     MapControl.prototype.plotItinerary = plotItinerary;
     MapControl.prototype.clearItineraries = clearItineraries;
+    MapControl.prototype.draggableItinerary = draggableItinerary;
     MapControl.prototype.setGeocodeMarker = setGeocodeMarker;
     MapControl.prototype.setDirectionsMarkers = setDirectionsMarkers;
     MapControl.prototype.clearDirectionsMarker = clearDirectionsMarker;
@@ -406,9 +407,16 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         if (makeFit) {
             map.fitBounds(layer.getBounds());
         }
+    }
 
+    /**
+     * Add listeners to an itinerary map layer to make it draggable.
+     *
+     * @param {Object} itinerary CAC.Routing.Itinerary object to be made draggable
+     */
+    function draggableItinerary(itinerary) {
         // show a draggable marker on the route line that adds a waypoint when released
-        layer.on('mouseover', function(e) {
+        itinerary.geojson.on('mouseover', function(e) {
             if (lastItineraryHoverMarker) {
                 lastItineraryHoverMarker.setLatLng(e.latlng, {draggable: true});
             } else {
@@ -510,6 +518,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
 
     function clearItineraries() {
         _.forIn(itineraries, function (itinerary) {
+            itinerary.geojson.off();
             map.removeLayer(itinerary.geojson);
         });
         itineraries = {};

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -418,6 +418,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
      * @param {Object} itinerary CAC.Routing.Itinerary object to be made draggable
      */
     function draggableItinerary(itinerary) {
+        clearWaypointInteractivity();
         // Show a draggable marker on the route line that adds a waypoint when released.
 
         // Leaflet listeners are removed by reference, so retain a reference to the
@@ -480,8 +481,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                     });
                 }
             }).addTo(map);
-        } else {
-            waypointsLayer = null;
         }
     }
 
@@ -611,19 +610,19 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
     }
 
     function clearWaypointInteractivity() {
-        _.forIn(itineraries, function (itinerary) {
-            itinerary.geojson.off('mouseover', itineraryHoverListener);
-        });
+        if (waypointsLayer) {
+            map.removeLayer(waypointsLayer);
+            waypointsLayer = null;
+        }
 
         if (lastItineraryHoverMarker) {
             map.removeLayer(lastItineraryHoverMarker);
             lastItineraryHoverMarker = null;
         }
 
-        if (waypointsLayer) {
-            map.removeLayer(waypointsLayer);
-            waypointsLayer = null;
-        }
+        _.forIn(itineraries, function (itinerary) {
+            itinerary.geojson.off('mouseover', itineraryHoverListener);
+        });
     }
 
     /**

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -39,6 +39,8 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
     var lastItineraryHoverMarker = null;
     var itineraryHoverListener = null;
     var isochroneLayer = null;
+    var waypointsLayer = null;
+    var waypointsMarkers = {};
     var tabControl = null;
 
     var destinationIcon = L.AwesomeMarkers.icon({
@@ -418,6 +420,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
      */
     function draggableItinerary(itinerary) {
         // Show a draggable marker on the route line that adds a waypoint when released.
+
         // Leaflet listeners are removed by reference, so retain a reference to the
         // listener function to be able to turn it off later.
         itineraryHoverListener = function(e) {
@@ -461,6 +464,19 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         };
 
         itinerary.geojson.on('mouseover', itineraryHoverListener);
+
+        // add a layer of draggable markers for the existing waypoints
+
+        // TODO: marker drag event handler?
+        waypointsMarkers = {};
+        waypointsLayer = cartodb.L.geoJson(turf.featureCollection(itinerary.waypoints), {
+            pointToLayer: function(geojson, latlng) {
+                var marker = new cartodb.L.marker(latlng, {icon: destinationIcon,
+                                                          title: 'Drag to change route'});
+                waypointsMarkers[geojson.properties.index] = marker;
+                return marker;
+            }
+        }).addTo(map);
     }
 
     /**

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -144,8 +144,10 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
             return null;
         }
 
-        return _.map(waypoints.split(';'), function(point) {
-            return turf.point(point.split(',').reverse());
+        // explicitly set the index property so it will populate on the geoJSON properties
+        // when point array used to create FeatureCollection
+        return _.map(waypoints.split(';'), function(point, index) {
+            return turf.point(point.split(',').reverse(), {index: index});
         });
     }
 

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -71,7 +71,7 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
     }
 
     /**
-     * Helper function to get label/via summary for an itinerary
+     * Helper function to get list of modes used by an itinerary
      *
      * @param {array} legs Legs property of OTP itinerary
      * @return {array} array of strings representing modes for itinerary
@@ -81,7 +81,7 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
     }
 
     /**
-     * Helper function to get label/via summary for an itinerary
+     * Helper function to get total distance in miles for an itinerary
      *
      * @param {array} legs Legs property of OTP itinerary
      * @return {float} distance of itinerary in miles (rounded to 2nd decimal)
@@ -94,7 +94,7 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
     }
 
     /**
-     * Helper function to get label/via summary for an itinerary or leg
+     * Helper function to get formatted duration string for an itinerary or leg
      *
      * @param {object} otpItinerary OTP itinerary or leg (both have duration property)
      * @return {string} duration of itinerary/leg, formatted with units (hrs, min, s)
@@ -114,7 +114,7 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
     }
 
     /**
-     * Helper function to get label/via summary for an itinerary
+     * Helper function to get geoJSON for an itinerary
      *
      * @param {array} legs set of legs for an OTP itinerary
      * @return {array} array of geojson features


### PR DESCRIPTION
Display draggable markers for waypoints. Delete waypoint on marker click; move waypoint when marker dragged.

Closes #501, #521, and #520. Re-uses destination marker icon for now, until #522 can be completed.

Adds tooltips to the markers that may be sufficient for #524, unless we don't want to make the user wait for the tooltip hover delay to find out what to do.

Also fixes issue where all itineraries would be editable if multiple shown; limits itinerary editing to when only one itinerary is shown, either because only option one was returned from the trip planner, or because the user has selected the itinerary from the list. Note that if a plan query includes waypoints, only one itinerary will be returned.

To test, try adding, moving, and deleting waypoints, and clicking in and out of the directions list to verify expected behavior.

Developed this on a branch based on #525, flibbertigibbet:feature/waypoint-markers.