### PR TITLE
Circle waypoint markers

### DIFF
--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -55,6 +55,18 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         iconColor: 'black',
         markerColor: 'lightgreen'
     });
+    var waypointRadius = 6;
+    var waypointColor = '#444';
+    var waypointCircle = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" ' +
+        'width="' + waypointRadius * 2 + '" height="' + waypointRadius * 2 + '">' +
+        '<circle cx="' + waypointRadius + '" cy="' + waypointRadius +
+        '" r="' + waypointRadius + '" fill="' + waypointColor + '"/></svg>';
+    var waypointIcon = L.icon( {
+        iconUrl: 'data:image/svg+xml;base64,' + btoa(waypointCircle),
+        iconSize: [waypointRadius * 2, waypointRadius * 2],
+        iconAnchor: [waypointRadius, waypointRadius],
+        popupAnchor: [0, -2 - waypointRadius]
+    } );
 
     var esriSatelliteAttribution = [
         '&copy; <a href="http://www.esri.com/">Esri</a> ',
@@ -466,7 +478,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                 var popupTimeout;
                 lastItineraryHoverMarker = new cartodb.L.Marker(e.latlng, {
                         draggable: true,
-                        icon: highlightIcon
+                        icon: waypointIcon
                     }).bindPopup('Drag marker to change route', {closeButton: false}
                     ).on('dragstart', function(e) {
                         dragging = true;
@@ -523,7 +535,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
             var popupTimeout;
             waypointsLayer = cartodb.L.geoJson(turf.featureCollection(itinerary.waypoints), {
                 pointToLayer: function(geojson, latlng) {
-                    var marker = new cartodb.L.marker(latlng, {icon: destinationIcon,
+                    var marker = new cartodb.L.marker(latlng, {icon: waypointIcon,
                                                                draggable: true });
                     marker.on('dragstart', function() {
                         dragging = true;

--- a/src/bower.json
+++ b/src/bower.json
@@ -9,6 +9,7 @@
     "handlebars": "~4.0.5",
     "jquery": "~2.1.4",
     "jQuery-Storage-API": "~1.9.1",
+    "leaflet": "~0.7.7",
     "cartodb.js": "~3.15",
     "Leaflet.encoded": "~0.0.8",
     "moment": "~2.15.1",


### PR DESCRIPTION
Converts the marker icon for waypoints to a circle.  Replaces PR #531 and resolves #522.

Also fixes a small issue I came across while testing by adding a `clearTimeout` to stop the add-waypoint marker from being deleted if you moused out but then came back to it.

![circles_again](https://cloud.githubusercontent.com/assets/6598836/19526907/f74796b8-95f3-11e6-9fc2-537e88497cc6.png)
