### PR TITLE
Feature/live updating reroute

### DIFF
--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -319,7 +319,10 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
     function liveUpdateItinerary(event, itinerary) {
         var oldLayer = itinerary.geojson;
         Routing.planLiveUpdate(itinerary).then(function(newItinerary) {
-            mapControl.updateItineraryLayer(oldLayer, newItinerary.geojson);
+            mapControl.updateItineraryLayer(oldLayer, newItinerary);
+        }, function(error) {
+            console.error(error);
+            mapControl.errorLiveUpdatingLayer();
         });
     }
 

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -98,6 +98,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
                                        onItineraryHover);
 
         mapControl.events.on(mapControl.eventNames.waypointsSet, queryWithWaypoints);
+        mapControl.events.on(mapControl.eventNames.waypointMoved, liveUpdateItinerary);
 
         typeaheadDest = new Typeahead(options.selectors.typeaheadDest);
         typeaheadDest.events.on(typeaheadDest.eventNames.selected, onTypeaheadSelected);
@@ -313,6 +314,10 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
             itinerary.highlight(true);
             currentItinerary = itinerary;
         }
+    }
+
+    function liveUpdateItinerary(event, itinerary) {
+        Routing.planLiveUpdate(itinerary).then(mapControl.plotItinerary(itinerary, true));
     }
 
     /**

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -322,6 +322,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
             mapControl.updateItineraryLayer(oldLayer, newItinerary);
         }, function(error) {
             console.error(error);
+            // occasionally cannot plan route if waypoint cannot be snapped to street grid
             mapControl.errorLiveUpdatingLayer();
         });
     }

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -317,7 +317,10 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
     }
 
     function liveUpdateItinerary(event, itinerary) {
-        Routing.planLiveUpdate(itinerary).then(mapControl.plotItinerary(itinerary, true));
+        var oldLayer = itinerary.geojson;
+        Routing.planLiveUpdate(itinerary).then(function(newItinerary) {
+            mapControl.updateItineraryLayer(oldLayer, newItinerary.geojson);
+        });
     }
 
     /**

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -135,6 +135,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
     MapControl.prototype.clearDirectionsMarker = clearDirectionsMarker;
     MapControl.prototype.highlightDestination = highlightDestination;
     MapControl.prototype.displayPoint = displayPoint;
+    MapControl.prototype.updateItineraryLayer = updateItineraryLayer;
 
     return MapControl;
 
@@ -663,6 +664,11 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
 
         // requery with the changed points as waypoints
         events.trigger(eventNames.waypointsSet, {waypoints: coordinates});
+    }
+
+    function updateItineraryLayer(oldLayer, newLayer) {
+        map.removeLayer(oldLayer);
+        newLayer.addTo(map);
     }
 
     function clearItineraries() {

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -421,6 +421,10 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         clearWaypointInteractivity();
         // Show a draggable marker on the route line that adds a waypoint when released.
 
+        var redrawWaypointDrag = _.throttle(function(event) { // jshint ignore:line
+                console.log(event.target.getLatLng());
+            }, 800);
+
         // Leaflet listeners are removed by reference, so retain a reference to the
         // listener function to be able to turn it off later.
         itineraryHoverListener = function(e) {
@@ -435,7 +439,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                 var popupTimeout;
                 lastItineraryHoverMarker = new cartodb.L.Marker(e.latlng, {
                         draggable: true,
-                        icon: highlightIcon,
+                        icon: highlightIcon
                     }).on('dragstart', function(e) {
                         dragging = true;
                         startDragPoint = e.target.getLatLng();
@@ -474,8 +478,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                                 startDragPoint = null;
                             }
                         }, 3000);
-                    });
-
+                    }).on('drag', redrawWaypointDrag);
                 map.addLayer(lastItineraryHoverMarker);
             }
         };
@@ -498,7 +501,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                         moveWaypoint(itinerary, geojson.properties.index, [coords.lat, coords.lng]);
                     }).on('click', function() {
                         removeWaypoint(itinerary, geojson.properties.index);
-                    });
+                    })).on('drag', redrawWaypointDrag);
 
                     marker.bindPopup('Drag to change or click to remove', {closeButton: false})
                     .on('mouseover', function () {

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -422,20 +422,10 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
     function draggableItinerary(itinerary) {
         clearWaypointInteractivity();
         // Show a draggable marker on the route line that adds a waypoint when released.
-
-        var lastLayer = itinerary.geojson;
         var redrawWaypointDrag = _.throttle(function(event, index) { // jshint ignore:line
-
-                // TODO: delay layer removal via held layer reference until response comes back
-
-                // TODO: why does this not work
-                map.removeLayer(lastLayer);
-
-                console.log(event.target.getLatLng());
                 var coords = event.target.getLatLng();
                 var waypoints = updateWaypointList(itinerary, index, [coords.lat, coords.lng]);
                 itinerary.routingParams.extraOptions.waypoints = waypoints;
-
                 events.trigger(eventNames.waypointMoved, itinerary);
         }, 800, {leading: true, trailing: true});
 

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -31,19 +31,38 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
 
         // not actually GeoJSON, but a Leaflet layer made from GeoJSON
         this.geojson = cartodb.L.geoJson({type: 'FeatureCollection',
-                                          features: getFeatures(otpItinerary.legs)});
+                                          features: this.getFeatures(otpItinerary.legs)});
         this.geojson.setStyle(getStyle(true, false));
 
         // expose functions
         this.getStyle = getStyle;
+
+        // set by CAC.Routing.Plans with the arguments sent to planTrip:
+        // coordsFrom, coordsTo, when, extraOptions
+        // (not used by directions list page)
+        this.routingParams = null;
     }
 
-    Itinerary.prototype.highlight = function (isHighlighted) {
+    Itinerary.prototype.highlight = function(isHighlighted) {
         this.geojson.setStyle(getStyle(true, isHighlighted));
     };
 
-    Itinerary.prototype.show = function (isShown) {
+    Itinerary.prototype.show = function(isShown) {
         this.geojson.setStyle(getStyle(isShown, false));
+    };
+
+    /**
+     * Get geoJSON for an itinerary
+     *
+     * @param {array} legs set of legs for an OTP itinerary
+     * @return {array} array of geojson features
+     */
+    Itinerary.prototype.getFeatures = function(legs) {
+        return _.map(legs, function(leg) {
+            var linestringGeoJson = L.Polyline.fromEncoded(leg.legGeometry.points).toGeoJSON();
+            linestringGeoJson.properties = leg;
+            return linestringGeoJson;
+        });
     };
 
     // cache of geocoded OSM nodes (node name mapped to reverse geocode name)
@@ -116,20 +135,6 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
         // fix hour singular
         str = str.replace('1 hrs,', '1 hr,');
         return str;
-    }
-
-    /**
-     * Helper function to get geoJSON for an itinerary
-     *
-     * @param {array} legs set of legs for an OTP itinerary
-     * @return {array} array of geojson features
-     */
-    function getFeatures(legs) {
-        return _.map(legs, function(leg) {
-            var linestringGeoJson = L.Polyline.fromEncoded(leg.legGeometry.points).toGeoJSON();
-            linestringGeoJson.properties = leg;
-            return linestringGeoJson;
-        });
     }
 
     /**

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -2,13 +2,14 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
     'use strict';
 
     var module = {
-        planTrip: planTrip
+        planTrip: planTrip,
+        planLiveUpdate: planLiveUpdate
     };
 
     return module;
 
     /**
-     * Find shortest path from one point to another
+     * Query OpenTripPlanner back-end for available routes.
      *
      * @param {array} coordsFrom The coords in lat-lng which we would like to travel from
      * @param {array} coordsTo The coords in lat-lng which we would like to travel to
@@ -49,9 +50,62 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
 
                 // return the Itinerary objects for the unique collection
                 var itineraries = _(planItineraries).map(function(itinerary, i) {
-                    return new Itinerary(itinerary, i);
+                    var cacItinerary = new Itinerary(itinerary, i);
+                    // keep parameters used to plan this trip
+                    cacItinerary.routingParams = {
+                        coordsFrom: coordsFrom,
+                        coordsTo: coordsTo,
+                        when: when,
+                        extraOptions: extraOptions
+                    };
+                    console.log(cacItinerary);
+                    return cacItinerary;
                 }).value();
                 deferred.resolve(itineraries);
+            } else {
+                deferred.reject(data.error);
+            }
+        }, function (error) {
+            deferred.reject(error);
+        });
+        return deferred.promise();
+    }
+
+    /**
+     * Query OpenTripPlanner to live update a route with waypoints as user edits it.
+     * Used to redraw route while user is dragging.
+     *
+     * If the existing itinerary.geojson layer is on the map, it must be removed before
+     * calling this function, as this function changes the layer reference.
+     *
+     * @param {Object} itinerary CAC.Routing.Itinerary previously returned from planTrip,
+                        with updated waypoint(s) on itinerary.routingParams.extraOptions
+     *
+     * @return {promise} The promise object which - if successful - resolves to updated itinerary
+     *                   with modified `geojson` features layer
+     */
+    function planLiveUpdate(itinerary) {
+        var deferred = $.Deferred();
+        console.log(itinerary);
+        var urlParams = prepareParams(itinerary.routingParams.coordsFrom,
+                                      itinerary.routingParams.coordsTo,
+                                      itinerary.routingParams.when,
+                                      itinerary.routingParams.extraOptions);
+
+        $.ajax({
+            url: Settings.routingUrl,
+            type: 'GET',
+            crossDomain: true,
+            data: urlParams,
+            processData: false
+        }).then(function(data) {
+            if (data.plan) {
+                var otpItinerary = data.plan.itineraries[0];
+
+                itinerary.geojson = cartodb.L.geoJson({type: 'FeatureCollection',
+                                          features: itinerary.getFeatures(otpItinerary.legs)});
+
+                deferred.resolve(itinerary);
             } else {
                 deferred.reject(data.error);
             }
@@ -78,6 +132,7 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
         // build out the waypoints portion of the encoded URL string here.
         var intermediatePlaces = '';
         if (extraOptions.hasOwnProperty('waypoints')) {
+            console.log(extraOptions.waypoints);
             intermediatePlaces = _.map(extraOptions.waypoints, function(waypoint) {
                 return $.param({intermediatePlaces: waypoint.join(',')});
             }).join('&');

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -104,6 +104,7 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
 
                 itinerary.geojson = cartodb.L.geoJson({type: 'FeatureCollection',
                                           features: itinerary.getFeatures(otpItinerary.legs)});
+                itinerary.geojson.setStyle(itinerary.getStyle(true, true));
 
                 deferred.resolve(itinerary);
             } else {

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -58,7 +58,6 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
                         when: when,
                         extraOptions: extraOptions
                     };
-                    console.log(cacItinerary);
                     return cacItinerary;
                 }).value();
                 deferred.resolve(itineraries);
@@ -86,7 +85,6 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
      */
     function planLiveUpdate(itinerary) {
         var deferred = $.Deferred();
-        console.log(itinerary);
         var urlParams = prepareParams(itinerary.routingParams.coordsFrom,
                                       itinerary.routingParams.coordsTo,
                                       itinerary.routingParams.when,
@@ -133,7 +131,6 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
         // build out the waypoints portion of the encoded URL string here.
         var intermediatePlaces = '';
         if (extraOptions.hasOwnProperty('waypoints')) {
-            console.log(extraOptions.waypoints);
             intermediatePlaces = _.map(extraOptions.waypoints, function(waypoint) {
                 return $.param({intermediatePlaces: waypoint.join(',')});
             }).join('&');

--- a/src/bower.json
+++ b/src/bower.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "bootstrap-sass-official": "~3.3.6",
     "bootstrap-select": "~1.11.2",
+    "console-polyfill": "~0.2.3",
     "eonasdan-bootstrap-datetimepicker": "~4.17.42",
     "handlebars": "~4.0.5",
     "jquery": "~2.1.4",

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -73,13 +73,14 @@ gulp.task('collectstatic', function () {
 });
 
 // turf module needs to be run through browserify to pack it with its dependencies
+var turfDistanceRoot = './node_modules/@turf/nearest/node_modules/@turf/distance';
 
 var buildTurfHelpers = function() {
-    return browserify('./node_modules/@turf/nearest/node_modules/@turf/distance/node_modules/@turf/helpers', {
+    return browserify(turfDistanceRoot + '/node_modules/@turf/helpers', {
             standalone: 'turf',
             expose: ['helpers']
         })
-        .require('./node_modules/@turf/nearest/node_modules/@turf/distance/node_modules/@turf/helpers',
+        .require(turfDistanceRoot + '/node_modules/@turf/helpers',
                  {expose: 'turf-helpers'})
         .bundle()
         .pipe(vinylSourceStream('turf-helpers.js'));
@@ -88,12 +89,12 @@ var buildTurfHelpers = function() {
 var buildTurfPointOnLine = function() {
     return browserify('./node_modules/@turf/nearest', {
             standalone: 'turf.nearest',
-            exclude: ['./node_modules/@turf/nearest/node_modules/@turf/distance/node_modules/@turf/helpers']
+            exclude: [turfDistanceRoot + '/node_modules/@turf/helpers']
         })
         .transform(aliasify, {aliases: {
-            'turf-helpers': './node_modules/@turf/nearest/node_modules/@turf/distance/node_modules/@turf/helpers',
-            'turf-invariant': './node_modules/@turf/nearest/node_modules/@turf/distance/node_modules/@turf/invariant',
-            'turf-distance': './node_modules/@turf/nearest/node_modules/@turf/distance'
+            'turf-helpers': turfDistanceRoot + '/node_modules/@turf/helpers',
+            'turf-invariant': turfDistanceRoot + '/node_modules/@turf/invariant',
+            'turf-distance': turfDistanceRoot
         }})
         .bundle()
         .pipe(vinylSourceStream('turf-nearest.js'));


### PR DESCRIPTION
Show re-routing previews as the user drags a waypoint marker. Closes #523.

Also add a `console` polyfill so that if any of our error logs happen on a browser without `console` defined, it won't break things more. (Close #527.)

Would like a refactor on the map controller after this goes in, as it has slowly grown to nearly 1,000 lines and could be broken up into several files.