### PR TITLE
Closes #547, Closes #548: Implement article card buttons

### DIFF
--- a/python/cac_tripplanner/templates/partials/article-card.html
+++ b/python/cac_tripplanner/templates/partials/article-card.html
@@ -1,5 +1,5 @@
-<a href="{% url 'learn-detail' slug=article.slug %}" class="preview-card-link">
-    <div class="preview-card">
+<div class="preview-card">
+    <a href="{% url 'learn-detail' slug=article.slug %}" class="preview-card-link">
         <img class="preview-photo" src="{{ article.narrow_image.url }}" width="308" height="204"
              alt="{{ article.title }}" />
         <div class="preview-details">
@@ -8,12 +8,10 @@
                 {% if article.content_type == 'tips' %}Tips and Tricks{% endif %}
             </div>
             <h2>{{ article.title }}</h2>
-            <p class="lede">
-                {{ article.teaser|safe }}
-            </p>
-            {% if show_link %}
-                <button class="goto-more-posts" href="{% url 'learn-list' %}">More tips, posts, and announcements</button>
-            {% endif %}
+            {{ article.teaser|safe }}
         </div>
-    </div>
-</a>
+    </a>
+    {% if show_link %}
+    <a class="goto-more-posts" href="{% url 'learn-list' %}">More tips, posts, and announcements</a>
+    {% endif %}
+</div>

--- a/python/cac_tripplanner/templates/partials/article-card.html
+++ b/python/cac_tripplanner/templates/partials/article-card.html
@@ -9,7 +9,7 @@
             </div>
             <h2>{{ article.title }}</h2>
             <p class="lede">
-                {{ article.content|safe }}
+                {{ article.teaser|safe }}
             </p>
             {% if show_link %}
                 <button class="goto-more-posts" href="{% url 'learn-list' %}">More tips, posts, and announcements</button>

--- a/python/cac_tripplanner/templates/partials/article-detail.html
+++ b/python/cac_tripplanner/templates/partials/article-detail.html
@@ -12,8 +12,5 @@
     </aside>
     <section class="info-article-section">
         {{ article.content|safe }}
-        <p class="info-article-p-image-inline">
-            <img class="info-article-image-inline" src="{{ article.narrow_image.url }}" alt="" />
-        </p>
     </section>
 </article>

--- a/python/cac_tripplanner/templates/partials/destination-card.html
+++ b/python/cac_tripplanner/templates/partials/destination-card.html
@@ -1,9 +1,9 @@
-<a href="{% url 'place-detail' pk=destination.pk %}" class="preview-card-link">
-    <div class="preview-card">
+<div class="preview-card">
+    <a href="{% url 'place-detail' pk=destination.pk %}" class="preview-card-link">
         <img class="preview-photo" src="{{ destination.wide_image.url }}" width="308" height="204" alt="{{ destination.name }}" />
         <div class="preview-details">
             <h2>{{ destination.name }}</h2>
             <p class="lede">{{ destination.description|striptags|truncatewords:20 }}</p>
         </div>
-    </div>
-</a>
+    </a>
+</div>

--- a/src/app/styles/components/_preview-card.scss
+++ b/src/app/styles/components/_preview-card.scss
@@ -1,6 +1,6 @@
-.preview-card-link {
-    @include delinkify;
+.preview-card {
     display: flex;
+    position: relative;
     flex: 1 0 auto;
     flex-flow: column nowrap;
     align-items: stretch;
@@ -16,7 +16,8 @@
     }
 }
 
-.preview-card {
+.preview-card-link {
+    @include delinkify;
     display: flex;
     flex: 1 0 auto;
     flex-flow: row nowrap;
@@ -55,6 +56,7 @@
         flex-flow: column nowrap;
         align-items: stretch;
         justify-content: space-between;
+        margin-bottom: 5rem;
     }
 
     .category-heading {
@@ -84,23 +86,30 @@
         font-weight: $font-weight-medium;
         line-height: 1.8;
     }
+}
 
-    .goto-more-posts {
-        @include delinkify;
-        display: block;
-        margin-top: 10px;
-        border: 0;
-        outline: 0;
-        background-color: $gophillygo-orange;
-        font-size: 1.4rem;
-        font-weight: $font-weight-bold;
-        line-height: 2.75;
-        text-align: center;
-        cursor: pointer;
-        appearance: none;
+.goto-more-posts {
+    @include delinkify;
+    position: absolute;
+    bottom: $home-section-padding;
+    right: $home-section-padding;
+    display: block;
+    padding: 0 10px;
+    border: 0;
+    outline: 0;
+    background-color: $gophillygo-orange;
+    font-size: 1.4rem;
+    font-weight: $font-weight-bold;
+    line-height: 2.75;
+    text-align: center;
+    cursor: pointer;
+    appearance: none;
 
-        &:hover {
-            @include button-hover;
-        }
+    @include respond-to('xs') {
+        left: $home-section-padding;
+    }
+
+    &:hover {
+        @include button-hover;
     }
 }

--- a/src/app/styles/components/_preview-card.scss
+++ b/src/app/styles/components/_preview-card.scss
@@ -1,3 +1,5 @@
+$goto-more-button-height: 4rem;
+
 .preview-card {
     display: flex;
     position: relative;
@@ -56,7 +58,7 @@
         flex-flow: column nowrap;
         align-items: stretch;
         justify-content: space-between;
-        margin-bottom: 5rem;
+        margin-bottom: calc(#{$goto-more-button-height} + #{$home-section-padding});
     }
 
     .category-heading {

--- a/src/app/styles/components/_preview-card.scss
+++ b/src/app/styles/components/_preview-card.scss
@@ -93,6 +93,7 @@
     position: absolute;
     bottom: $home-section-padding;
     right: $home-section-padding;
+    left: calc(50% + #{($home-section-padding / 2)});
     display: block;
     padding: 0 10px;
     border: 0;


### PR DESCRIPTION
## Overview

Nested link tags were causing trouble with button clicks. Reworked the HTML structure a bit for preview cards after some discussion with @lederer. See commit log for details, this version is no JS and HTML5 compliant.

Also makes some minor tweaks to the preview card, including showing the teaser html inline (not wrapped in a `<p>` tag) and only show the teaser, not the entire content.

## Demo

![cac-home-link-learn-detail](https://cloud.githubusercontent.com/assets/1818302/19968353/9c744494-a1aa-11e6-8d6d-d4899e4fbc1d.png)
![cac-home-link-learn-large](https://cloud.githubusercontent.com/assets/1818302/19968355/9c79b320-a1aa-11e6-8930-0421db5f0fec.png)
![cac-home-link-learn-list](https://cloud.githubusercontent.com/assets/1818302/19968354/9c765504-a1aa-11e6-9351-14775d1a3986.png)
