### PR TITLE
Feature/directions form

### DIFF
--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -27,20 +27,28 @@
             </div>
             <div class="directions-from directions-text-input">
                 <label for="input-directions-from">from</label>
-                <input type="text" id="input-directions-from" name="input-directions-from" value="" placeholder="Enter a starting point">
-                <button class="btn-geolocate" title="Detect current location" type="button" name="geolocate"><i class="icon-geolocate"></i></button>
+                <input type="text" id="input-directions-from" name="input-directions-from"
+                    value="" placeholder="Enter a starting point"
+                    class="typeahead" type="search" data-typeahead-key="from">
+                <button class="btn-geolocate" title="Detect current location" type="button"
+                    name="geolocate"><i class="icon-geolocate"></i></button>
             </div>
             <div class="directions-to directions-text-input">
                 <label for="input-directions-to">to</label>
-                <input type="text" id="input-directions-to" name="input-directions-to" value="" placeholder="Enter a destination — or choose one below">
-                <button class="btn-reverse" title="Swap starting point and destination" type="button" name="reverse"><i class="icon-reverse"></i></button>
+                <input type="text" id="input-directions-to" name="input-directions-to" value=""
+                    placeholder="Enter a destination — or choose one below"
+                    class="typeahead" type="search" data-typeahead-key="to">
+                <button class="btn-reverse" title="Swap starting point and destination"
+                    type="button" name="reverse"><i class="icon-reverse"></i></button>
             </div>
         </div>
     </form>
 
     <div class="sidebar-banner indego-banner">
         <div class="banner-message">Need wheels? Click <i class="icon-sliders"></i> for Indego bike sharing</div>
-        <button title="Dismiss this message" name="close" class="btn-dismiss-sidebar-banner"><i class="icon-cancel"></i></button>
+        <button title="Dismiss this message" name="close"
+            class="btn-dismiss-sidebar-banner"><i class="icon-cancel"></i>
+        </button>
     </div>
 
     <div class="places">

--- a/src/app/scripts/cac/control/cac-control-bike-mode-options.js
+++ b/src/app/scripts/cac/control/cac-control-bike-mode-options.js
@@ -88,7 +88,7 @@ CAC.Control.BikeModeOptions = (function ($) {
         });
 
         // slice off trailing comma
-        mode = mode ? mode.substr(0, mode.length-1) : options.defaultMode;
+        mode = mode ? mode.substr(0, mode.length - 1) : options.defaultMode;
         return mode;
     }
 

--- a/src/app/scripts/cac/control/cac-control-bike-mode-options.js
+++ b/src/app/scripts/cac/control/cac-control-bike-mode-options.js
@@ -25,10 +25,12 @@ CAC.Control.BikeModeOptions = (function ($) {
                 triangleTimeFactor: 0.17
             }
         },
+        defaultMode: 'WALK,TRANSIT',
+        // map button class names to OpenTripPlanner mode parameters
         modes: {
-            // used to suffix to mode inputs selector
-            walkBike: ':radio[name="anytime-mode"]',
-            transit: '[name="public-transit-mode"]'
+            walk: 'WALK',
+            bike: 'BICYCLE',
+            transit: 'TRANSIT'
         }
     };
 
@@ -67,12 +69,26 @@ CAC.Control.BikeModeOptions = (function ($) {
     /**
      * Helper to return the mode string based on the buttons within the given input selector.
      *
-     * * @param modeSelectors {String} jQuery selector like '#someId input'
+     * @param modeSelectors {String} jQuery selector like '#someId input'
+     * @returns {String} comma-separated list of OpenTripPlanner mode parameters
      */
     function getMode(modeSelectors) {
-        var mode = $(modeSelectors + options.modes.walkBike + ':checked').val() || 'WALK';
-        var transit = $(modeSelectors + options.modes.transit).prop('checked');
-        mode = transit ? 'TRANSIT,' + mode : mode;
+        var mode = '';
+        var $selected = $(modeSelectors);
+
+        if (!$selected) {
+            console.error('no mode controls found');
+            return options.defaultMode;
+        }
+
+        _.each(options.modes, function(val, key) {
+            if ($selected.hasClass(key)) {
+                mode += val + ',';
+            }
+        });
+
+        // slice off trailing comma
+        mode = mode ? mode.substr(0, mode.length-1) : options.defaultMode;
         return mode;
     }
 

--- a/src/app/scripts/cac/control/cac-control-bike-mode-options.js
+++ b/src/app/scripts/cac/control/cac-control-bike-mode-options.js
@@ -73,23 +73,15 @@ CAC.Control.BikeModeOptions = (function ($) {
      * @returns {String} comma-separated list of OpenTripPlanner mode parameters
      */
     function getMode(modeSelectors) {
-        var mode = '';
         var $selected = $(modeSelectors);
-
         if (!$selected) {
             console.error('no mode controls found');
             return options.defaultMode;
         }
-
-        _.each(options.modes, function(val, key) {
-            if ($selected.hasClass(key)) {
-                mode += val + ',';
-            }
-        });
-
-        // slice off trailing comma
-        mode = mode ? mode.substr(0, mode.length - 1) : options.defaultMode;
-        return mode;
+        var mode = _(options.modes).filter(function(val, key) {
+            return $selected.hasClass(key);
+        }).join(',');
+        return mode || options.defaultMode;
     }
 
     /**

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -58,13 +58,15 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         // put zoom control on top right
         zoomControl = new cartodb.L.Control.Zoom({ position: 'topright' });
 
-        // hide zoom control on home page view
+        initializeBasemaps();
+
         if (!homepage) {
+            // hide zoom control on home page view
             zoomControl.addTo(map);
+            // delay loading overlays
+            initializeOverlays();
         }
 
-        initializeBasemaps();
-        initializeOverlays();
         initializeLayerControl();
 
         this.isochroneControl = new CAC.Map.IsochroneControl({map: map, tabControl: tabControl});
@@ -131,7 +133,8 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         overlays['Bike Share Locations'] = overlaysControl.bikeShareOverlay();
         overlays['Bike Routes'] = overlaysControl.bikeRoutesOverlay(map);
 
-        // TODO: handle hiding layers on home view more cleanly.
+        // TODO: handle hiding layers on home view more cleanly
+        // when user switches back to home view from map view
         // Would be better to initialize but not add to map, to avoid flashing,
         // although it probably won't be visible due to centering of home page text.
         if (homepage) {

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -80,7 +80,8 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
         if ($(options.selectors.directionsFrom).hasClass(options.selectors.errorClass) ||
             $(options.selectors.directionsTo).hasClass(options.selectors.errorClass)) {
 
-            console.error('error! danger will robinson!');
+            // TODO: update or remove error modals
+            console.error('error with origin or destination');
             //$(options.selectors.submitErrorModal).modal();
             return;
         }
@@ -95,6 +96,7 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
                 .removeClass(options.selectors.homePageClass)
                 .addClass(options.selectors.mapPageClasses);
         } else {
+            // TODO: update or remove error modals
             //$(options.selectors.submitErrorModal).modal();
             console.error('missing origin or destination.');
         }

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -3,15 +3,23 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
 
     var defaults = {
         selectors: {
-            articlesContainer: '.articles',
-            articlesSpinner: '#articlesSpinner',
-            destinationBlock: '.block-destination',
-            destinationsContainer: '.destinations',
-            destinationsSpinner: '#destinationsSpinner',
-            directionsForm: '#directions',
-            directionsFrom: '#directionsFrom',
+            placeCard: '.place-card',
+            placeList: '.place-list',
+
+            // directions form selectors
+            directionsForm: '.directions-form-element',
+            directionsFrom: '.directions-from',
+            directionsTo: '.directions-to',
+
+            // mode related selectors
+            modeToggle: '.mode-toggle',
+            modeOption: '.mode-option',
+            transitModeOption: '.mode-option.transit',
+            onClass: 'on',
+            offClass: 'off',
+            transitIconOnOffClasses: 'icon-transit-on icon-transit-off',
+
             directionsMode: '#directionsMode input',
-            directionsTo: '#directionsTo',
             errorClass: 'error',
             exploreForm: '#explore',
             exploreMode: '#exploreMode input',
@@ -127,6 +135,20 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
             tabControl: sidebarTabControl
         });
 
+        // handle mode toggle buttons
+        $(options.selectors.modeToggle).on('click', options.selectors.modeOption, function(e) {
+            $(this).toggleClass(options.selectors.onClass)
+                .siblings(options.selectors.modeOption).toggleClass(options.selectors.onClass);
+            e.preventDefault();
+        });
+
+        $(options.selectors.transitModeOption).on('click', function(e) {
+            $(this).toggleClass(options.selectors.onClass + ' ' + options.selectors.offClass)
+                .find('i').toggleClass(options.selectors.transitIconOnOffClasses);
+            e.preventDefault();
+        });
+
+        // TODO: update below for redesign
         this.destinations = null;
         $(options.selectors.toggleButton).on('click', function(){
             var id = $(this).attr('id');
@@ -146,7 +168,7 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
         $(options.selectors.directionsForm).submit(submitDirections);
 
         $(options.selectors.viewAllDestinations).click($.proxy(clickedViewAllDestinations, this));
-        $(options.selectors.destinationsContainer).on('click', options.selectors.destinationBlock,
+        $(options.selectors.placeList).on('click', options.selectors.placeCard,
                                                       $.proxy(clickedDestination, this));
 
         $(document).ready(loadFromPreferences);
@@ -158,7 +180,7 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
         event.preventDefault();
 
         // hide existing destinations list and show loading spinner
-        $(options.selectors.destinationsContainer).addClass('hidden');
+        $(options.selectors.placeList).addClass('hidden');
         $(options.selectors.destinationsSpinner).removeClass('hidden');
 
         var origin = UserPreferences.getPreference('origin');
@@ -176,15 +198,15 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
         }).then(function(data) {
             if (data.destinations && data.destinations.length) {
                 var html = Templates.destinations(data.destinations);
-                $(options.selectors.destinationsContainer).html(html);
+                $(options.selectors.placeList).html(html);
 
                 // hide 'view all' button and spinner, and show features again
                 $(options.selectors.viewAllDestinations).addClass('hidden');
                 $(options.selectors.destinationsSpinner).addClass('hidden');
-                $(options.selectors.destinationsContainer).removeClass('hidden');
+                $(options.selectors.placeList).removeClass('hidden');
             } else {
                 $(options.selectors.destinationsSpinner).addClass('hidden');
-                $(options.selectors.destinationsContainer).removeClass('hidden');
+                $(options.selectors.placeList).removeClass('hidden');
             }
         });
     }
@@ -200,7 +222,7 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
         UserPreferences.setPreference('exploreTime', exploreTime);
         UserPreferences.setPreference('mode', mode);
 
-        var block = $(event.target).closest(options.selectors.destinationBlock);
+        var block = $(event.target).closest(options.selectors.placeCard);
         var placeId = block.data('destination-id');
         UserPreferences.setPreference('placeId', placeId);
         window.location = '/map';

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -41,10 +41,9 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
             toggleDirectionsButton: '#toggle-directions',
             toggleExploreButton: '#toggle-explore',
             typeaheadExplore: '#exploreOrigin',
-            viewAllDestinations: '#viewAllDestinations'
         }
     };
-    var destinationSearchUrl = '/api/destinations/search';
+
     var options = {};
     var bikeModeOptions = null;
     var typeaheads = {};
@@ -191,7 +190,6 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
         $(options.selectors.exploreForm).submit(submitExplore);
         $(options.selectors.directionsForm).submit(submitDirections);
 
-        $(options.selectors.viewAllDestinations).click($.proxy(clickedViewAllDestinations, this));
         $(options.selectors.placeList).on('click',
                                           options.selectors.placeCard,
                                           $.proxy(clickedDestination, this));
@@ -200,41 +198,6 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
     };
 
     return Home;
-
-    function clickedViewAllDestinations(event) {
-        event.preventDefault();
-
-        // hide existing destinations list and show loading spinner
-        $(options.selectors.placeList).addClass('hidden');
-        $(options.selectors.destinationsSpinner).removeClass('hidden');
-
-        var origin = UserPreferences.getPreference('origin');
-        var payload = {
-            'lat': origin.feature.geometry.y,
-            'lon': origin.feature.geometry.x
-        };
-
-        $.ajax({
-            type: 'GET',
-            data: payload,
-            cache: true,
-            url: destinationSearchUrl,
-            contentType: 'application/json'
-        }).then(function(data) {
-            if (data.destinations && data.destinations.length) {
-                var html = Templates.destinations(data.destinations);
-                $(options.selectors.placeList).html(html);
-
-                // hide 'view all' button and spinner, and show features again
-                $(options.selectors.viewAllDestinations).addClass('hidden');
-                $(options.selectors.destinationsSpinner).addClass('hidden');
-                $(options.selectors.placeList).removeClass('hidden');
-            } else {
-                $(options.selectors.destinationsSpinner).addClass('hidden');
-                $(options.selectors.placeList).removeClass('hidden');
-            }
-        });
-    }
 
     /**
      * When user clicks a destination, look it up, then redirect to its details in 'explore' tab.

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -3,13 +3,14 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
 
     var defaults = {
         selectors: {
+            // destinations
             placeCard: '.place-card',
             placeList: '.place-list',
 
             // directions form selectors
             directionsForm: '.directions-form-element',
-            directionsFrom: '.directions-from',
-            directionsTo: '.directions-to',
+            directionsFromInput: '.directions-from',
+            directionsToInput: '.directions-to',
 
             // mode related selectors
             modeToggle: '.mode-toggle',
@@ -19,6 +20,11 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
             offClass: 'off',
             transitIconOnOffClasses: 'icon-transit-on icon-transit-off',
 
+            // typeahead
+            typeaheadFrom: '#input-directions-from',
+            typeaheadTo: '#input-directions-to',
+
+            // TODO: update below
             directionsMode: '#directionsMode input',
             errorClass: 'error',
             exploreForm: '#explore',
@@ -29,9 +35,9 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
             toggleButton: '.toggle-search button',
             toggleDirectionsButton: '#toggle-directions',
             toggleExploreButton: '#toggle-explore',
+
             typeaheadExplore: '#exploreOrigin',
-            typeaheadFrom: '#directionsFrom',
-            typeaheadTo: '#directionsTo',
+
             viewAllDestinations: '#viewAllDestinations'
         }
     };
@@ -168,8 +174,9 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
         $(options.selectors.directionsForm).submit(submitDirections);
 
         $(options.selectors.viewAllDestinations).click($.proxy(clickedViewAllDestinations, this));
-        $(options.selectors.placeList).on('click', options.selectors.placeCard,
-                                                      $.proxy(clickedDestination, this));
+        $(options.selectors.placeList).on('click',
+                                          options.selectors.placeCard,
+                                          $.proxy(clickedDestination, this));
 
         $(document).ready(loadFromPreferences);
     };

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -9,22 +9,27 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
 
             // directions form selectors
             directionsForm: '.directions-form-element',
-            directionsFromInput: '.directions-from',
-            directionsToInput: '.directions-to',
+            directionsFrom: '.directions-from',
+            directionsTo: '.directions-to',
 
             // mode related selectors
             modeToggle: '.mode-toggle',
             modeOption: '.mode-option',
-            transitModeOption: '.mode-option.transit',
             onClass: 'on',
             offClass: 'off',
+            selectedModes: '.mode-option.on',
             transitIconOnOffClasses: 'icon-transit-on icon-transit-off',
+            transitModeOption: '.mode-option.transit',
 
             // typeahead
             typeaheadFrom: '#input-directions-from',
             typeaheadTo: '#input-directions-to',
 
-            // TODO: update below
+            // top-level classes
+            homePageClass: 'body-home',
+            mapPageClasses: 'body-map body-has-sidebar-banner',
+
+            // TODO: update or remove old selectors below
             directionsMode: '#directionsMode input',
             errorClass: 'error',
             exploreForm: '#explore',
@@ -35,9 +40,7 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
             toggleButton: '.toggle-search button',
             toggleDirectionsButton: '#toggle-directions',
             toggleExploreButton: '#toggle-explore',
-
             typeaheadExplore: '#exploreOrigin',
-
             viewAllDestinations: '#viewAllDestinations'
         }
     };
@@ -57,8 +60,11 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
     }
 
     var submitDirections = function(event) {
-        event.preventDefault();
-        var mode = bikeModeOptions.getMode(options.selectors.directionsMode);
+        if (event) {
+            event.preventDefault();
+        }
+        var mode = bikeModeOptions.getMode(options.selectors.selectedModes);
+
         var origin = UserPreferences.getPreference('originText');
         var destination = UserPreferences.getPreference('destinationText');
 
@@ -74,16 +80,23 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
         if ($(options.selectors.directionsFrom).hasClass(options.selectors.errorClass) ||
             $(options.selectors.directionsTo).hasClass(options.selectors.errorClass)) {
 
-            $(options.selectors.submitErrorModal).modal();
+            console.error('error! danger will robinson!');
+            //$(options.selectors.submitErrorModal).modal();
             return;
         }
 
         if (origin && destination) {
             UserPreferences.setPreference('method', 'directions');
             UserPreferences.setPreference('mode', mode);
-            window.location = '/map';
+
+            // change to map view
+            $('.' + options.selectors.homePageClass)
+                .blur()
+                .removeClass(options.selectors.homePageClass)
+                .addClass(options.selectors.mapPageClasses);
         } else {
-            $(options.selectors.submitErrorModal).modal();
+            //$(options.selectors.submitErrorModal).modal();
+            console.error('missing origin or destination.');
         }
     };
 
@@ -126,6 +139,7 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
         // 'directions' tab options
         var destinationText = UserPreferences.getPreference('destinationText');
         typeaheads.typeaheadFrom.setValue(originText);
+
         typeaheads.typeaheadTo.setValue(destinationText);
         bikeModeOptions.setMode(options.selectors.directionsMode, mode);
     };
@@ -170,6 +184,8 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
         }, this));
 
         // save form data and redirect to map when 'go' button clicked
+
+        // TODO: redesign has form, but no way to submit. remove this?
         $(options.selectors.exploreForm).submit(submitExplore);
         $(options.selectors.directionsForm).submit(submitDirections);
 
@@ -262,7 +278,7 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
             }
         } else if (key === 'to') {
             prefKey = 'destination';
-            $input = $(options.selectors.directionsTo);
+            $input = $(options.selectors.typeaheadTo);
         } else {
             return;
         }
@@ -271,6 +287,8 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
             $input.removeClass(options.selectors.errorClass);
             UserPreferences.setPreference(prefKey, location);
             UserPreferences.setPreference(prefKey + 'Text', $input.typeahead('val'));
+
+            submitDirections(event);
         } else {
             $input.addClass(options.selectors.errorClass);
             UserPreferences.setPreference(prefKey, undefined);

--- a/src/app/scripts/cac/search/cac-typeahead.js
+++ b/src/app/scripts/cac/search/cac-typeahead.js
@@ -30,6 +30,10 @@ CAC.Search.Typeahead = (function (_, $, Geocoder, SearchParams, Utils) {
         selected: 'cac:typeahead:selected'
     };
 
+    var selectors = {
+        geolocate: '.icon-geolocate'
+    };
+
     function CACTypeahead(selector, options) {
         this.options = $.extend({}, defaults, options);
         this.suggestAdapter = suggestAdapterFactory();
@@ -71,11 +75,9 @@ CAC.Search.Typeahead = (function (_, $, Geocoder, SearchParams, Utils) {
                 }
             }, this));
 
-            // Add locator button and wire it up
-            var locatorTemplate = '<i class="fa fa-crosshairs locate-icon"></i>';
-            var $locator = $(locatorTemplate).insertBefore($element);
+            // Wire up locator button
             if ('geolocation' in navigator) {
-                $element.parent().on('click', '.locate-icon', function() {
+                $element.parent().parent().find(selectors.geolocate).on('click', function() {
                     navigator.geolocation.getCurrentPosition(function(pos) {
                         var coords = pos.coords;
                         Geocoder.reverse(coords.latitude, coords.longitude).then(function (data) {
@@ -90,6 +92,9 @@ CAC.Search.Typeahead = (function (_, $, Geocoder, SearchParams, Utils) {
                             }
                         });
 
+                    }, function(error) {
+                        console.error('geolocation error:');
+                        console.error(error);
                     });
                 });
             }
@@ -97,11 +102,9 @@ CAC.Search.Typeahead = (function (_, $, Geocoder, SearchParams, Utils) {
             // Trigger cleared event when user clears the input via keyboard or clicking the x
             $element.on('keyup search change', function() {
                 if ($element.val()) {
-                    $locator.hide();
                 } else {
                     $element.typeahead('close');
                     events.trigger(eventNames.cleared, [typeaheadKey]);
-                    $locator.show();
                 }
             });
         }, this);


### PR DESCRIPTION
Wires up the directions form controls on the home page:
  - Adds back address autocomplete (needs styling; see #571)
  - Wires up new geolocation button
  - Updates handing of mode selection and toggling classes on the new mode buttons
  - Transitions to the map view when both 'from' and 'to' fields completed (does not query for directions)

