### PR TITLE
Check that step exists before trying to merge it

### DIFF
--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -242,7 +242,7 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
                 // merge it back into a single step
                 var lastStep = _.clone(_.last(thisLeg.steps));
                 var nextStep = _.first(nextLeg.steps);
-                if (nextStep.relativeDirection === 'CONTINUE' &&
+                if (nextStep && nextStep.relativeDirection === 'CONTINUE' &&
                         lastStep.streetName === nextStep.streetName) {
                     lastStep.distance += nextStep.distance;
                     lastStep.elevation = lastStep.elevation.concat(nextStep.elevation);


### PR DESCRIPTION
Resolves #567.
Or I believe it does, though I wasn't able to reproduce the error.
The error is `Cannot read property 'relativeDirection' of undefined.`,
which has to be this line.  Presumably a leg somehow has no steps.
Checking for this case and continuing on should be fine.