### PR TITLE
Closes #584: Restore and update tests for CMS app

### DIFF
--- a/python/cac_tripplanner/cms/tests.py
+++ b/python/cac_tripplanner/cms/tests.py
@@ -9,106 +9,104 @@ from django.utils.timezone import now
 from cms.models import Article
 
 
-# TODO: re-enable as implemented with redesign
+class ArticleTests(TestCase):
+    def setUp(self):
+        user = User.objects.create_user(username='test-user')
+        test_image = File(open('default_media/square/BartramsGarden.jpg'))
 
-# class ArticleTests(TestCase):
-#     def setUp(self):
-#         user = User.objects.create_user(username='test-user')
-#         test_image = File(open('default_media/square/BartramsGarden.jpg'))
+        common_args = dict(
+            teaser='None',
+            content='None',
+            author=user,
+            narrow_image=test_image,
+            wide_image=test_image
+        )
 
-#         common_args = dict(
-#             teaser='None',
-#             content='None',
-#             author=user,
-#             narrow_image=test_image,
-#             wide_image=test_image
-#         )
+        publish_date = now() - timedelta(hours=1)
 
-#         publish_date = now() - timedelta(hours=1)
+        self.client = Client()
 
-#         self.client = Client()
+        self.unpublished_comm = Article.objects.create(
+            content_type=Article.ArticleTypes.community_profile,
+            title='unpublished-comm',
+            slug='unpublished-comm',
+            **common_args)
+        self.unpublished_tips = Article.objects.create(
+            content_type=Article.ArticleTypes.tips_and_tricks,
+            title='unpublished-tips',
+            slug='unpublished-tips',
+            **common_args)
+        self.published_comm = Article.objects.create(
+            content_type=Article.ArticleTypes.community_profile,
+            publish_date=publish_date,
+            title='published-comm',
+            slug='published-comm',
+            **common_args)
+        self.published_tips = Article.objects.create(
+            content_type=Article.ArticleTypes.tips_and_tricks,
+            publish_date=publish_date,
+            title='published-tips',
+            slug='published-tips',
+            **common_args)
 
-#         self.unpublished_comm = Article.objects.create(
-#             content_type=Article.ArticleTypes.community_profile,
-#             title='unpublished-comm',
-#             slug='unpublished-comm',
-#             **common_args)
-#         self.unpublished_tips = Article.objects.create(
-#             content_type=Article.ArticleTypes.tips_and_tricks,
-#             title='unpublished-tips',
-#             slug='unpublished-tips',
-#             **common_args)
-#         self.published_comm = Article.objects.create(
-#             content_type=Article.ArticleTypes.community_profile,
-#             publish_date=publish_date,
-#             title='published-comm',
-#             slug='published-comm',
-#             **common_args)
-#         self.published_tips = Article.objects.create(
-#             content_type=Article.ArticleTypes.tips_and_tricks,
-#             publish_date=publish_date,
-#             title='published-tips',
-#             slug='published-tips',
-#             **common_args)
+    def test_home_view(self):
+        """Verify that home view includes one article"""
 
-#     def test_home_view(self):
-#         """Verify that home view includes both tips and a community profile"""
-#         url = reverse('home')
-#         response = self.client.get(url)
-#         self.assertContains(response, self.published_comm.slug, count=2, status_code=200)
-#         self.assertContains(response, self.published_tips.slug, count=2, status_code=200)
+        # Delete second published article so random always returns the same item
+        self.published_tips.delete()
 
-#     def test_community_profile_manager(self):
-#         """Test that community profile manager works"""
-#         community_profiles_count = Article.profiles.count()
-#         self.assertEqual(community_profiles_count, 2)
+        url = reverse('home')
+        response = self.client.get(url)
+        self.assertContains(response, 'Places we love', status_code=200)
+        self.assertContains(response, self.published_comm.title, status_code=200)
 
-#         published_community_profiles_count = Article.profiles.published().count()
-#         self.assertEqual(published_community_profiles_count, 1)
+    def test_community_profile_manager(self):
+        """Test that article manager properly filters community articles"""
+        community_profiles_count = Article.profiles.count()
+        self.assertEqual(community_profiles_count, 2)
 
-#         random = Article.profiles.random()
-#         published = Article.profiles.published()[0]
-#         self.assertEqual(random, published)
+        published_community_profiles_count = Article.profiles.published().count()
+        self.assertEqual(published_community_profiles_count, 1)
 
-#     def test_tips_and_tricks_manager(self):
-#         """Test that community profile manager works"""
+        random = Article.profiles.random()
+        published = Article.profiles.published()[0]
+        self.assertEqual(random, published)
 
-#         tips_count = Article.tips.count()
-#         self.assertEqual(tips_count, 2)
+    def test_tips_and_tricks_manager(self):
+        """Test that article manager properly filters tip articles"""
 
-#         published_tips_count = Article.tips.published().count()
-#         self.assertEqual(published_tips_count, 1)
+        tips_count = Article.tips.count()
+        self.assertEqual(tips_count, 2)
 
-#         random = Article.tips.random()
-#         published = Article.tips.published()[0]
-#         self.assertEqual(random, published)
+        published_tips_count = Article.tips.published().count()
+        self.assertEqual(published_tips_count, 1)
 
-#     def test_article_manager(self):
-#         """Test that community profile manager works"""
+        random = Article.tips.random()
+        published = Article.tips.published()[0]
+        self.assertEqual(random, published)
 
-#         published_articles_count = Article.objects.published().count()
-#         self.assertEqual(published_articles_count, 2)
+    def test_article_manager(self):
+        """Test that article manager filters unpublished articles"""
 
-#     def test_community_profile_detail_view(self):
-#         """Test that community profile detail view works"""
-#         url = reverse('community-profile-detail',
-#                       kwargs={'slug': self.published_comm.slug})
-#         response = self.client.get(url)
-#         self.assertContains(response, 'published-comm', status_code=200)
+        published_articles_count = Article.objects.published().count()
+        self.assertEqual(published_articles_count, 2)
 
-#         url = reverse('community-profile-detail',
-#                       kwargs={'slug': self.unpublished_comm.slug})
-#         response_404 = self.client.get(url)
-#         self.assertEqual(response_404.status_code, 404)
+    def test_learn_detail_view(self):
+        """Test that learn detail view works"""
+        url = reverse('learn-detail',
+                      kwargs={'slug': self.published_comm.slug})
+        response = self.client.get(url)
+        self.assertContains(response, 'published-comm', status_code=200)
 
-#     def test_tips_and_tricks_detail_view(self):
-#         """Test that tips and tricks detail view works"""
-#         url = reverse('tips-and-tricks-detail',
-#                       kwargs={'slug': self.published_tips.slug})
-#         response = self.client.get(url)
-#         self.assertContains(response, 'published-tips', status_code=200)
+        url = reverse('learn-detail',
+                      kwargs={'slug': self.unpublished_comm.slug})
+        response_404 = self.client.get(url)
+        self.assertEqual(response_404.status_code, 404)
 
-#         url = reverse('tips-and-tricks-detail',
-#                       kwargs={'slug': self.unpublished_tips.slug})
-#         response_404 = self.client.get(url)
-#         self.assertEqual(response_404.status_code, 404)
+    def test_learn_list_view(self):
+        """Test that learn list view works"""
+        url = reverse('learn-list')
+        response = self.client.get(url)
+
+        self.assertContains(response, self.published_comm.title, status_code=200)
+        self.assertContains(response, self.published_tips.title, status_code=200)


### PR DESCRIPTION
Significant changes:
- Updates `test_home_view` with new conditions based on new UI
- Consolidates the old `test_community_profile_view` and `test_tips_tricks_view` detail/list tests into `test_learn_view` tests since those views were combined.