### PR TITLE
Break up map controller

### DIFF
--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -110,6 +110,7 @@
     <script src="{% static 'scripts/main/cac/urlrouting/cac-urlrouting.js' %}"></script>
     <script src="{% static 'scripts/main/cac/map/cac-map-control.js' %}"></script>
     <script src="{% static 'scripts/main/cac/map/cac-map-isochrone.js' %}"></script>
+    <script src="{% static 'scripts/main/cac/map/cac-map-itinerary.js' %}"></script>
     <script src="{% static 'scripts/main/cac/map/cac-map-overlays.js' %}"></script>
     <script src="{% static 'scripts/main/cac/map/cac-map-templates.js' %}"></script>
     <script src="{% static 'scripts/main/cac/control/cac-control-bike-mode-options.js' %}"></script>

--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -109,6 +109,7 @@
     <script src="{% static 'scripts/main/cac/routing/cac-routing-plans.js' %}"></script>
     <script src="{% static 'scripts/main/cac/urlrouting/cac-urlrouting.js' %}"></script>
     <script src="{% static 'scripts/main/cac/map/cac-map-control.js' %}"></script>
+    <script src="{% static 'scripts/main/cac/map/cac-map-isochrone.js' %}"></script>
     <script src="{% static 'scripts/main/cac/map/cac-map-overlays.js' %}"></script>
     <script src="{% static 'scripts/main/cac/map/cac-map-templates.js' %}"></script>
     <script src="{% static 'scripts/main/cac/control/cac-control-bike-mode-options.js' %}"></script>

--- a/src/app/scripts/cac/control/cac-control-sidebar-directions.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-directions.js
@@ -52,6 +52,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
 
     var bikeModeOptions = null;
     var mapControl = null;
+    var itineraryControl = null;
     var tabControl = null;
     var urlRouter = null;
     var directionsListControl = null;
@@ -63,6 +64,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
         options = $.extend({}, defaults, params);
         mapControl = options.mapControl;
         tabControl = options.tabControl;
+        itineraryControl = mapControl.itineraryControl;
         urlRouter = options.urlRouter;
         bikeModeOptions = new BikeModeOptions();
 
@@ -97,8 +99,8 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
         itineraryListControl.events.on(itineraryListControl.eventNames.itineraryHover,
                                        onItineraryHover);
 
-        mapControl.events.on(mapControl.eventNames.waypointsSet, queryWithWaypoints);
-        mapControl.events.on(mapControl.eventNames.waypointMoved, liveUpdateItinerary);
+        itineraryControl.events.on(itineraryControl.eventNames.waypointsSet, queryWithWaypoints);
+        itineraryControl.events.on(itineraryControl.eventNames.waypointMoved, liveUpdateItinerary);
 
         typeaheadDest = new Typeahead(options.selectors.typeaheadDest);
         typeaheadDest.events.on(typeaheadDest.eventNames.selected, onTypeaheadSelected);
@@ -218,9 +220,9 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
             }
             // Add the itineraries to the map, highlighting the first one
             var isFirst = true;
-            mapControl.clearItineraries();
+            itineraryControl.clearItineraries();
             _.forIn(itineraries, function (itinerary) {
-                mapControl.plotItinerary(itinerary, isFirst);
+                itineraryControl.plotItinerary(itinerary, isFirst);
                 itinerary.highlight(isFirst);
                 if (isFirst) {
                     currentItinerary = itinerary;
@@ -233,7 +235,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
             // lets the user to continue to add or modify waypoints without
             // having to select it in the list.
             if (itineraries.length === 1 && !isArriveBy()) {
-                mapControl.draggableItinerary(currentItinerary);
+                itineraryControl.draggableItinerary(currentItinerary);
             }
 
             // put markers at start and end
@@ -243,7 +245,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
             itineraryListControl.show();
         }, function (error) {
             $(options.selectors.spinner).addClass('hidden');
-            mapControl.clearItineraries();
+            itineraryControl.clearItineraries();
             itineraryListControl.setItinerariesError(error);
             $(options.selectors.directions).addClass(options.selectors.resultsClass);
             itineraryListControl.show();
@@ -265,7 +267,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
 
     function clearItineraries() {
         UserPreferences.setPreference('waypoints', undefined);
-        mapControl.clearItineraries();
+        itineraryControl.clearItineraries();
         itineraryListControl.hide();
         directionsListControl.hide();
         $(options.selectors.directions).removeClass(options.selectors.resultsClass);
@@ -290,7 +292,7 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
             itinerary.highlight(true);
 
             if (!isArriveBy()) {
-                mapControl.draggableItinerary(itinerary);
+                itineraryControl.draggableItinerary(itinerary);
             }
 
             currentItinerary = itinerary;
@@ -333,11 +335,11 @@ CAC.Control.SidebarDirections = (function (_, $, Control, BikeModeOptions, Geoco
     function liveUpdateItinerary(event, itinerary) {
         var oldLayer = itinerary.geojson;
         Routing.planLiveUpdate(itinerary).then(function(newItinerary) {
-            mapControl.updateItineraryLayer(oldLayer, newItinerary);
+            itineraryControl.updateItineraryLayer(oldLayer, newItinerary);
         }, function(error) {
             console.error(error);
             // occasionally cannot plan route if waypoint cannot be snapped to street grid
-            mapControl.errorLiveUpdatingLayer();
+            itineraryControl.errorLiveUpdatingLayer();
         });
     }
 

--- a/src/app/scripts/cac/control/cac-control-sidebar-explore.js
+++ b/src/app/scripts/cac/control/cac-control-sidebar-explore.js
@@ -207,7 +207,7 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
         // do not zoom to fit isochrone if going to highlight a selected destination
         var zoomToFit = !selectedPlaceId;
 
-        mapControl.fetchIsochrone(exploreLatLng, when, exploreMinutes, otpOptions, zoomToFit).then(
+        mapControl.isochroneControl.fetchIsochrone(exploreLatLng, when, exploreMinutes, otpOptions, zoomToFit).then(
             function (destinations) {
                 $(options.selectors.spinner).addClass('hidden');
                 $(options.selectors.destinations).removeClass('hidden');
@@ -228,7 +228,7 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
         UserPreferences.clearLocation('origin');
         exploreLatLng = null;
         selectedPlaceId = null;
-        mapControl.clearDiscoverPlaces();
+        mapControl.isochroneControl.clearDiscoverPlaces();
     }
 
     function onTypeaheadSelected(event, key, location) {
@@ -260,7 +260,7 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
             exploreLatLng = null;
             UserPreferences.clearLocation('origin');
             $input.addClass(options.selectors.errorClass);
-            mapControl.clearDiscoverPlaces();
+            mapControl.isochroneControl.clearDiscoverPlaces();
             return true;
         }
     }
@@ -352,12 +352,12 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
             var $destination = $(MapTemplates.destinationBlock(destination));
             $destination.click(function () {
                 setDestinationSidebarDetail(destination.id);
-                mapControl.highlightDestination(destination.id, { panTo: true });
+                mapControl.isochroneControl.highlightDestination(destination.id, { panTo: true });
             });
             $destination.hover(function () {
-                mapControl.highlightDestination(destination.id);
+                mapControl.isochroneControl.highlightDestination(destination.id);
             }, function () {
-                mapControl.highlightDestination(null);
+                mapControl.isochroneControl.highlightDestination(null);
             });
             $container.append($destination);
         });
@@ -372,7 +372,7 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
         if (selectedPlaceId) {
             setDestinationSidebarDetail(selectedPlaceId);
             // also highlight it on the map and pan to it
-            mapControl.highlightDestination(selectedPlaceId, { panTo: true });
+            mapControl.isochroneControl.highlightDestination(selectedPlaceId, { panTo: true });
         }
     }
 
@@ -405,7 +405,7 @@ CAC.Control.SidebarExplore = (function (_, $, BikeModeOptions, Geocoder, MapTemp
         UserPreferences.setPreference('placeId', undefined);
         updateUrl();
         setDestinationSidebar(destinationsCache);
-        mapControl.highlightDestination(null);
+        mapControl.isochroneControl.highlightDestination(null);
     }
 
     /* Update the URL based on current UserPreferences

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -6,9 +6,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         homepage: true,
         center: [39.95, -75.1667],
         zoom: 14,
-        selectors: {
-            destinationPopup: '.destination-directions-link'
-        }
     };
 
     var map = null;
@@ -24,7 +21,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
 
     var events = $({});
     var eventNames = {
-        destinationPopupClick: 'cac:map:control:destinationpopup',
         currentLocationClick: 'cac:map:control:currentlocation',
         originMoved: 'cac:map:control:originmoved',
         destinationMoved: 'cac:map:control:destinationmoved',
@@ -34,14 +30,10 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
     };
     var basemaps = {};
     var overlays = {};
-    var destinationsLayer = null;
-    var destinationMarkers = {};
-    var lastHighlightedMarker = null;
     var lastDisplayPointMarker = null;
     var lastItineraryHoverMarker = null;
     var itineraryHoverListener = null;
     var liveUpdatingItinerary = false; // true when live update request sent but not completed
-    var isochroneLayer = null;
     var waypointsLayer = null;
 
     var layerControl = null;
@@ -50,17 +42,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
 
     var homepage = true; // whether currently displaying home page view TODO: rework
 
-    var destinationIcon = L.AwesomeMarkers.icon({
-        icon: 'beenhere',
-        prefix: 'md',
-        markerColor: 'green'
-    });
-    var highlightIcon = L.AwesomeMarkers.icon({
-        icon: 'beenhere',
-        prefix: 'md',
-        iconColor: 'black',
-        markerColor: 'lightgreen'
-    });
     var waypointRadius = 6;
     var waypointColor = '#444';
     var waypointCircle = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" ' +
@@ -83,18 +64,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, ',
         '&copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
     ].join('');
-
-    /**
-     * Variables used for limiting to one isochrone request at a time.
-     * Unlike the planTrip request, the isochrone request cannot be handled
-     * solely via debounce, due to differences in the way the isochrone
-     * request flows through the system. There are actions that take place
-     * on this module (drawing the isochrone on the map), and then actions
-     * that take place on the sidebar module (generating the destinations),
-     * so doing the limiting correctly is more of a challenge.
-     */
-    var activeIsochroneRequest = null;
-    var pendingIsochroneRequest = null;
 
     function MapControl(options) {
         this.events = events;
@@ -119,11 +88,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         initializeOverlays();
         initializeLayerControl();
 
-        // set listener for click event on destination popup
-        $('#' + this.options.id).on('click', this.options.selectors.destinationPopup, function(event) {
-            events.trigger(eventNames.destinationPopupClick,
-                           destinationMarkers[event.currentTarget.id].destination);
-        });
+        this.isochroneControl = new CAC.Map.IsochroneControl({map: map, tabControl: tabControl});
 
         // add minimize button to layer control
         var leafletMinimizer = '.leaflet-minimize';
@@ -146,11 +111,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         });
     }
 
-    MapControl.prototype.clearIsochrone = clearIsochrone;
-    MapControl.prototype.clearDiscoverPlaces = clearDiscoverPlaces;
-    MapControl.prototype.fetchIsochrone = fetchIsochrone;
-    MapControl.prototype.locateUser = locateUser;
-    MapControl.prototype.drawDestinations = drawDestinations;
     MapControl.prototype.plotItinerary = plotItinerary;
     MapControl.prototype.clearItineraries = clearItineraries;
     MapControl.prototype.clearWaypointInteractivity = clearWaypointInteractivity;
@@ -158,7 +118,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
     MapControl.prototype.setGeocodeMarker = setGeocodeMarker;
     MapControl.prototype.setDirectionsMarkers = setDirectionsMarkers;
     MapControl.prototype.clearDirectionsMarker = clearDirectionsMarker;
-    MapControl.prototype.highlightDestination = highlightDestination;
     MapControl.prototype.displayPoint = displayPoint;
     MapControl.prototype.updateItineraryLayer = updateItineraryLayer;
     MapControl.prototype.errorLiveUpdatingLayer = errorLiveUpdatingLayer;
@@ -259,183 +218,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
             deferred.fail(function() { return 'geolocation not supported on this device'; });
         }
         return deferred.promise();
-    }
-
-    /**
-     * Add isochrone outline to map
-     */
-    function drawIsochrone(isochrone, zoomToFit) {
-        try {
-            isochroneLayer = cartodb.L.geoJson(isochrone, {
-                clickable: false,
-                style: {
-                    clickable: false,
-                    color: '#5c2482',
-                    fillColor: '#5c2482',
-                    lineCap: 'round',
-                    lineJoin: 'round',
-                    opacity: 0.4,
-                    fillOpacity: 0.3,
-                    stroke: true,
-                    weight: 2
-                }
-            });
-        } catch (err) {
-            console.error('isochrone layer failed to load from GeoJSON');
-            console.error(err);
-            isochroneLayer = null;
-        }
-
-        if (isochroneLayer) {
-            isochroneLayer.addTo(map);
-            if (zoomToFit) {
-                map.fitBounds(isochroneLayer.getBounds());
-            }
-        }
-    }
-
-    /**
-     * Fetch all the reachable destinations within our destination database,
-     * and their enclosing isochrone (travelshed).
-     *
-     * @return {Object} Promise resolving to JSON with 'matched' and 'isochrone' properties
-     */
-    function fetchReachable(payload) {
-        var isochroneUrl = '/map/reachable';
-        var deferred = $.Deferred();
-        $.ajax({
-            type: 'GET',
-            data: payload,
-            cache: false,
-            url: isochroneUrl,
-            contentType: 'application/json'
-        }).then(deferred.resolve);
-        return deferred.promise();
-    }
-
-    /**
-     * Makes an isochrone request. Only allows one isochrone request at a time.
-     * If another request comes in while one is active, the results of the active
-     * request will be discarded upon completion, and the new query issued.
-     *
-     * @param {Deferred} A jQuery Deferred object used for resolution
-     * @param {Object} Parameters to be sent along with the request
-     * @param {boolean} Whether to pan/zoom map to fit returned isochrone
-     */
-    function getIsochrone(deferred, params, zoomToFit) {
-        // Check if there's already an active request. If there is one,
-        // then we can't make a query yet -- store it as pending.
-        // If there was already a pending query, immediately resolve it.
-        if (activeIsochroneRequest) {
-            if (pendingIsochroneRequest) {
-                pendingIsochroneRequest.deferred.resolve();
-            }
-            pendingIsochroneRequest = { deferred: deferred, params: params, zoomToFit: zoomToFit };
-            return;
-        }
-
-        // Set the active isochrone request and make query
-        activeIsochroneRequest = { deferred: deferred, params: params, zoomToFit: zoomToFit };
-        fetchReachable(params).then(function(data) {
-            activeIsochroneRequest = null;
-            if (pendingIsochroneRequest) {
-                // These results are already out of date. Don't display them, and instead
-                // send off the pending request.
-                deferred.resolve();
-
-                var pending = pendingIsochroneRequest;
-                pendingIsochroneRequest = null;
-                getIsochrone(pending.deferred, pending.params, zoomToFit);
-                return;
-            }
-
-            if (!tabControl.isTabShowing('explore')) {
-                // if user has switched away from the explore tab, do not show results
-                deferred.resolve();
-                return;
-            }
-            drawIsochrone(data.isochrone, zoomToFit);
-            // also draw 'matched' list of locations
-            drawDestinations(data.matched);
-            deferred.resolve(data.matched);
-        }, function(error) {
-            activeIsochroneRequest = null;
-            pendingIsochroneRequest = null;
-            console.error(error);
-        });
-    }
-
-    /**
-     * Get travelshed and destinations within it, then display results on map.
-    */
-    function fetchIsochrone(coordsOrigin, when, exploreMinutes, otpParams, zoomToFit) {
-        var deferred = $.Deferred();
-        // clear results of last search
-        clearDiscoverPlaces();
-
-        var formattedTime = when.format('hh:mma');
-        var formattedDate = when.format('YYYY/MM/DD');
-
-        var params = {
-            time: formattedTime,
-            date: formattedDate,
-            cutoffSec: exploreMinutes * 60 // API expects seconds
-        };
-
-        // Default precision of 200m; 100m seems good for improving response times on non-transit
-        // http://dev.opentripplanner.org/apidoc/0.12.0/resource_LIsochrone.html
-        if (otpParams.mode === 'WALK' || otpParams.mode === 'BICYCLE') {
-            params.precisionMeters = 100;
-        }
-
-        params = $.extend(otpParams, params);
-
-        if (coordsOrigin) {
-            params.fromPlace = coordsOrigin.join(',');
-            getIsochrone(deferred, params, zoomToFit);
-        }
-
-        return deferred.promise();
-    }
-
-    /**
-     * Draw an array of geojson destination points onto the map
-     */
-    function drawDestinations(matched) {
-        // put destination details onto point geojson object's properties
-        // build map of unconverted destination objects
-        var destinations = {};
-        var locationGeoJSON = _.map(matched, function(destination) {
-            destinations[destination.id] = destination;
-            var point = _.property('point')(destination);
-            point.properties = _.omit(destination, 'point');
-            return point;
-        });
-        destinationMarkers = {};
-        destinationsLayer = cartodb.L.geoJson(locationGeoJSON, {
-            pointToLayer: function (geojson, latLng) {
-                var popupTemplate = ['<h4>{{geojson.properties.name}}</h4>',
-                                     '<div class="destination-description">',
-                                    // HTML-formatted description
-                                     geojson.properties.description,
-                                     '</div>',
-                                     '<a href="{{geojson.properties.website_url}}" ',
-                                     'target="_blank">{{geojson.properties.website_url}}</a>',
-                                     '<a class="destination-directions-link pull-right" ',
-                                     'id="{{geojson.properties.id}}">Get Directions</a>'
-                                    ].join('');
-                var template = Handlebars.compile(popupTemplate);
-                var popupContent = template({geojson: geojson});
-                var markerId = geojson.properties.id;
-                var marker = new cartodb.L.marker(latLng, {icon: destinationIcon})
-                        .bindPopup(popupContent);
-                destinationMarkers[markerId] = {
-                    marker: marker,
-                    destination: destinations[geojson.properties.id]
-                };
-                return marker;
-            }
-        }).addTo(map);
     }
 
     /**
@@ -823,26 +605,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         });
     }
 
-    /**
-     * Remove layers for isochrone and destinations within it.
-     */
-    function clearDiscoverPlaces() {
-        clearDestinations();
-        clearIsochrone();
-    }
-
-    function clearDestinations() {
-        if (destinationsLayer) {
-            map.removeLayer(destinationsLayer);
-        }
-    }
-
-    function clearIsochrone() {
-        if (isochroneLayer) {
-            map.removeLayer(isochroneLayer);
-        }
-    }
-
     function setGeocodeMarker(latLng) {
         // helper for when marker dragged to new place
         function markerDrag(event) {
@@ -963,27 +725,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
             map.removeLayer(directionsMarkers[type]);
         }
         directionsMarkers[type] = null;
-    }
-
-    function highlightDestination(destinationId, opts) {
-        var defaults = {
-            panTo: false
-        };
-        var options = $.extend({}, defaults, opts);
-        if (!destinationId) {
-            // revert to original marker if set
-            if (lastHighlightedMarker) {
-                lastHighlightedMarker.setIcon(destinationIcon);
-            }
-            return;
-        }
-        // Update icon for passed destination
-        var marker = destinationMarkers[destinationId].marker;
-        marker.setIcon(highlightIcon);
-        if (options.panTo) {
-            map.panTo(marker.getLatLng());
-        }
-        lastHighlightedMarker = marker;
     }
 
     /**

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -17,7 +17,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
     };
 
     var overlaysControl = null;
-    var itineraries = {};
 
     var events = $({});
     var eventNames = {
@@ -25,35 +24,16 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         originMoved: 'cac:map:control:originmoved',
         destinationMoved: 'cac:map:control:destinationmoved',
         geocodeMarkerMoved: 'cac:map:control:geocodemoved',
-        waypointMoved: 'cac:map:control:waypointmoved',
-        waypointsSet: 'cac:map:control:waypointsset'
     };
     var basemaps = {};
     var overlays = {};
     var lastDisplayPointMarker = null;
-    var lastItineraryHoverMarker = null;
-    var itineraryHoverListener = null;
-    var liveUpdatingItinerary = false; // true when live update request sent but not completed
-    var waypointsLayer = null;
 
     var layerControl = null;
     var tabControl = null;
     var zoomControl = null;
 
     var homepage = true; // whether currently displaying home page view TODO: rework
-
-    var waypointRadius = 6;
-    var waypointColor = '#444';
-    var waypointCircle = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" ' +
-        'width="' + waypointRadius * 2 + '" height="' + waypointRadius * 2 + '">' +
-        '<circle cx="' + waypointRadius + '" cy="' + waypointRadius +
-        '" r="' + waypointRadius + '" fill="' + waypointColor + '"/></svg>';
-    var waypointIcon = L.icon( {
-        iconUrl: 'data:image/svg+xml;base64,' + btoa(waypointCircle),
-        iconSize: [waypointRadius * 2, waypointRadius * 2],
-        iconAnchor: [waypointRadius, waypointRadius],
-        popupAnchor: [0, -2 - waypointRadius]
-    } );
 
     var esriSatelliteAttribution = [
         '&copy; <a href="http://www.esri.com/">Esri</a> ',
@@ -71,7 +51,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         this.options = $.extend({}, defaults, options);
         overlaysControl = new CAC.Map.OverlaysControl();
         map = new cartodb.L.map(this.options.id, { zoomControl: false })
-            .setView(this.options.center, this.options.zoom);
+                           .setView(this.options.center, this.options.zoom);
 
         tabControl = options.tabControl;
         homepage = options.homepage;
@@ -89,6 +69,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         initializeLayerControl();
 
         this.isochroneControl = new CAC.Map.IsochroneControl({map: map, tabControl: tabControl});
+        this.itineraryControl = new CAC.Map.ItineraryControl({map: map});
 
         // add minimize button to layer control
         var leafletMinimizer = '.leaflet-minimize';
@@ -111,16 +92,10 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         });
     }
 
-    MapControl.prototype.plotItinerary = plotItinerary;
-    MapControl.prototype.clearItineraries = clearItineraries;
-    MapControl.prototype.clearWaypointInteractivity = clearWaypointInteractivity;
-    MapControl.prototype.draggableItinerary = draggableItinerary;
     MapControl.prototype.setGeocodeMarker = setGeocodeMarker;
     MapControl.prototype.setDirectionsMarkers = setDirectionsMarkers;
     MapControl.prototype.clearDirectionsMarker = clearDirectionsMarker;
     MapControl.prototype.displayPoint = displayPoint;
-    MapControl.prototype.updateItineraryLayer = updateItineraryLayer;
-    MapControl.prototype.errorLiveUpdatingLayer = errorLiveUpdatingLayer;
 
     return MapControl;
 
@@ -218,391 +193,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
             deferred.fail(function() { return 'geolocation not supported on this device'; });
         }
         return deferred.promise();
-    }
-
-    /**
-     * Plots an itinerary on a map, optionally zooming to fit.
-     *
-     * @param {Object} itinerary CAC.Routing.Itinerary object with geojson to draw
-     * @param {Boolean} makeFit If true, zoom to fit itinerary in view
-     */
-    function plotItinerary(itinerary, makeFit) {
-        itineraries[itinerary.id] = itinerary;
-        var layer = itinerary.geojson.addTo(map);
-        if (makeFit) {
-            map.fitBounds(layer.getBounds());
-        }
-    }
-
-    /**
-     * Add listeners to an itinerary map layer to make it draggable.
-     *
-     * @param {Object} itinerary CAC.Routing.Itinerary object to be made draggable
-     */
-    function draggableItinerary(itinerary) {
-        clearWaypointInteractivity();
-
-        /**
-         * Show a draggable marker on the route line that adds a waypoint when released.
-         * Throttles calls to the trip planner for live updates; fires event when live update done.
-         *
-         * @param {object} event Leaflet drag event (that has coordinates on it)
-         * @param {integer} index Offset of waypoint to add or move within ordered waypoint list
-         * @param {boolean} isNew Whether this is a new waypoint to add, or move existing if false
-         */
-        var redrawWaypointDrag = _.throttle(function(event, index, isNew) { // jshint ignore:line
-            if (liveUpdatingItinerary) {
-                return; // do not send another request if one already in progress
-            }
-
-            liveUpdatingItinerary = true;
-            var coords = event.target.getLatLng();
-            var lastItinerary = itineraries[itinerary.id];
-            var waypoints;
-            if (isNew) {
-                // adding new waypoint
-                waypoints = addWaypoint(lastItinerary, [coords.lat, coords.lng], index);
-            } else {
-                // dragging existing waypoint
-                waypoints = updateWaypointList(lastItinerary, index, [coords.lat, coords.lng]);
-            }
-            lastItinerary.routingParams.extraOptions.waypoints = waypoints;
-            events.trigger(eventNames.waypointMoved, lastItinerary);
-        }, 800, {leading: true, trailing: true});
-
-        // Leaflet listeners are removed by reference, so retain a reference to the
-        // listener function to be able to turn it off later.
-        itineraryHoverListener = function(e) {
-            if (lastItineraryHoverMarker) {
-                lastItineraryHoverMarker.setLatLng(e.latlng, {draggable: true});
-            } else {
-                // flag if user currently dragging out a new waypoint or not
-                var dragging = false;
-                // index for new waypoint, based on where user began dragging
-                var newWaypointIndex = null;
-		        // Use a timeout when closing the popup so it doesn't strobe on extraneous mouseouts
-                var popupTimeout;
-                // The marker closes with a timeout as well, and holding onto it lets us avoid
-                // removing the marker while it's still under the mouse
-                var markerTimeout;
-                lastItineraryHoverMarker = new cartodb.L.Marker(e.latlng, {
-                        draggable: true,
-                        icon: waypointIcon
-                    }).bindPopup('Drag marker to change route', {closeButton: false}
-                    ).on('dragstart', function(e) {
-                        dragging = true;
-                        var pt = e.target.getLatLng();
-                        var startDragPoint = [pt.lng, pt.lat];
-                        newWaypointIndex = getNewWaypointIndex(itinerary, startDragPoint);
-                    }).on('dragend', function(e) {
-                        dragging = false;
-                        // cancel any live route updates queued
-                        redrawWaypointDrag.cancel();
-                        var coords = e.target.getLatLng();
-                        setAddedWaypoint(itinerary, [coords.lat, coords.lng], newWaypointIndex);
-                        newWaypointIndex = null;
-                    }).on('drag', function(event) {
-                        // get itinerary from collection to pick up newer version with
-                        // layer modified by live dragging updates
-                        redrawWaypointDrag(event, newWaypointIndex, true);
-                    }).on('mouseover', function() {
-                        clearTimeout(popupTimeout);
-                        clearTimeout(markerTimeout);
-                        return dragging || this.openPopup();
-                    }).on('mouseout', function() {
-                        // Close popup, but with a slight delay to avoid flickering, and with an
-                        // existence check to avoid errors if the marker has been destroyed
-                        popupTimeout = setTimeout(function() {
-                            if (lastItineraryHoverMarker) {
-                                lastItineraryHoverMarker.closePopup();
-                            }
-                         }, 50);
-
-                        // hide marker after awhile if not dragging
-                        if (!dragging) {
-                            markerTimeout = setTimeout(function() {
-                                if (lastItineraryHoverMarker && !dragging) {
-                                    map.removeLayer(lastItineraryHoverMarker);
-                                    lastItineraryHoverMarker = null;
-                                    dragging = false;
-                                    newWaypointIndex = null;
-                                }
-                            }, 3000);
-                        }
-                    });
-
-                map.addLayer(lastItineraryHoverMarker);
-            }
-        };
-
-        itinerary.geojson.on('mouseover', itineraryHoverListener);
-
-        // add a layer of draggable markers for the existing waypoints
-        if (itinerary.waypoints) {
-            var dragging = false;
-            var popupTimeout;
-            waypointsLayer = cartodb.L.geoJson(turf.featureCollection(itinerary.waypoints), {
-                pointToLayer: function(geojson, latlng) {
-                    var marker = new cartodb.L.marker(latlng, {icon: waypointIcon,
-                                                               draggable: true });
-                    marker.on('dragstart', function() {
-                        dragging = true;
-                    }).on('dragend', function(e) {
-                        dragging = false;
-                        // cancel any live route updates queued
-                        redrawWaypointDrag.cancel();
-                        // get itinerary from collection to pick up newer version with
-                        // layer modified by live dragging updates
-                        var coords = e.target.getLatLng();
-                        moveWaypoint(itineraries[itinerary.id],
-                                     geojson.properties.index,
-                                     [coords.lat, coords.lng]);
-                    }).on('click', function() {
-                        removeWaypoint(itinerary, geojson.properties.index);
-                    }).on('drag', function(event) {
-                            redrawWaypointDrag(event, geojson.properties.index, false);
-                    });
-
-		    marker.bindPopup('Drag to change or click to remove', {closeButton: false})
-                    .on('mouseover', function () {
-                        clearTimeout(popupTimeout);
-                        return dragging || this.openPopup();
-                    }).on('mouseout', function () {
-                        // Close popup, but with a slight delay to avoid flickering, and with an
-                        // existence check to avoid errors if the marker has been destroyed
-                        popupTimeout = setTimeout(function() {
-                            if (marker) {
-                                marker.closePopup();
-                            }
-                        }, 50);
-                    });
-                    return marker;
-                }
-            }).addTo(map);
-        }
-
-        // Explicitly bring selected layer to foreground.
-        // Fixes issue with Firefox inconsistently adding/removing interactivity
-        // when there are multiple overlapping itinerary paths.
-        itinerary.geojson.bringToFront();
-    }
-
-    function getNewWaypointIndex(itinerary, startDragPoint) {
-        var waypoints = itinerary.waypoints;
-
-        if (!waypoints || !waypoints.length) {
-            return 0;
-        }
-
-        var originPoint = turf.point([itinerary.from.lon, itinerary.from.lat], {index: -1});
-        var destPoint = turf.point([itinerary.to.lon, itinerary.to.lat], {index: waypoints.length});
-
-        var allFeatures = _.concat([originPoint], waypoints, [destPoint]);
-
-        var turfPoint = turf.point(startDragPoint);
-        var nearest = turf.nearest(turfPoint, turf.featureCollection(allFeatures));
-
-        var nearestIndex = nearest.properties.index;
-
-        // drop the nearest point to repeat search, in order to find next nearest
-        var remainingFeatures = _.concat(_.slice(allFeatures, 0, nearestIndex),
-                                       _.slice(allFeatures, nearestIndex + 1));
-
-        var nextNearest = turf.nearest(turfPoint, turf.featureCollection(remainingFeatures));
-
-        var nextNearestIndex = nextNearest.properties.index;
-
-        // determine the sequence ordering of the two nearest points, so the new point can
-        // be added between them
-        var smallerIndex = Math.min(nearestIndex, nextNearestIndex);
-        var largerIndex = Math.max(nearestIndex, nextNearestIndex);
-        var newIndex = smallerIndex + 1;
-
-        // If the nearest two points aren't in sequence and the larger indexed one is closer,
-        // put the new point right before that one instead of right after the 2nd nearest
-        if (largerIndex - smallerIndex !== 1 && smallerIndex !== nearestIndex) {
-            newIndex = largerIndex - 1;
-        }
-
-        return newIndex;
-    }
-
-    /**
-     * Add a waypoint. If there is one or more existing waypoints, add the waypoint
-     * at the provided index, which should be between the two nearest points to where
-     * the user began the route edit on the linestring.
-     * Adds the new point to the sequence of waypoints + origin and destination points,
-     * which are ordered from origin to destination.
-     *
-     * @param {Object} itinerary CAC.Routing.Itinerary object with waypoint to move
-     * @param {array} newWaypoint coordinates as [lat, lng] for waypoint to add
-     * @param {number} newWaypointIndex Offset where new waypoint should be added in the
-     *                 ordered list of waypoints
-     */
-    function addWaypoint(itinerary, newWaypoint, newWaypointIndex) {
-
-        // note that it is important to not mutate itinerary.waypoints here
-        var waypoints = itinerary.waypoints;
-
-        if (!waypoints || !waypoints.length) {
-            // first waypoint added; no need to interpolate with existing waypoints
-            return [newWaypoint];
-        }
-
-        // extract the coordinates for the existing waypoints
-        var coordinates = _.map(waypoints, function(waypoint) {
-            return _.map([waypoint.geometry.coordinates[1],
-                         waypoint.geometry.coordinates[0]],
-                         parseFloat);
-        });
-
-        // insert new waypoint into ordered points list
-        coordinates = _.concat(_.slice(coordinates, 0, newWaypointIndex),
-                               [newWaypoint],
-                               _.slice(coordinates, newWaypointIndex));
-
-        return coordinates;
-    }
-
-    function setAddedWaypoint(itinerary, newWaypoint, newWaypointIndex) {
-        var waypoints = addWaypoint(itinerary, newWaypoint, newWaypointIndex);
-        // ensure all itinerary layers are removed from the map
-        removeItineraryLayers();
-        // requery with the changed points as waypoints
-        events.trigger(eventNames.waypointsSet, {waypoints: waypoints});
-    }
-
-    /**
-     * Helper to get updated list of waypoints on waypoint drag or drag end.
-     *
-     * @param {Object} itinerary CAC.Routing.Itinerary object with waypoint to move
-     * @param {integer} waypointIndex offset of waypoint to move
-     * @param {array} newCoordinates [lat, lng] of new location for the waypoint
-     */
-    function updateWaypointList(itinerary, waypointIndex, newCoordinates) {
-
-        // note that it is important to not mutate itinerary.waypoints here
-        var waypoints = itinerary.waypoints;
-
-        // should not happen, but sanity-check for waypoint indexing
-        if (!waypoints || waypoints.length <= waypointIndex) {
-            console.error('Could not find waypoint to move');
-            return;
-        }
-
-        // extract the coordinates for the existing waypoints,
-        // exchanging for new coordinates on moved waypoint
-        return _.map(waypoints, function(waypoint, index) {
-            if (index === waypointIndex) {
-                return newCoordinates;
-            } else {
-                return _.map([waypoint.geometry.coordinates[1],
-                             waypoint.geometry.coordinates[0]],
-                             parseFloat);
-            }
-        });
-    }
-
-    /**
-     * Move an existing waypoint on an itinerary.
-     *
-     * @param {Object} itinerary CAC.Routing.Itinerary object with waypoint to move
-     * @param {integer} waypointIndex offset of waypoint to move
-     * @param {array} newCoordinates [lat, lng] of new location for the waypoint
-     */
-    function moveWaypoint(itinerary, waypointIndex, newCoordinates) {
-        if (liveUpdatingItinerary) {
-            liveUpdatingItinerary = false;
-        }
-        var coordinates = updateWaypointList(itinerary, waypointIndex, newCoordinates);
-
-        // ensure all itinerary layers are removed from the map
-        removeItineraryLayers();
-
-        // requery with the changed points as waypoints
-        events.trigger(eventNames.waypointsSet, {waypoints: coordinates});
-    }
-
-    /**
-     * Remove a waypoint from an itinerary.
-     *
-     * @param {Object} itinerary CAC.Routing.Itinerary object with waypoint to remove
-     * @param {integer} waypointIndex offset of waypoint to remove from itinerary
-     */
-    function removeWaypoint(itinerary, waypointIndex) {
-        // should not happen, but sanity-check for waypoint indexing
-        if (!itinerary.waypoints || itinerary.waypoints.length <= waypointIndex) {
-            console.error('Could not find waypoint to remove');
-            return;
-        }
-
-        // remove waypoint from ordered points list
-        itinerary.waypoints.splice(waypointIndex, 1);
-
-        // extract the coordinates for the existing waypoints
-        var coordinates = _.map(itinerary.waypoints, function(waypoint) {
-            return waypoint.geometry.coordinates.reverse();
-        });
-
-        // requery with the changed points as waypoints
-        events.trigger(eventNames.waypointsSet, {waypoints: coordinates});
-    }
-
-    function updateItineraryLayer(oldLayer, newItinerary) {
-        // If flag is false, dragged marker was released before this event could fire.
-        // Remove the old layer and do not add the new one.
-        if (!liveUpdatingItinerary) {
-            map.removeLayer(oldLayer);
-            return;
-        }
-
-        map.removeLayer(oldLayer);
-        newItinerary.geojson.addTo(map);
-        itineraries[newItinerary.id] = newItinerary;
-        liveUpdatingItinerary = false;
-    }
-
-    function errorLiveUpdatingLayer() {
-        liveUpdatingItinerary = false;
-    }
-
-    function clearItineraries() {
-        clearWaypointInteractivity();
-        _.forIn(itineraries, function (itinerary) {
-            map.removeLayer(itinerary.geojson);
-        });
-        itineraries = {};
-    }
-
-    /**
-     * Remove all itinerary map layers by inspecting for the GeoJSON `from` property.
-     *
-     * TODO: find better way to handle potential race conditions with live updating,
-     * which mean itinerary layers cannot be reliably removed by using the dictionary of
-     * itineraries stored in the map control during or on end of waypoint drag.
-     */
-    function removeItineraryLayers() {
-        map.eachLayer(function(layer) {
-            if (layer.feature && layer.feature.properties && layer.feature.properties.from) {
-                map.removeLayer(layer);
-            }
-        });
-    }
-
-    function clearWaypointInteractivity() {
-        if (waypointsLayer) {
-            map.removeLayer(waypointsLayer);
-            waypointsLayer = null;
-        }
-
-        if (lastItineraryHoverMarker) {
-            map.removeLayer(lastItineraryHoverMarker);
-            lastItineraryHoverMarker = null;
-        }
-
-        _.forIn(itineraries, function (itinerary) {
-            itinerary.geojson.off('mouseover', itineraryHoverListener);
-        });
     }
 
     function setGeocodeMarker(latLng) {

--- a/src/app/scripts/cac/map/cac-map-isochrone.js
+++ b/src/app/scripts/cac/map/cac-map-isochrone.js
@@ -1,0 +1,288 @@
+CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
+    'use strict';
+
+    var defaults = {
+        selectors: {
+            destinationPopup: '.destination-directions-link'
+        }
+    };
+
+    var map = null;
+    var tabControl = null;
+
+    var events = $({});
+    var eventNames = {
+        destinationPopupClick: 'cac:map:control:destinationpopup',
+    };
+
+    var isochroneLayer = null;
+    var destinationMarkers = {};
+    var destinationsLayer = null;
+    var lastHighlightedMarker = null;
+    var destinationIcon = L.AwesomeMarkers.icon({
+        icon: 'beenhere',
+        prefix: 'md',
+        markerColor: 'green'
+    });
+    var highlightIcon = L.AwesomeMarkers.icon({
+        icon: 'beenhere',
+        prefix: 'md',
+        iconColor: 'black',
+        markerColor: 'lightgreen'
+    });
+
+
+    /**
+     * Variables used for limiting to one isochrone request at a time.
+     * Unlike the planTrip request, the isochrone request cannot be handled
+     * solely via debounce, due to differences in the way the isochrone
+     * request flows through the system. There are actions that take place
+     * on this module (drawing the isochrone on the map), and then actions
+     * that take place on the sidebar module (generating the destinations),
+     * so doing the limiting correctly is more of a challenge.
+     */
+    var activeIsochroneRequest = null;
+    var pendingIsochroneRequest = null;
+
+    function IsochroneControl(options) {
+        this.events = events;
+        this.eventNames = eventNames;
+
+        this.options = $.extend({}, defaults, options);
+        map = options.map;
+        tabControl = options.tabControl;
+
+        // set listener for click event on destination popup
+        $('#' + this.options.id).on('click', this.options.selectors.destinationPopup, function(event) {
+            events.trigger(eventNames.destinationPopupClick,
+                           destinationMarkers[event.currentTarget.id].destination);
+        });
+    }
+
+    IsochroneControl.prototype.clearIsochrone = clearIsochrone;
+    IsochroneControl.prototype.fetchIsochrone = fetchIsochrone;
+    IsochroneControl.prototype.drawDestinations = drawDestinations;
+    IsochroneControl.prototype.highlightDestination = highlightDestination;
+
+    return IsochroneControl;
+
+
+    /**
+     * Add isochrone outline to map
+     */
+    function drawIsochrone(isochrone, zoomToFit) {
+        try {
+            isochroneLayer = cartodb.L.geoJson(isochrone, {
+                clickable: false,
+                style: {
+                    clickable: false,
+                    color: '#5c2482',
+                    fillColor: '#5c2482',
+                    lineCap: 'round',
+                    lineJoin: 'round',
+                    opacity: 0.4,
+                    fillOpacity: 0.3,
+                    stroke: true,
+                    weight: 2
+                }
+            });
+        } catch (err) {
+            console.error('isochrone layer failed to load from GeoJSON');
+            console.error(err);
+            isochroneLayer = null;
+        }
+
+        if (isochroneLayer) {
+            isochroneLayer.addTo(map);
+            if (zoomToFit) {
+                map.fitBounds(isochroneLayer.getBounds());
+            }
+        }
+    }
+
+    /**
+     * Fetch all the reachable destinations within our destination database,
+     * and their enclosing isochrone (travelshed).
+     *
+     * @return {Object} Promise resolving to JSON with 'matched' and 'isochrone' properties
+     */
+    function fetchReachable(payload) {
+        var isochroneUrl = '/map/reachable';
+        var deferred = $.Deferred();
+        $.ajax({
+            type: 'GET',
+            data: payload,
+            cache: false,
+            url: isochroneUrl,
+            contentType: 'application/json'
+        }).then(deferred.resolve);
+        return deferred.promise();
+    }
+
+    /**
+     * Makes an isochrone request. Only allows one isochrone request at a time.
+     * If another request comes in while one is active, the results of the active
+     * request will be discarded upon completion, and the new query issued.
+     *
+     * @param {Deferred} A jQuery Deferred object used for resolution
+     * @param {Object} Parameters to be sent along with the request
+     * @param {boolean} Whether to pan/zoom map to fit returned isochrone
+     */
+    function getIsochrone(deferred, params, zoomToFit) {
+        // Check if there's already an active request. If there is one,
+        // then we can't make a query yet -- store it as pending.
+        // If there was already a pending query, immediately resolve it.
+        if (activeIsochroneRequest) {
+            if (pendingIsochroneRequest) {
+                pendingIsochroneRequest.deferred.resolve();
+            }
+            pendingIsochroneRequest = { deferred: deferred, params: params, zoomToFit: zoomToFit };
+            return;
+        }
+
+        // Set the active isochrone request and make query
+        activeIsochroneRequest = { deferred: deferred, params: params, zoomToFit: zoomToFit };
+        fetchReachable(params).then(function(data) {
+            activeIsochroneRequest = null;
+            if (pendingIsochroneRequest) {
+                // These results are already out of date. Don't display them, and instead
+                // send off the pending request.
+                deferred.resolve();
+
+                var pending = pendingIsochroneRequest;
+                pendingIsochroneRequest = null;
+                getIsochrone(pending.deferred, pending.params, zoomToFit);
+                return;
+            }
+
+            if (!tabControl.isTabShowing('explore')) {
+                // if user has switched away from the explore tab, do not show results
+                deferred.resolve();
+                return;
+            }
+            drawIsochrone(data.isochrone, zoomToFit);
+            // also draw 'matched' list of locations
+            drawDestinations(data.matched);
+            deferred.resolve(data.matched);
+        }, function(error) {
+            activeIsochroneRequest = null;
+            pendingIsochroneRequest = null;
+            console.error(error);
+        });
+    }
+
+    /**
+     * Get travelshed and destinations within it, then display results on map.
+    */
+    function fetchIsochrone(coordsOrigin, when, exploreMinutes, otpParams, zoomToFit) {
+        var deferred = $.Deferred();
+        // clear results of last search
+        clearDiscoverPlaces();
+
+        var formattedTime = when.format('hh:mma');
+        var formattedDate = when.format('YYYY/MM/DD');
+
+        var params = {
+            time: formattedTime,
+            date: formattedDate,
+            cutoffSec: exploreMinutes * 60 // API expects seconds
+        };
+
+        // Default precision of 200m; 100m seems good for improving response times on non-transit
+        // http://dev.opentripplanner.org/apidoc/0.12.0/resource_LIsochrone.html
+        if (otpParams.mode === 'WALK' || otpParams.mode === 'BICYCLE') {
+            params.precisionMeters = 100;
+        }
+
+        params = $.extend(otpParams, params);
+
+        if (coordsOrigin) {
+            params.fromPlace = coordsOrigin.join(',');
+            getIsochrone(deferred, params, zoomToFit);
+        }
+
+        return deferred.promise();
+    }
+
+    /**
+     * Draw an array of geojson destination points onto the map
+     */
+    function drawDestinations(matched) {
+        // put destination details onto point geojson object's properties
+        // build map of unconverted destination objects
+        var destinations = {};
+        var locationGeoJSON = _.map(matched, function(destination) {
+            destinations[destination.id] = destination;
+            var point = _.property('point')(destination);
+            point.properties = _.omit(destination, 'point');
+            return point;
+        });
+        destinationMarkers = {};
+        destinationsLayer = cartodb.L.geoJson(locationGeoJSON, {
+            pointToLayer: function (geojson, latLng) {
+                var popupTemplate = ['<h4>{{geojson.properties.name}}</h4>',
+                                     '<div class="destination-description">',
+                                    // HTML-formatted description
+                                     geojson.properties.description,
+                                     '</div>',
+                                     '<a href="{{geojson.properties.website_url}}" ',
+                                     'target="_blank">{{geojson.properties.website_url}}</a>',
+                                     '<a class="destination-directions-link pull-right" ',
+                                     'id="{{geojson.properties.id}}">Get Directions</a>'
+                                    ].join('');
+                var template = Handlebars.compile(popupTemplate);
+                var popupContent = template({geojson: geojson});
+                var markerId = geojson.properties.id;
+                var marker = new cartodb.L.marker(latLng, {icon: destinationIcon})
+                        .bindPopup(popupContent);
+                destinationMarkers[markerId] = {
+                    marker: marker,
+                    destination: destinations[geojson.properties.id]
+                };
+                return marker;
+            }
+        }).addTo(map);
+    }
+
+    function highlightDestination(destinationId, opts) {
+        var defaults = {
+            panTo: false
+        };
+        var options = $.extend({}, defaults, opts);
+        if (!destinationId) {
+            // revert to original marker if set
+            if (lastHighlightedMarker) {
+                lastHighlightedMarker.setIcon(destinationIcon);
+            }
+            return;
+        }
+        // Update icon for passed destination
+        var marker = destinationMarkers[destinationId].marker;
+        marker.setIcon(highlightIcon);
+        if (options.panTo) {
+            map.panTo(marker.getLatLng());
+        }
+        lastHighlightedMarker = marker;
+    }
+
+    /**
+     * Remove layers for isochrone and destinations within it.
+     */
+    function clearDiscoverPlaces() {
+        clearDestinations();
+        clearIsochrone();
+    }
+
+    function clearDestinations() {
+        if (destinationsLayer) {
+            map.removeLayer(destinationsLayer);
+        }
+    }
+
+    function clearIsochrone() {
+        if (isochroneLayer) {
+            map.removeLayer(isochroneLayer);
+        }
+    }
+
+})(jQuery, Handlebars, cartodb, L, turf, _);

--- a/src/app/scripts/cac/map/cac-map-itinerary.js
+++ b/src/app/scripts/cac/map/cac-map-itinerary.js
@@ -1,0 +1,431 @@
+CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
+    'use strict';
+
+    var map = null;
+    var itineraries = {};
+
+    var events = $({});
+    var eventNames = {
+        waypointMoved: 'cac:map:control:waypointmoved',
+        waypointsSet: 'cac:map:control:waypointsset'
+    };
+    var lastItineraryHoverMarker = null;
+    var itineraryHoverListener = null;
+    var liveUpdatingItinerary = false; // true when live update request sent but not completed
+    var waypointsLayer = null;
+
+    var waypointRadius = 6;
+    var waypointColor = '#444';
+    var waypointCircle = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" ' +
+        'width="' + waypointRadius * 2 + '" height="' + waypointRadius * 2 + '">' +
+        '<circle cx="' + waypointRadius + '" cy="' + waypointRadius +
+        '" r="' + waypointRadius + '" fill="' + waypointColor + '"/></svg>';
+    var waypointIcon = L.icon( {
+        iconUrl: 'data:image/svg+xml;base64,' + btoa(waypointCircle),
+        iconSize: [waypointRadius * 2, waypointRadius * 2],
+        iconAnchor: [waypointRadius, waypointRadius],
+        popupAnchor: [0, -2 - waypointRadius]
+    } );
+
+    function ItineraryControl(options) {
+        this.events = events;
+        this.eventNames = eventNames;
+        map = options.map;
+    }
+
+    ItineraryControl.prototype.plotItinerary = plotItinerary;
+    ItineraryControl.prototype.clearItineraries = clearItineraries;
+    ItineraryControl.prototype.clearWaypointInteractivity = clearWaypointInteractivity;
+    ItineraryControl.prototype.draggableItinerary = draggableItinerary;
+    ItineraryControl.prototype.updateItineraryLayer = updateItineraryLayer;
+    ItineraryControl.prototype.errorLiveUpdatingLayer = errorLiveUpdatingLayer;
+
+    return ItineraryControl;
+
+
+    /**
+     * Plots an itinerary on a map, optionally zooming to fit.
+     *
+     * @param {Object} itinerary CAC.Routing.Itinerary object with geojson to draw
+     * @param {Boolean} makeFit If true, zoom to fit itinerary in view
+     */
+    function plotItinerary(itinerary, makeFit) {
+        itineraries[itinerary.id] = itinerary;
+        var layer = itinerary.geojson.addTo(map);
+        if (makeFit) {
+            map.fitBounds(layer.getBounds());
+        }
+    }
+
+    /**
+     * Add listeners to an itinerary map layer to make it draggable.
+     *
+     * @param {Object} itinerary CAC.Routing.Itinerary object to be made draggable
+     */
+    function draggableItinerary(itinerary) {
+        clearWaypointInteractivity();
+
+        /**
+         * Show a draggable marker on the route line that adds a waypoint when released.
+         * Throttles calls to the trip planner for live updates; fires event when live update done.
+         *
+         * @param {object} event Leaflet drag event (that has coordinates on it)
+         * @param {integer} index Offset of waypoint to add or move within ordered waypoint list
+         * @param {boolean} isNew Whether this is a new waypoint to add, or move existing if false
+         */
+        var redrawWaypointDrag = _.throttle(function(event, index, isNew) { // jshint ignore:line
+            if (liveUpdatingItinerary) {
+                return; // do not send another request if one already in progress
+            }
+
+            liveUpdatingItinerary = true;
+            var coords = event.target.getLatLng();
+            var lastItinerary = itineraries[itinerary.id];
+            var waypoints;
+            if (isNew) {
+                // adding new waypoint
+                waypoints = addWaypoint(lastItinerary, [coords.lat, coords.lng], index);
+            } else {
+                // dragging existing waypoint
+                waypoints = updateWaypointList(lastItinerary, index, [coords.lat, coords.lng]);
+            }
+            lastItinerary.routingParams.extraOptions.waypoints = waypoints;
+            events.trigger(eventNames.waypointMoved, lastItinerary);
+        }, 800, {leading: true, trailing: true});
+
+        // Leaflet listeners are removed by reference, so retain a reference to the
+        // listener function to be able to turn it off later.
+        itineraryHoverListener = function(e) {
+            if (lastItineraryHoverMarker) {
+                lastItineraryHoverMarker.setLatLng(e.latlng, {draggable: true});
+            } else {
+                // flag if user currently dragging out a new waypoint or not
+                var dragging = false;
+                // index for new waypoint, based on where user began dragging
+                var newWaypointIndex = null;
+                // Use a timeout when closing the popup so it doesn't strobe on extraneous mouseouts
+                var popupTimeout;
+                // The marker closes with a timeout as well, and holding onto it lets us avoid
+                // removing the marker while it's still under the mouse
+                var markerTimeout;
+                lastItineraryHoverMarker = new cartodb.L.Marker(e.latlng, {
+                        draggable: true,
+                        icon: waypointIcon
+                    }).bindPopup('Drag marker to change route', {closeButton: false}
+                    ).on('dragstart', function(e) {
+                        dragging = true;
+                        var pt = e.target.getLatLng();
+                        var startDragPoint = [pt.lng, pt.lat];
+                        newWaypointIndex = getNewWaypointIndex(itinerary, startDragPoint);
+                    }).on('dragend', function(e) {
+                        dragging = false;
+                        // cancel any live route updates queued
+                        redrawWaypointDrag.cancel();
+                        var coords = e.target.getLatLng();
+                        setAddedWaypoint(itinerary, [coords.lat, coords.lng], newWaypointIndex);
+                        newWaypointIndex = null;
+                    }).on('drag', function(event) {
+                        // get itinerary from collection to pick up newer version with
+                        // layer modified by live dragging updates
+                        redrawWaypointDrag(event, newWaypointIndex, true);
+                    }).on('mouseover', function() {
+                        clearTimeout(popupTimeout);
+                        clearTimeout(markerTimeout);
+                        return dragging || this.openPopup();
+                    }).on('mouseout', function() {
+                        // Close popup, but with a slight delay to avoid flickering, and with an
+                        // existence check to avoid errors if the marker has been destroyed
+                        popupTimeout = setTimeout(function() {
+                            if (lastItineraryHoverMarker) {
+                                lastItineraryHoverMarker.closePopup();
+                            }
+                         }, 50);
+
+                        // hide marker after awhile if not dragging
+                        if (!dragging) {
+                            markerTimeout = setTimeout(function() {
+                                if (lastItineraryHoverMarker && !dragging) {
+                                    map.removeLayer(lastItineraryHoverMarker);
+                                    lastItineraryHoverMarker = null;
+                                    dragging = false;
+                                    newWaypointIndex = null;
+                                }
+                            }, 3000);
+                        }
+                    });
+
+                map.addLayer(lastItineraryHoverMarker);
+            }
+        };
+
+        itinerary.geojson.on('mouseover', itineraryHoverListener);
+
+        // add a layer of draggable markers for the existing waypoints
+        if (itinerary.waypoints) {
+            var dragging = false;
+            var popupTimeout;
+            waypointsLayer = cartodb.L.geoJson(turf.featureCollection(itinerary.waypoints), {
+                pointToLayer: function(geojson, latlng) {
+                    var marker = new cartodb.L.marker(latlng, {icon: waypointIcon,
+                                                               draggable: true });
+                    marker.on('dragstart', function() {
+                        dragging = true;
+                    }).on('dragend', function(e) {
+                        dragging = false;
+                        // cancel any live route updates queued
+                        redrawWaypointDrag.cancel();
+                        // get itinerary from collection to pick up newer version with
+                        // layer modified by live dragging updates
+                        var coords = e.target.getLatLng();
+                        moveWaypoint(itineraries[itinerary.id],
+                                     geojson.properties.index,
+                                     [coords.lat, coords.lng]);
+                    }).on('click', function() {
+                        removeWaypoint(itinerary, geojson.properties.index);
+                    }).on('drag', function(event) {
+                            redrawWaypointDrag(event, geojson.properties.index, false);
+                    });
+
+            marker.bindPopup('Drag to change or click to remove', {closeButton: false})
+                    .on('mouseover', function () {
+                        clearTimeout(popupTimeout);
+                        return dragging || this.openPopup();
+                    }).on('mouseout', function () {
+                        // Close popup, but with a slight delay to avoid flickering, and with an
+                        // existence check to avoid errors if the marker has been destroyed
+                        popupTimeout = setTimeout(function() {
+                            if (marker) {
+                                marker.closePopup();
+                            }
+                        }, 50);
+                    });
+                    return marker;
+                }
+            }).addTo(map);
+        }
+
+        // Explicitly bring selected layer to foreground.
+        // Fixes issue with Firefox inconsistently adding/removing interactivity
+        // when there are multiple overlapping itinerary paths.
+        itinerary.geojson.bringToFront();
+    }
+
+    function getNewWaypointIndex(itinerary, startDragPoint) {
+        var waypoints = itinerary.waypoints;
+
+        if (!waypoints || !waypoints.length) {
+            return 0;
+        }
+
+        var originPoint = turf.point([itinerary.from.lon, itinerary.from.lat], {index: -1});
+        var destPoint = turf.point([itinerary.to.lon, itinerary.to.lat], {index: waypoints.length});
+
+        var allFeatures = _.concat([originPoint], waypoints, [destPoint]);
+
+        var turfPoint = turf.point(startDragPoint);
+        var nearest = turf.nearest(turfPoint, turf.featureCollection(allFeatures));
+
+        var nearestIndex = nearest.properties.index;
+
+        // drop the nearest point to repeat search, in order to find next nearest
+        var remainingFeatures = _.concat(_.slice(allFeatures, 0, nearestIndex),
+                                       _.slice(allFeatures, nearestIndex + 1));
+
+        var nextNearest = turf.nearest(turfPoint, turf.featureCollection(remainingFeatures));
+
+        var nextNearestIndex = nextNearest.properties.index;
+
+        // determine the sequence ordering of the two nearest points, so the new point can
+        // be added between them
+        var smallerIndex = Math.min(nearestIndex, nextNearestIndex);
+        var largerIndex = Math.max(nearestIndex, nextNearestIndex);
+        var newIndex = smallerIndex + 1;
+
+        // If the nearest two points aren't in sequence and the larger indexed one is closer,
+        // put the new point right before that one instead of right after the 2nd nearest
+        if (largerIndex - smallerIndex !== 1 && smallerIndex !== nearestIndex) {
+            newIndex = largerIndex - 1;
+        }
+
+        return newIndex;
+    }
+
+    /**
+     * Add a waypoint. If there is one or more existing waypoints, add the waypoint
+     * at the provided index, which should be between the two nearest points to where
+     * the user began the route edit on the linestring.
+     * Adds the new point to the sequence of waypoints + origin and destination points,
+     * which are ordered from origin to destination.
+     *
+     * @param {Object} itinerary CAC.Routing.Itinerary object with waypoint to move
+     * @param {array} newWaypoint coordinates as [lat, lng] for waypoint to add
+     * @param {number} newWaypointIndex Offset where new waypoint should be added in the
+     *                 ordered list of waypoints
+     */
+    function addWaypoint(itinerary, newWaypoint, newWaypointIndex) {
+
+        // note that it is important to not mutate itinerary.waypoints here
+        var waypoints = itinerary.waypoints;
+
+        if (!waypoints || !waypoints.length) {
+            // first waypoint added; no need to interpolate with existing waypoints
+            return [newWaypoint];
+        }
+
+        // extract the coordinates for the existing waypoints
+        var coordinates = _.map(waypoints, function(waypoint) {
+            return _.map([waypoint.geometry.coordinates[1],
+                         waypoint.geometry.coordinates[0]],
+                         parseFloat);
+        });
+
+        // insert new waypoint into ordered points list
+        coordinates = _.concat(_.slice(coordinates, 0, newWaypointIndex),
+                               [newWaypoint],
+                               _.slice(coordinates, newWaypointIndex));
+
+        return coordinates;
+    }
+
+    function setAddedWaypoint(itinerary, newWaypoint, newWaypointIndex) {
+        var waypoints = addWaypoint(itinerary, newWaypoint, newWaypointIndex);
+        // ensure all itinerary layers are removed from the map
+        removeItineraryLayers();
+        // requery with the changed points as waypoints
+        events.trigger(eventNames.waypointsSet, {waypoints: waypoints});
+    }
+
+    /**
+     * Helper to get updated list of waypoints on waypoint drag or drag end.
+     *
+     * @param {Object} itinerary CAC.Routing.Itinerary object with waypoint to move
+     * @param {integer} waypointIndex offset of waypoint to move
+     * @param {array} newCoordinates [lat, lng] of new location for the waypoint
+     */
+    function updateWaypointList(itinerary, waypointIndex, newCoordinates) {
+
+        // note that it is important to not mutate itinerary.waypoints here
+        var waypoints = itinerary.waypoints;
+
+        // should not happen, but sanity-check for waypoint indexing
+        if (!waypoints || waypoints.length <= waypointIndex) {
+            console.error('Could not find waypoint to move');
+            return;
+        }
+
+        // extract the coordinates for the existing waypoints,
+        // exchanging for new coordinates on moved waypoint
+        return _.map(waypoints, function(waypoint, index) {
+            if (index === waypointIndex) {
+                return newCoordinates;
+            } else {
+                return _.map([waypoint.geometry.coordinates[1],
+                             waypoint.geometry.coordinates[0]],
+                             parseFloat);
+            }
+        });
+    }
+
+    /**
+     * Move an existing waypoint on an itinerary.
+     *
+     * @param {Object} itinerary CAC.Routing.Itinerary object with waypoint to move
+     * @param {integer} waypointIndex offset of waypoint to move
+     * @param {array} newCoordinates [lat, lng] of new location for the waypoint
+     */
+    function moveWaypoint(itinerary, waypointIndex, newCoordinates) {
+        if (liveUpdatingItinerary) {
+            liveUpdatingItinerary = false;
+        }
+        var coordinates = updateWaypointList(itinerary, waypointIndex, newCoordinates);
+
+        // ensure all itinerary layers are removed from the map
+        removeItineraryLayers();
+
+        // requery with the changed points as waypoints
+        events.trigger(eventNames.waypointsSet, {waypoints: coordinates});
+    }
+
+    /**
+     * Remove a waypoint from an itinerary.
+     *
+     * @param {Object} itinerary CAC.Routing.Itinerary object with waypoint to remove
+     * @param {integer} waypointIndex offset of waypoint to remove from itinerary
+     */
+    function removeWaypoint(itinerary, waypointIndex) {
+        // should not happen, but sanity-check for waypoint indexing
+        if (!itinerary.waypoints || itinerary.waypoints.length <= waypointIndex) {
+            console.error('Could not find waypoint to remove');
+            return;
+        }
+
+        // remove waypoint from ordered points list
+        itinerary.waypoints.splice(waypointIndex, 1);
+
+        // extract the coordinates for the existing waypoints
+        var coordinates = _.map(itinerary.waypoints, function(waypoint) {
+            return waypoint.geometry.coordinates.reverse();
+        });
+
+        // requery with the changed points as waypoints
+        events.trigger(eventNames.waypointsSet, {waypoints: coordinates});
+    }
+
+    function updateItineraryLayer(oldLayer, newItinerary) {
+        // If flag is false, dragged marker was released before this event could fire.
+        // Remove the old layer and do not add the new one.
+        if (!liveUpdatingItinerary) {
+            map.removeLayer(oldLayer);
+            return;
+        }
+
+        map.removeLayer(oldLayer);
+        newItinerary.geojson.addTo(map);
+        itineraries[newItinerary.id] = newItinerary;
+        liveUpdatingItinerary = false;
+    }
+
+    function errorLiveUpdatingLayer() {
+        liveUpdatingItinerary = false;
+    }
+
+    function clearItineraries() {
+        clearWaypointInteractivity();
+        _.forIn(itineraries, function (itinerary) {
+            map.removeLayer(itinerary.geojson);
+        });
+        itineraries = {};
+    }
+
+    /**
+     * Remove all itinerary map layers by inspecting for the GeoJSON `from` property.
+     *
+     * TODO: find better way to handle potential race conditions with live updating,
+     * which mean itinerary layers cannot be reliably removed by using the dictionary of
+     * itineraries stored in the map control during or on end of waypoint drag.
+     */
+    function removeItineraryLayers() {
+        map.eachLayer(function(layer) {
+            if (layer.feature && layer.feature.properties && layer.feature.properties.from) {
+                map.removeLayer(layer);
+            }
+        });
+    }
+
+    function clearWaypointInteractivity() {
+        if (waypointsLayer) {
+            map.removeLayer(waypointsLayer);
+            waypointsLayer = null;
+        }
+
+        if (lastItineraryHoverMarker) {
+            map.removeLayer(lastItineraryHoverMarker);
+            lastItineraryHoverMarker = null;
+        }
+
+        _.forIn(itineraries, function (itinerary) {
+            itinerary.geojson.off('mouseover', itineraryHoverListener);
+        });
+    }
+
+})(jQuery, Handlebars, cartodb, L, turf, _);

--- a/src/app/scripts/cac/pages/cac-pages-map.js
+++ b/src/app/scripts/cac/pages/cac-pages-map.js
@@ -86,7 +86,7 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl, UserPreferences
         }
 
         // not a mobile device; go to directions tab
-        mapControl.clearIsochrone();
+        mapControl.isochroneControl.clearIsochrone();
         sidebarDirectionsControl.clearDirections();
         mapControl.setGeocodeMarker(null);
         sidebarDirectionsControl.setDestination(destination);
@@ -116,7 +116,7 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl, UserPreferences
         // Load user preferences on tab switch in order to easily keep the pages in sync
         if (tabId === 'directions') {
             UserPreferences.setPreference('method', 'directions');
-            mapControl.clearIsochrone();
+            mapControl.isochroneControl.clearIsochrone();
             mapControl.setGeocodeMarker(null);
             if (sidebarDirectionsControl) {
                 sidebarDirectionsControl.setFromUserPreferences();

--- a/src/karma/karma-coverage.conf.js
+++ b/src/karma/karma-coverage.conf.js
@@ -35,6 +35,8 @@ module.exports = function(config) {
       'app/scripts/cac/routing/cac-routing-plans.js',
       'app/scripts/cac/urlrouting/cac-urlrouting.js',
       'app/scripts/cac/map/cac-map-control.js',
+      'app/scripts/cac/map/cac-map-isochrone.js',
+      'app/scripts/cac/map/cac-map-itinerary.js',
       'app/scripts/cac/map/cac-map-overlays.js',
       'app/scripts/cac/map/cac-map-templates.js',
       'app/scripts/cac/control/cac-control-bike-mode-options.js',

--- a/src/karma/karma-dev.conf.js
+++ b/src/karma/karma-dev.conf.js
@@ -35,6 +35,8 @@ module.exports = function(config) {
       'app/scripts/cac/routing/cac-routing-plans.js',
       'app/scripts/cac/urlrouting/cac-urlrouting.js',
       'app/scripts/cac/map/cac-map-control.js',
+      'app/scripts/cac/map/cac-map-isochrone.js',
+      'app/scripts/cac/map/cac-map-itinerary.js',
       'app/scripts/cac/map/cac-map-overlays.js',
       'app/scripts/cac/map/cac-map-templates.js',
       'app/scripts/cac/control/cac-control-bike-mode-options.js',


### PR DESCRIPTION
Work-alike refactor to move the isochrone and itinerary functionality of the map into their own controllers, to make the whole setup easier to understand and work with.  They're pretty well self-contained conceptually and the seams in the code were not hard to separate.

This is hard to test on `redesign`, since none of this behavior is wired up yet.  I did the work on `develop` where I could try it out then cherry-picked the finished changes to `redesign` and there was only one conflict (the addition, in `redesign` of `var layerControl = null;` right below some lines I had deleted.  So it might cherry-pick back to `develop` cleanly at the moment.  Or I could push my `develop` branch for reference.
