### PR TITLE
Feature/sidebar directions

### DIFF
--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -86,38 +86,6 @@
     <div class="directions-results">
         <h1>Choose a route</h1>
         <div class="routes-list">
-            <div class="route-summary">
-                <svg class="route-summary-path" width="3" height="100%" xmlns="http://www.w3.org/2000/svg">
-                    <line x1="50%" y1="6%" x2="50%" y2="94%" stroke-width="3" stroke="#e23331"></line>
-                </svg>
-                <div class="route-summary-details">
-                    <div class="route-summary-primary-details">
-                        <div class="route-duration">33 <span class="units">min</span></div>
-                        <div class="route-distance">9.1 <span class="units">miles</span></div>
-                        <div class="route-name">via N 10th St</div>
-                    </div>
-                    <div class="route-summary-secondary-details">
-                        <div class="route-start-stop">3:14pm – 3:48pm</div>
-                        <div class="route-modes"><i class="icon-transit"></i><i class="icon-walk"></i></div>
-                    </div>
-                </div>
-            </div>
-            <div class="route-summary">
-                <svg class="route-summary-path" width="3" height="100%" xmlns="http://www.w3.org/2000/svg">
-                    <line x1="50%" y1="6%" x2="50%" y2="94%" stroke-width="3" stroke="#5c99c6" stroke-dasharray="7, 7"></line>
-                </svg>
-                <div class="route-summary-details">
-                    <div class="route-summary-primary-details">
-                        <div class="route-duration">37 <span class="units">min</span></div>
-                        <div class="route-distance">9.6 <span class="units">miles</span></div>
-                        <div class="route-name">via N 8th St</div>
-                    </div>
-                    <div class="route-summary-secondary-details">
-                        <div class="route-start-stop">3:23pm – 4:00pm</div>
-                        <div class="route-modes"><i class="icon-transit"></i><i class="icon-walk"></i></div>
-                    </div>
-                </div>
-            </div>
         </div>
     </div>
 

--- a/src/app/font/fontello/config.json
+++ b/src/app/font/fontello/config.json
@@ -273,6 +273,18 @@
       "search": [
         "icon-indego"
       ]
+    },
+    {
+      "uid": "57a0ac800df728aad61a7cf9e12f5fef",
+      "css": "flag",
+      "code": 62009,
+      "src": "fontawesome"
+    },
+    {
+      "uid": "d7271d490b71df4311e32cdacae8b331",
+      "css": "home",
+      "code": 62016,
+      "src": "fontawesome"
     }
   ]
 }

--- a/src/app/font/fontello/css/gpg-embedded.css
+++ b/src/app/font/fontello/css/gpg-embedded.css
@@ -21,34 +21,34 @@
   }
 }
 */
- 
+
  [class^="icon-"]:before, [class*=" icon-"]:before {
   font-family: "gpg";
   font-style: normal;
   font-weight: normal;
   speak: none;
- 
+
   display: inline-block;
   text-decoration: inherit;
   width: 1em;
   margin-right: .2em;
   text-align: center;
   /* opacity: .8; */
- 
+
   /* For safety - reset parent styles, that can break glyph codes*/
   font-variant: normal;
   text-transform: none;
-     
+
   /* fix buttons height, for twitter bootstrap */
   line-height: 1em;
- 
+
   /* Animation center compensation - margins should be symmetric */
   /* remove if not needed */
   margin-left: .2em;
- 
+
   /* you can be more comfortable with increased icons size */
   /* font-size: 120%; */
- 
+
   /* Uncomment for 3D effect */
   /* text-shadow: 1px 1px 1px rgba(127, 127, 127, 0.3); */
 }
@@ -80,3 +80,5 @@
 .icon-share:before { content: '\f1e0'; } /* '' */
 .icon-facebook:before { content: '\f230'; } /* '' */
 .icon-train:before { content: '\f238'; } /* '' */
+.icon-flag:before { content: '\f239'; } /* '' */
+.icon-home:before { content: '\f240'; } /* '' */

--- a/src/app/font/fontello/css/gpg-ie7-codes.css
+++ b/src/app/font/fontello/css/gpg-ie7-codes.css
@@ -27,3 +27,5 @@
 .icon-share { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xf1e0;&nbsp;'); }
 .icon-facebook { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xf230;&nbsp;'); }
 .icon-train { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xf238;&nbsp;'); }
+.icon-flag { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xf239;&nbsp;'); }
+.icon-home { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xf240;&nbsp;'); }

--- a/src/app/font/fontello/css/gpg-ie7.css
+++ b/src/app/font/fontello/css/gpg-ie7.css
@@ -2,14 +2,14 @@
   font-family: 'gpg';
   font-style: normal;
   font-weight: normal;
- 
+
   /* fix buttons height */
   line-height: 1em;
- 
+
   /* you can be more comfortable with increased icons size */
   /* font-size: 120%; */
 }
- 
+
 .icon-plus { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xe800;&nbsp;'); }
 .icon-bike { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xe801;&nbsp;'); }
 .icon-transit { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xe802;&nbsp;'); }
@@ -38,3 +38,5 @@
 .icon-share { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xf1e0;&nbsp;'); }
 .icon-facebook { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xf230;&nbsp;'); }
 .icon-train { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xf238;&nbsp;'); }
+.icon-flag { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xf239;&nbsp;'); }
+.icon-home { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xf240;&nbsp;'); }

--- a/src/app/font/fontello/css/gpg.css
+++ b/src/app/font/fontello/css/gpg.css
@@ -19,42 +19,42 @@
   }
 }
 */
- 
+
  [class^="icon-"]:before, [class*=" icon-"]:before {
   font-family: "gpg";
   font-style: normal;
   font-weight: normal;
   speak: none;
- 
+
   display: inline-block;
   text-decoration: inherit;
   width: 1em;
   margin-right: .2em;
   text-align: center;
   /* opacity: .8; */
- 
+
   /* For safety - reset parent styles, that can break glyph codes*/
   font-variant: normal;
   text-transform: none;
- 
+
   /* fix buttons height, for twitter bootstrap */
   line-height: 1em;
- 
+
   /* Animation center compensation - margins should be symmetric */
   /* remove if not needed */
   margin-left: .2em;
- 
+
   /* you can be more comfortable with increased icons size */
   /* font-size: 120%; */
- 
+
   /* Font smoothing. That was taken from TWBS */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
- 
+
   /* Uncomment for 3D effect */
   /* text-shadow: 1px 1px 1px rgba(127, 127, 127, 0.3); */
 }
- 
+
 .icon-plus:before { content: '\e800'; } /* '' */
 .icon-bike:before { content: '\e801'; } /* '' */
 .icon-transit:before { content: '\e802'; } /* '' */

--- a/src/app/font/fontello/css/gpg.css
+++ b/src/app/font/fontello/css/gpg.css
@@ -83,3 +83,5 @@
 .icon-share:before { content: '\f1e0'; } /* '' */
 .icon-facebook:before { content: '\f230'; } /* '' */
 .icon-train:before { content: '\f238'; } /* '' */
+.icon-flag:before { content: '\f239'; } /* '' */
+.icon-home:before { content: '\f240'; } /* '' */

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -228,6 +228,8 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
                      .addClass(options.selectors.mapPageClasses);
         }
 
+        mapControl.goToMapPage();
+
         Routing.planTrip(directions.origin, directions.destination, date, params)
         .then(function (itineraries) {
             $(options.selectors.spinner).addClass('hidden');

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -240,7 +240,7 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
             // Add the itineraries to the map, highlighting the first one
             var isFirst = true;
             itineraryControl.clearItineraries();
-            _.forIn(itineraries, function (itinerary) {
+            _.forEach(itineraries, function (itinerary) {
                 itineraryControl.plotItinerary(itinerary, isFirst);
                 itinerary.highlight(isFirst);
                 if (isFirst) {

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -33,6 +33,8 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
             homePageClass: 'body-home',
             mapPageClasses: 'body-map body-has-sidebar-banner',
 
+            itineraryBlock: '.route-summary',
+
             // TODO: update or remove below components (from before refactor)
             bikeTriangleDiv: '#directionsBikeTriangle',
             datepicker: '#datetimeDirections',
@@ -41,8 +43,6 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
             directions: '.directions',
             directionInput: '.direction-input',
             errorClass: 'error',
-            itineraryBlock: '.block-itinerary',
-            itineraryList: 'section.directions .itineraries',
             maxWalkDiv: '#directionsMaxWalk',
             resultsClass: 'show-results',
             spinner: 'section.directions div.sidebar-details > .sk-spinner',
@@ -90,7 +90,7 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
             showBackButton: true,
             showShareButton: true,
             selectors: {
-                container: 'section.directions .directions-list',
+                container: options.selectors.itineraryList,
                 directionItem: '.direction-item',
                 backButton: 'a.back',
                 shareButton: 'a.share'
@@ -99,11 +99,7 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
         directionsListControl.events.on(directionsListControl.eventNames.backButtonClicked,
                                         onDirectionsBackClicked);
 
-        itineraryListControl = new Control.ItineraryList({
-            selectors: {
-                container: 'section.directions .itineraries'
-            }
-        });
+        itineraryListControl = new Control.ItineraryList();
         itineraryListControl.events.on(itineraryListControl.eventNames.itineraryClicked,
                                        onItineraryClicked);
         itineraryListControl.events.on(itineraryListControl.eventNames.itineraryHover,

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -150,8 +150,6 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
 
             // TODO: fix URL routing for redesign
             //updateUrl();  // Still update the URL if they request one-sided directions
-
-            console.error('error getting directions: missing origin and/or destination');
             return;
         }
 

--- a/src/app/scripts/cac/control/cac-control-itinerary-list.js
+++ b/src/app/scripts/cac/control/cac-control-itinerary-list.js
@@ -14,7 +14,8 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates) {
         // Should the share button be shown in the control
         showShareButton: false,
         selectors: {
-            container: '.itineraries'
+            container: '.routes-list',
+            itineraryItem: '.route-summary'
         }
     };
     var options = {};
@@ -53,12 +54,11 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates) {
     function setItineraries(newItineraries) {
         itineraries = newItineraries;
 
-
         // Show the directions div and populate with itineraries
         var html = MapTemplates.itineraryList(itineraries);
         $container.html(html);
-        $('.block-itinerary').on('click', onItineraryClicked);
-        $('.block-itinerary').hover(onItineraryHover);
+        $(options.selectors.itineraryItem).on('click', onItineraryClicked);
+        $(options.selectors.itineraryItem).hover(onItineraryHover);
     }
 
     /**
@@ -102,9 +102,9 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates) {
      * @param {Boolean} show If false, will make all itineraries transparent (hide them)
      */
     function showItineraries(show) {
-        for (var i in itineraries) {
-            itineraries[i].show(show);
-        }
+        _.forEach(itineraries, function(itinerary) {
+            itinerary.show(show);
+        });
     }
 
     function hide() {

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -97,8 +97,23 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
     MapControl.prototype.setDirectionsMarkers = setDirectionsMarkers;
     MapControl.prototype.clearDirectionsMarker = clearDirectionsMarker;
     MapControl.prototype.displayPoint = displayPoint;
+    MapControl.prototype.goToMapPage = goToMapPage;
 
     return MapControl;
+
+    /**
+     * Display map components not shown on the homepage.
+     */
+    function goToMapPage() {
+        if (!homepage) {
+            return; // already on map page; do nothing
+        }
+
+        homepage = false;
+        zoomControl.addTo(map);
+        initializeOverlays();
+        layerControl.addTo(map);
+    }
 
     function initializeBasemaps() {
         var retina = '';

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -235,13 +235,13 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         // Remove comment if icon definitions are abstracted elsewhere
         var originIcon = L.AwesomeMarkers.icon({
             icon: 'home',
-            prefix: 'fa',
+            prefix: 'icon',
             markerColor: 'purple'
         });
 
         var destIcon = L.AwesomeMarkers.icon({
-            icon: 'flag-o',
-            prefix: 'fa',
+            icon: 'flag',
+            prefix: 'icon',
             markerColor: 'red'
         });
 

--- a/src/app/scripts/cac/map/cac-map-itinerary.js
+++ b/src/app/scripts/cac/map/cac-map-itinerary.js
@@ -391,7 +391,7 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
 
     function clearItineraries() {
         clearWaypointInteractivity();
-        _.forIn(itineraries, function (itinerary) {
+        _.forEach(itineraries, function (itinerary) {
             map.removeLayer(itinerary.geojson);
         });
         itineraries = {};
@@ -423,7 +423,7 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
             lastItineraryHoverMarker = null;
         }
 
-        _.forIn(itineraries, function (itinerary) {
+        _.forEach(itineraries, function (itinerary) {
             itinerary.geojson.off('mouseover', itineraryHoverListener);
         });
     }

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -201,23 +201,32 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
 
     // Template for itinerary summaries
     function itineraryList(itineraries) {
-        var source = '{{#each itineraries}}' +
-                '<div class="block block-itinerary" data-itinerary="{{this.id}}">' +
-                    '<div class="trip-numbers">' +
-                        '<div class="trip-duration"> {{this.formattedDuration}}</div>' +
-                        '<div class="trip-distance"> {{this.distanceMiles}} mi</div>' +
-                    '</div>' +
-                    '<div class="trip-details">' +
-                        '{{#each this.modes}}' +
-                            '<div class="direction-icon">' +
-                                ' {{modeIcon this}}' +
-                            '</div>' +
-                        '{{/each}}' +
-                        '<span class="short-description"> via {{this.via}}</span>' +
-                        '<a class="itinerary" data-itinerary="{{this.id}}"> View Directions</a>' +
-                    '</div>' +
-                '</div>' +
-                '{{/each}}';
+        var source = ['{{#each itineraries}}',
+            '<div class="route-summary" data-itinerary="{{this.id}}">',
+            '<svg class="route-summary-path" width="3" height="100%" xmlns="http://www.w3.org/2000/svg">',
+                '<line x1="50%" y1="6%" x2="50%" y2="94%" stroke-width="3" stroke="#e23331"></line>',
+            '</svg>',
+            '<div class="route-summary-details">',
+                '<div class="route-summary-primary-details">',
+                    '<div class="route-duration units">{{this.formattedDuration}}</div>',
+                    '<div class="route-distance">{{this.distanceMiles}}  <span class="units">miles</span></div>',
+                    '<div class="route-name">via {{this.via}}</div>',
+                '</div>',
+                '<div class="route-summary-secondary-details">',
+                    // TODO: add formatted start and end times to itinerary info
+                    '<div class="route-start-stop">3:14pm – 3:48pm</div>',
+                    '<div class="route-modes">',
+                        '{{#each this.modes}}',
+                            ' {{modeIcon this}}',
+                        '{{/each}}',
+                    '</div>',
+                '</div>',
+            '</div>',
+        '</div>{{/each}}'].join('');
+
+        // TODO: split out units from formatted duration to go in separate span
+        //<div class="route-duration">33 <span class="units">min</span></div>',
+
         var template = Handlebars.compile(source);
         var html = template({itineraries: itineraries});
         return html;

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -326,8 +326,9 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
 
         Handlebars.registerHelper('datetime', function(dateTime) {
             // round to the nearest minute
-            var dt = moment(dateTime).add(1, 'minute').startOf('minute');
-            return new Handlebars.SafeString(dt.format('h:m a'));
+            var COEFF = 60000; // to round Unix timestamp to nearest minute
+            var dt = moment(Math.round(dateTime / COEFF) * COEFF);
+            return new Handlebars.SafeString(dt.format('hh:mm A'));
         });
 
         Handlebars.registerHelper('inMiles', function(meters) {

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -214,7 +214,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                 '</div>',
                 '<div class="route-summary-secondary-details">',
                     // TODO: add formatted start and end times to itinerary info
-                    '<div class="route-start-stop">3:14pm – 3:48pm</div>',
+                    '<div class="route-start-stop">{{datetime this.startTime}} – {{datetime this.endTime}}</div>',
                     '<div class="route-modes">',
                         '{{#each this.modes}}',
                             ' {{modeIcon this}}',
@@ -329,7 +329,9 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
         });
 
         Handlebars.registerHelper('datetime', function(dateTime) {
-            return new Handlebars.SafeString(new Date(dateTime).toLocaleTimeString());
+            // round to the nearest minute
+            var dt = moment(dateTime).add(1, 'minute').startOf('minute');
+            return new Handlebars.SafeString(dt.format('h:m a'));
         });
 
         Handlebars.registerHelper('inMiles', function(meters) {

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -213,7 +213,6 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                     '<div class="route-name">via {{this.via}}</div>',
                 '</div>',
                 '<div class="route-summary-secondary-details">',
-                    // TODO: add formatted start and end times to itinerary info
                     '<div class="route-start-stop">{{datetime this.startTime}} – {{datetime this.endTime}}</div>',
                     '<div class="route-modes">',
                         '{{#each this.modes}}',
@@ -223,9 +222,6 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                 '</div>',
             '</div>',
         '</div>{{/each}}'].join('');
-
-        // TODO: split out units from formatted duration to go in separate span
-        //<div class="route-duration">33 <span class="units">min</span></div>',
 
         var template = Handlebars.compile(source);
         var html = template({itineraries: itineraries});

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -103,6 +103,12 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, Modal, Templates, UserP
                                           options.selectors.placeCardDirectionsLink,
                                           $.proxy(clickedDestination, this));
 
+        mapControl.events.on(mapControl.eventNames.originMoved,
+                             $.proxy(moveOrigin, this));
+
+        mapControl.events.on(mapControl.eventNames.destinationMoved,
+                             $.proxy(moveDestination, this));
+
         // TODO: re-enable loading settings from user preferences
         // once routing figured out. Currently there is no way to go back
         // to the home page, so if there is an origin and destination in
@@ -146,6 +152,14 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, Modal, Templates, UserP
     function onOptionsModalItemClicked(event) {
         // TODO: Replace with actual functionality once this item is
         console.log($(event.target).html());
+    }
+
+    function moveOrigin(event, position) {
+        directionsControl.moveOriginDestination('origin', position);
+    }
+
+    function moveDestination(event, position) {
+        directionsControl.moveOriginDestination('destination', position);
     }
 
 })(jQuery, CAC.Control.ModeOptions, CAC.Map.Control, CAC.Control.Modal, CAC.Home.Templates, CAC.User.Preferences,

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -150,15 +150,17 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, Modal, Templates, UserP
     }
 
     function onOptionsModalItemClicked(event) {
-        // TODO: Replace with actual functionality once this item is
+        // TODO: implement modals
         console.log($(event.target).html());
     }
 
     function moveOrigin(event, position) {
+        event.preventDefault();
         directionsControl.moveOriginDestination('origin', position);
     }
 
     function moveDestination(event, position) {
+        event.preventDefault(); // necessary to prevent typeahead dropdown from opening
         directionsControl.moveOriginDestination('destination', position);
     }
 

--- a/src/app/scripts/cac/pages/cac-pages-map.js
+++ b/src/app/scripts/cac/pages/cac-pages-map.js
@@ -63,6 +63,10 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl, UserPreferences
     // featured destination select
     function getDestinationDirections(event, destination) {
 
+        /* TODO: remove this UA check
+        // Leaving for now as checking for mobile may be useful for delaying
+        // map loading.
+        //
         // check user agent to see if mobile device; if so, redirect to Google Maps
         var regex = /android|iphone|ipod/i;
         var userAgent = navigator.userAgent.toLowerCase();
@@ -84,6 +88,7 @@ CAC.Pages.Map = (function ($, Handlebars, _, moment, MapControl, UserPreferences
             window.location = url;
             return false;
         }
+        */
 
         // not a mobile device; go to directions tab
         mapControl.isochroneControl.clearIsochrone();

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -124,17 +124,7 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
      * @return {string} duration of itinerary/leg, formatted with units (hrs, min, s)
      */
     function getFormattedDuration(otpItineraryLeg) {
-        // x hrs, y min, z s (will trim empty units from left)
-        var fmt = 'h [hrs], m [min], ss [s]';
-        var str = moment.duration(otpItineraryLeg.duration, 'seconds').format(fmt);
-        // trim empty seconds from right of string
-        var emptySecIdx = str.indexOf(', 00 s');
-        if (emptySecIdx > 0) {
-            str = str.substring(0, emptySecIdx);
-        }
-        // fix hour singular
-        str = str.replace('1 hrs,', '1 hr,');
-        return str;
+        return moment.duration(otpItineraryLeg.duration, 'seconds').humanize();
     }
 
     /**

--- a/src/app/scripts/cac/utils.js
+++ b/src/app/scripts/cac/utils.js
@@ -178,21 +178,22 @@ CAC.Utils = (function (_) {
 
     function modeStringHelper(modeString) {
         var modeIcons = {
-            BUS: {name: 'bus', font: 'fa'},
-            SUBWAY: {name: 'subway', font: 'fa'},
-            CAR: {name: 'car', font: 'fa'},
-            TRAIN: {name: 'train', font: 'fa'},
-            RAIL: {name: 'train', font: 'fa'},
-            BICYCLE: {name: 'bicycle', font: 'fa'},
-            WALK: {name: 'directions-walk', font: 'md'},
-            TRAM: {name: 'directions-subway', font: 'md'},
-            FERRY: {name: 'directions-ferry', font: 'md'}
+            // TODO: add appropriate mode icons
+            BUS: {name: 'train', font: 'icon'}, // TODO
+            SUBWAY: {name: 'train', font: 'icon'}, // TODO
+            CAR: {name: 'train', font: 'icon'}, // TODO
+            TRAIN: {name: 'train', font: 'icon'},
+            RAIL: {name: 'train', font: 'icon'}, // TODO
+            BICYCLE: {name: 'bike', font: 'icon'},
+            WALK: {name: 'walk', font: 'icon'},
+            TRAM: {name: 'train', font: 'icon'}, // TODO
+            FERRY: {name: 'train', font: 'icon'} // TODO
         };
 
         var mode = modeIcons[modeString];
 
         if (!mode) {
-            mode = {name: 'md-directoins-transit', font: 'md'};
+            mode = {name: 'transit', font: 'icon'};
             console.error('Unrecognized transit mode: ' + modeString + '. Using default icon.');
         }
 

--- a/src/bower.json
+++ b/src/bower.json
@@ -10,7 +10,7 @@
     "cartodb.js": "~3.15",
     "Leaflet.awesome-markers": "~2.0.2",
     "Leaflet.encoded": "~0.0.8",
-    "moment": "~2.15.1",
+    "moment": "~2.16.0",
     "moment-duration-format": "~1.3.0",
     "lodash": "~4.16.3",
     "spinkit": "~1.2.5",


### PR DESCRIPTION
Implements the itinerary summary list in the sidebar.

The summary cards will need a little styling help, as the text in practice overflows the expected one line of text. The formatted duration string isn't split into numeric and unit portion, so the additional formatting for the unit is applied to the whole string. Using moment's `humanize` function now, which can return numberless strings such as "an hour".

Created #598 for the missing mode icons (just use a train for now).

Created #599 for card highlight interactivity (perhaps can be handled via CSS).

![image](https://cloud.githubusercontent.com/assets/960264/20158886/31dd5930-a6ab-11e6-9de8-05fcf6626999.png)


Also updates some date/time and duration formatting, adds icons for origin and destination markers, fixes issues with itinerary map plotting, and shows map controls once directions return (map controls are hidden on home view).

