### PR TITLE
Closes #551: Reimplement JotForms subscribe form in footer

### DIFF
--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -73,6 +73,9 @@
     {% block jsimports %}
 
     <script type="text/javascript" src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+    <script type="text/javascript">
+        jQuery.noConflict(); // because JotForms.
+    </script>
 
     {% if debug %}
 

--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -230,7 +230,7 @@
 
 {%block jspage %}
 <script type="text/javascript">
-//jQuery.noConflict(); // because JotForms.
+jQuery.noConflict(); // because JotForms.
 jQuery(document).ready(function ($) {
     CAC.Settings.fbAppId = '{{ fb_app_id }}';
     CAC.Settings.routingUrl = '{{ routing_url }}';

--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -230,7 +230,6 @@
 
 {%block jspage %}
 <script type="text/javascript">
-jQuery.noConflict(); // because JotForms.
 jQuery(document).ready(function ($) {
     CAC.Settings.fbAppId = '{{ fb_app_id }}';
     CAC.Settings.routingUrl = '{{ routing_url }}';

--- a/python/cac_tripplanner/templates/partials/contact-form.html
+++ b/python/cac_tripplanner/templates/partials/contact-form.html
@@ -9,7 +9,6 @@
     document.ready(function() {
         var selectors = {
             emailAddressBox:  'emailAddress',
-            emailAgreeCheckbox: 'emailAgree',
             emailSubscribeButton: 'emailSubscribe'
         };
 
@@ -19,9 +18,8 @@
         // Check email address entrered and checkbox checked before allowing submission of contact form
         var validateContactForm = function() {
             var emailAddress = document.getElementById(selectors.emailAddressBox).value;
-            var checkedAgree = document.getElementById(selectors.emailAgreeCheckbox).checked;
 
-            if (checkedAgree && emailRegex.test(emailAddress)) {
+            if (emailRegex.test(emailAddress)) {
                 document.getElementById(selectors.emailSubscribeButton).disabled = false;
             } else {
                 document.getElementById(selectors.emailSubscribeButton).disabled = true;
@@ -30,37 +28,24 @@
 
         // contact form validation
         document.getElementById(selectors.emailAddressBox).on('change', validateContactForm);
-        document.getElementById(selectors.emailAgreeCheckbox).on('change', validateContactForm);
+        document.getElementById(selectors.emailAddressBox).on('keyup', validateContactForm);
     });
 </script>
-<div class="contact-form">
-    <div class="container text-center form-group">
-        <h4>Contact Us</h4>
-        <p>Stay up to date on all things GoPhillyGo. Enter your information below to be updated on GoPhillyGo events and featured content from the site.</p><br />
-        <form class="jotform-form" action="https://submit.jotform.us/submit/51094584186159/" method="post"
-            target="_blank" name="form_51094584186159" id="51094584186159" accept-charset="utf-8">
-            <input type="hidden" name="formID" value="51094584186159" />
-            <ul class="list-inline">
-                <li><input class="form-control" type="text" name="q1_firstName"
-                    placeholder="First Name" value=""></li>
-                <li><input class="form-control" type="text" name="q3_lastName"
-                    placeholder="Last Name" value=""></li>
-                <li><input class="form-control" type="text" id="emailAddress"
-                    name="q4_emailAddress" placeholder="Email Address" value=""></li>
-            </ul>
-            <div class="submit">
-                <div class="checkbox">
-                    <label>
-                        <input type="checkbox" id="emailAgree" value=""
-                            name="agree"> I agree to receive emails from GoPhillyGo </label>
-                </div>
-                <br />
-                <input type="submit" id="emailSubscribe" value="subscribe" disabled />
-            </div>
-            <input type="hidden" id="simple_spc" name="simple_spc" value="51094584186159" />
-            <script type="text/javascript">
-                document.getElementById("si" + "mple" + "_spc").value = "51094584186159-51094584186159";
-            </script>
-        </form>
-    </div>
-</div>
+
+
+<h2>Stay up to date</h2>
+<p>
+    Stay up to date on all things GoPhillyGo — events, updates, featured content.
+</p>
+<form class="jotform-form subscribe-form" action="https://submit.jotform.us/submit/51094584186159/"
+      method="post" target="_blank" name="form_51094584186159" id="51094584186159" accept-charset="utf-8">
+    <input type="hidden" name="formID" value="51094584186159" />
+    <input type="hidden" name="q1_firstName" placeholder="First Name" value="">
+    <input type="hidden" name="q3_lastName" placeholder="Last Name" value="">
+    <input id="emailAddress" name="q4_emailAddress" class="subscribe-input" type="text" name="email" value="" placeholder="Your email address">
+    <button id="emailSubscribe" class="subscribe-btn" type="submit" name="subscribe-submit" disabled>Subscribe</button>
+    <input type="hidden" id="simple_spc" name="simple_spc" value="51094584186159" />
+    <script type="text/javascript">
+        document.getElementById("si" + "mple" + "_spc").value = "51094584186159-51094584186159";
+    </script>
+</form>

--- a/python/cac_tripplanner/templates/partials/contact-form.html
+++ b/python/cac_tripplanner/templates/partials/contact-form.html
@@ -25,10 +25,11 @@
                 document.getElementById(selectors.emailSubscribeButton).disabled = true;
             }
         }
+        var debouncedValidate = _.debounce(validateContactForm, 400);
 
         // contact form validation
         document.getElementById(selectors.emailAddressBox).on('change', validateContactForm);
-        document.getElementById(selectors.emailAddressBox).on('keyup', validateContactForm);
+        document.getElementById(selectors.emailAddressBox).on('keyup', debouncedValidate);
     });
 </script>
 

--- a/python/cac_tripplanner/templates/partials/footer.html
+++ b/python/cac_tripplanner/templates/partials/footer.html
@@ -1,13 +1,6 @@
 <footer class="app-footer">
     <div class="footer-subscribe">
-        <h2>Stay up to date</h2>
-        <p>
-            Stay up to date on all things GoPhillyGo — events, updates, featured content.
-        </p>
-        <form class="subscribe-form" action="" method="post">
-            <input class="subscribe-input" type="text" name="email" value="" placeholder="Your email address">
-            <button class="subscribe-btn" type="submit" name="subscribe-submit">Subscribe</button>
-        </form>
+        {% include "partials/contact-form.html" %}
     </div>
     <div class="footer-follow">
         <h2>Follow us</h2>

--- a/src/app/styles/components/_app-footer.scss
+++ b/src/app/styles/components/_app-footer.scss
@@ -92,6 +92,11 @@
         line-height: 2.5;
         text-align: center;
         text-transform: uppercase;
+        cursor: pointer;
+
+        &[disabled], &[disabled]:hover {
+            background-color: lighten($gophillygo-green, 30%);
+        }
     }
 
     .body-map & {


### PR DESCRIPTION
The First/Last name fields were left in, but hidden, to remain
compatible with existing form.

Added email validation on keyup so that the subscribe button
changes state while typing. It felt weird to have to click
out of the input box to enable the subscribe button.

Seemingly no issues with re-enabling jQuery.noConflict().

Added some basic styling for subscribe button disabled state.

## Demo

![cac-jotform-1](https://cloud.githubusercontent.com/assets/1818302/20063214/5c138586-a4d4-11e6-87a0-4cf19afa6445.png)
![cac-jotform-2](https://cloud.githubusercontent.com/assets/1818302/20063215/5c16b008-a4d4-11e6-87ac-3e7fe7ec7e14.png)
