### PR TITLE
Closes #581: Fixes place card links

### DIFF
--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -5,6 +5,7 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
         selectors: {
             // destinations
             placeCard: '.place-card',
+            placeCardDirectionsLink: '.place-card .place-action-go',
             placeList: '.place-list',
 
             // directions form selectors
@@ -191,7 +192,7 @@ CAC.Pages.Home = (function ($, BikeModeOptions,  MapControl, Templates, UserPref
         $(options.selectors.directionsForm).submit(submitDirections);
 
         $(options.selectors.placeList).on('click',
-                                          options.selectors.placeCard,
+                                          options.selectors.placeCardDirectionsLink,
                                           $.proxy(clickedDestination, this));
 
         $(document).ready(loadFromPreferences);


### PR DESCRIPTION
Only the buttons in the place card should be clickable,
unlike the article preview card. The rationale for this,
according to @lederer is:

It’s not obvious (to users, nor to us strategically) which of
those actions the default should be. So we don’t
have a default, and require the user to make an explicit choice.