### PR TITLE
Wire up redesigned 'About' page

### DIFF
--- a/python/cac_tripplanner/cac_tripplanner/urls.py
+++ b/python/cac_tripplanner/cac_tripplanner/urls.py
@@ -26,8 +26,8 @@ urlpatterns = [
     # Places
     url(r'^place/(?P<pk>[\d-]+)/$', place_detail_view, name='place-detail'),
 
-    # About and FAQ
-    url(r'^info/(?P<slug>[\w-]+)/$', cms_views.about_faq, name='about-faq'),
+    # About (no more FAQ)
+    url(r'^(?P<slug>about)/$', cms_views.about_faq, name='about'),
 
     # All Published Articles
     url(r'^api/articles$', cms_views.AllArticles.as_view(), name='api_articles'),

--- a/python/cac_tripplanner/cms/views.py
+++ b/python/cac_tripplanner/cms/views.py
@@ -36,7 +36,7 @@ def home(request):
 
 def about_faq(request, slug):
     page = get_object_or_404(AboutFaq.objects.all(), slug=slug)
-    context = dict(tab='info', page=page, **DEFAULT_CONTEXT)
+    context = dict(tab='about', page=page, **DEFAULT_CONTEXT)
     return render(request, 'about-faq.html', context=context)
 
 def learn_list(request):

--- a/python/cac_tripplanner/templates/about-faq.html
+++ b/python/cac_tripplanner/templates/about-faq.html
@@ -1,19 +1,14 @@
 {% extends "base.html" %}
 {% block content %}
 {% include "partials/header.html" %}
-<div class="article">
-    <section class="jumbotron small"></section>
-    <section class="content">
-      <div class="container">
-        <div class="row">
-            <div class="col-lg-8 col-lg-offset-2 content-main">
-                <h1>{{ page.title }}</h1>
-    
-                {{ page.content|safe }}
-            </div>
-        </div>
-      </div>
-    </section>
+<div class="main">
+    <h1>{{ page.title }}</h1>
+    <article class="info-article">
+        <section class="info-article-section">
+            <dl class="faq">
+            {{ page.content|safe }}
+        </section>
+    </article>
 </div>
 {% include "partials/footer.html" %}
 {% endblock %}

--- a/python/cac_tripplanner/templates/partials/footer.html
+++ b/python/cac_tripplanner/templates/partials/footer.html
@@ -12,7 +12,7 @@
         </ul>
     </div>
     <div class="footer-about">
-        <a class="goto-about" title="Learn more about GoPhillyGo" href="about.html">
+        <a class="goto-about" title="Learn more about GoPhillyGo" href="/about/">
             <h2>About</h2>
             <p>
                 GoPhillyGo is a project of the Clean Air Council, Azavea, and Warkulwiz Design Associates. The project is funded by the William Penn Foundation.

--- a/src/app/styles/layouts/_info.scss
+++ b/src/app/styles/layouts/_info.scss
@@ -1,4 +1,4 @@
-.body-info, .body-explore {
+.body-info, .body-explore, .body-about {
     display: flex;
     position: absolute;
     top: 0;
@@ -194,12 +194,15 @@
     .faq {
         padding-top: 4rem;
 
-        dt {
+        /* Redesign prototype uses `dt` and `dd` but existing About page in database uses
+         * `h3` and `p`, so applying the styles to both. */
+        dt, h3 {
             color: $gophillygo-red;
             font-weight: $font-weight-bold;
+            font-size: $font-size-base;
         }
 
-        dd {
+        dd, p {
             margin: 1em 0 3em 0;
         }
     }


### PR DESCRIPTION
Converts the About page placeholder to a redesigned view that still uses
the About article from the database.

Note that the existing production About article uses `h3` and `p` tags
whereas the redesign prototype uses `dt` and `dd`. This applies the
styles to both so that either way will work.

The FAQ is gone, but I didn't go so far as to rename the view and model
from 'AboutFaq' to just 'About'. Seems harmless to me and would make it
easier if (heaven forfend) we want a FAQ again.

Resolves  #555.

Screenshots, using the About content copied from the production site.  The all-caps titles aren't from styling, they were typed that way.

![about_page_wide](https://cloud.githubusercontent.com/assets/6598836/20191891/75659f14-a755-11e6-8b46-be960a9e64eb.png)

![about_page_mobile](https://cloud.githubusercontent.com/assets/6598836/20191893/780db3e6-a755-11e6-89d8-c3c2860b0f03.png)

