### PR TITLE
Don't show waypoints in directions list

### DIFF
--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -194,12 +194,12 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
                     leg.to.name = name;
                 });
             }
-            leg.formattedDuration = getFormattedDuration(leg);
             return leg;
         });
         if (hasWaypoints) {
             newLegs = mergeLegsAcrossWaypoints(newLegs);
         }
+        _.forEach(newLegs, function (leg) { leg.formattedDuration = getFormattedDuration(leg); });
         return newLegs;
     }
 

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -8,23 +8,6 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
      * @param {integer} index integer to uniquely identify itinerary
      */
     function Itinerary(otpItinerary, index) {
-        this.id = index.toString();
-        this.via = getVia(otpItinerary.legs);
-        this.modes = getModes(otpItinerary.legs);
-        this.distanceMiles = getDistanceMiles(otpItinerary.legs);
-        this.formattedDuration = getFormattedDuration(otpItinerary);
-        this.startTime = otpItinerary.startTime;
-        this.endTime = otpItinerary.endTime;
-        this.legs = getLegs(otpItinerary.legs);
-        this.from = _.head(otpItinerary.legs).from;
-        this.to = _.last(otpItinerary.legs).to;
-        this.agencies = getTransitAgencies(otpItinerary.legs);
-
-        // not actually GeoJSON, but a Leaflet layer made from GeoJSON
-        this.geojson = cartodb.L.geoJson({type: 'FeatureCollection',
-                                          features: getFeatures(otpItinerary.legs)});
-        this.geojson.setStyle(getStyle(true, false));
-
         // extract reverse-geocoded start and end addresses
         var params = Utils.getUrlParams();
         this.fromText = params.originText;
@@ -33,6 +16,23 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
         // array of turf points, for ease of use both making into a
         // Leaflet layer as GeoJSON, and for interpolating new waypoints.
         this.waypoints = getWaypointFeatures(params.waypoints);
+
+        this.id = index.toString();
+        this.via = getVia(otpItinerary.legs);
+        this.modes = getModes(otpItinerary.legs);
+        this.distanceMiles = getDistanceMiles(otpItinerary.legs);
+        this.formattedDuration = getFormattedDuration(otpItinerary);
+        this.startTime = otpItinerary.startTime;
+        this.endTime = otpItinerary.endTime;
+        this.legs = getLegs(otpItinerary.legs, (this.waypoints && this.waypoints.length > 0));
+        this.from = _.head(otpItinerary.legs).from;
+        this.to = _.last(otpItinerary.legs).to;
+        this.agencies = getTransitAgencies(otpItinerary.legs);
+
+        // not actually GeoJSON, but a Leaflet layer made from GeoJSON
+        this.geojson = cartodb.L.geoJson({type: 'FeatureCollection',
+                                          features: getFeatures(otpItinerary.legs)});
+        this.geojson.setStyle(getStyle(true, false));
 
         // expose functions
         this.getStyle = getStyle;
@@ -176,12 +176,14 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
 
     /**
      * Check leg from/to place name; if it's an OSM node label, reverse geocode it and update label
+     * Also, if there are waypoints, call the function to merge legs across them.
      *
      * @params {Array} legs Itinerary legs returned by OTP
+     * @param {Boolean} hasWaypoints If true, call mergeLegsAcrossWaypoints
      * @returns {Array} Itinerary legs, with prettified place labels
      */
-    function getLegs(legs) {
-        return _.map(legs, function(leg) {
+    function getLegs(legs, hasWaypoints) {
+        var newLegs = _.map(legs, function(leg) {
             if (leg.from.name.indexOf('Start point 0.') > -1) {
                 getOsmNodeName(leg.from).then(function(name) {
                     leg.from.name = name;
@@ -195,6 +197,48 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
             leg.formattedDuration = getFormattedDuration(leg);
             return leg;
         });
+        if (hasWaypoints) {
+            newLegs = mergeLegsAcrossWaypoints(newLegs);
+        }
+        return newLegs;
+    }
+
+    /* Waypoints always result in a step break, which ends up producing useless "To Destination"
+     * steps in the itinerary details.
+     * See https://github.com/opentripplanner/OpenTripPlanner/blob/otp-1.0.0/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java#L305
+     * and https://github.com/opentripplanner/OpenTripPlanner/blob/otp-1.0.0/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java#L212
+     * There's no configuration option to make OTP not do that, so instead this munges the
+     * resulting separate steps into one.
+     * Specifically, it loops over the legs, checking for each one whether the next one is the same
+     * mode and, if so, summing times/distances and resetting the 'to' to turn the first leg into
+     * a combination of itself and the second.  Since there can be multiple waypoints in what would
+     * be a single leg, more than two consecutive legs can end up getting merged together.
+     *
+     * Note that this makes no attempt to merge the `legGeometry` attributes so it's important that
+     * `getFeatures`, which gets the itinerary's geometry into Leaflet, gets called on the original
+     * legs array rather than the munged one.
+     */
+    function mergeLegsAcrossWaypoints(legs) {
+        if (legs.length === 1) {
+            return legs;
+        }
+        var index = 0;
+        while(index < legs.length - 1) {
+            var thisLeg = legs[index];
+            var nextLeg = legs[index+1];
+            if (thisLeg.mode === nextLeg.mode && !nextLeg.interlineWithPreviousLeg) {
+                var newLeg = _.clone(thisLeg);
+                newLeg.distance = thisLeg.distance + nextLeg.distance;
+                newLeg.duration = thisLeg.duration + nextLeg.duration;
+                newLeg.endTime = nextLeg.endTime;
+                newLeg.to = nextLeg.to;
+                newLeg.steps = _.concat(thisLeg.steps, nextLeg.steps);
+                legs.splice(index, 2, newLeg);
+            } else {
+                index++;
+            }
+        }
+        return legs;
     }
 
     /**


### PR DESCRIPTION
Waypoints always cause OTP to make a new leg, but we don't want them to
show up as separate "To Destination" steps in the directions list.
So this processes the legs array to conflate the steps on either side
of a waypoint.

**Notes**
- This post-hoc combination of legs isn't ideal, and could be susceptible to subtle bugs from changes in the attributes of the leg objects returned by OTP, but I'm not seeing a cleaner way to do it.
- Putting a waypoint in the middle of a transit leg always makes you stop there.  I.e. if you want to force your directions to take the 23 bus from center city to Germantown, dragging a waypoint onto a spot along the 23's route might put you on the 23 the whole way, but the resulting directions will have you get off at the spot and then get back on.  I don't see any way to get around that.  I note also that Goog the Great and Powerful doesn't allow route customization in transit mode.

**To test**
Drag a waypoint that's not in the middle of a transit leg (either in single-mode directions or a walking/biking leg of multi-mode directions) and click on the itinerary to show the directions list. The step you modified should still be all one step, just with more turns, and there should be no "to Destination" steps except the last one.

![merged_across_waypoints](https://cloud.githubusercontent.com/assets/6598836/19318864/4e1949ae-9078-11e6-9845-75d6463c597b.png)


Closes #500.