### PR TITLE
Copy media assets on dev VM

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -62,6 +62,17 @@
   notify: Restart cac-tripplanner-app
   when: develop or test
 
+- name: Run collectstatic
+  django_manage: command=collectstatic
+                 app_path=/opt/app/python/cac_tripplanner
+
+- name: Copy media assets
+  copy: src=../../python/cac_tripplanner/default_media
+        dest=/media/cac
+        owner={{ app_username }}
+        group={{ app_username }}
+  when: develop or test
+
 - name: Copy nginx config
   template: src=nginx-default.j2 dest=/etc/nginx/sites-available/default
   notify: Restart nginx


### PR DESCRIPTION
Fixes #534.

When building VMs during development, test media assets will be copied to the expected directory. Fixes destination images not displaying after fresh provision.