### PR TITLE
Exclude pre-minified CSS

### DIFF
--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -110,7 +110,10 @@ var copyVendorJS = function(filter, extraFiles) {
 gulp.task('clean', function() {
     // This must be done synchronously to prevent sporadic failures
     return del.sync([
-        staticRoot + '/**'
+        stat.fonts,
+        stat.scripts,
+        stat.styles,
+        stat.images
     ], { force: true });
 });
 
@@ -149,7 +152,7 @@ gulp.task('copy:scripts', function() {
 
 gulp.task('copy:vendor-css', function() {
     return copyBowerFiles(['**/*.css',
-                          //'!**/*.min.css',
+                          '!**/*.min.css',
                           // leaflet loaded over CDN
                           '!**/leaflet.css'], [])
         .pipe(concat('vendor.css'))

--- a/src/package.json
+++ b/src/package.json
@@ -68,6 +68,7 @@
     "bower-install": "bower install",
     "bower-clean": "bower cache clean",
     "bower-prune": "bower prune",
+    "gulp-clean": "gulp clean",
     "gulp-development": "gulp development",
     "gulp-production": "gulp production",
     "gulp-test": "gulp test",


### PR DESCRIPTION
Fixes #515. Since the redesign, pre-minified CSS can be safely excluded.
Also modifies gulp clean task to only remove gulp-managed assets from /srv.