### PR TITLE
Waypoint interpolation v3

### DIFF
--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -94,7 +94,7 @@
     <script src="{% static 'scripts/vendor/typeahead.bundle.js' %}"></script>
     <script src="{% static 'scripts/vendor/leaflet.awesome-markers.js' %}"></script>
     <script src="{% static 'scripts/vendor/turf-helpers.js' %}"></script>
-    <script src="{% static 'scripts/vendor/turf-nearest.js' %}"></script>
+    <script src="{% static 'scripts/vendor/turf-point-on-line.js' %}"></script>
     <script src="{% static 'scripts/vendor/moment.js' %}"></script>
     <script src="{% static 'scripts/vendor/moment-duration-format.js' %}"></script>
     <script src="{% static 'scripts/vendor/bootstrap-datetimepicker.min.js' %}"></script>

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -581,6 +581,8 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         itinerary.geojson.bringToFront();
     }
 
+    // Figure out where in the sequence of waypoints the click to create a new one falls.
+    // Returns the index in the waypoint array at which to insert the new waypoint.
     function getNewWaypointIndex(itinerary, startDragPoint) {
         var waypoints = itinerary.waypoints;
 
@@ -588,37 +590,23 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
             return 0;
         }
 
-        var originPoint = turf.point([itinerary.from.lon, itinerary.from.lat], {index: -1});
-        var destPoint = turf.point([itinerary.to.lon, itinerary.to.lat], {index: waypoints.length});
+        // Combine the whole itinerary into a single linestring
+        var combinedRoute = turf.lineString(_.flatMap(itinerary.geojson.toGeoJSON().features,
+                                                      'geometry.coordinates'));
+        // Figure out how far the new point is along that linestring. Index is fine since we
+        // just need to do comparisons.
+        var newPointDist = turf.pointOnLine(combinedRoute, startDragPoint).properties.index;
 
-        var allFeatures = _.concat([originPoint], waypoints, [destPoint]);
-
-        var turfPoint = turf.point(startDragPoint);
-        var nearest = turf.nearest(turfPoint, turf.featureCollection(allFeatures));
-
-        var nearestIndex = nearest.properties.index;
-
-        // drop the nearest point to repeat search, in order to find next nearest
-        var remainingFeatures = _.concat(_.slice(allFeatures, 0, nearestIndex),
-                                       _.slice(allFeatures, nearestIndex + 1));
-
-        var nextNearest = turf.nearest(turfPoint, turf.featureCollection(remainingFeatures));
-
-        var nextNearestIndex = nextNearest.properties.index;
-
-        // determine the sequence ordering of the two nearest points, so the new point can
-        // be added between them
-        var smallerIndex = Math.min(nearestIndex, nextNearestIndex);
-        var largerIndex = Math.max(nearestIndex, nextNearestIndex);
-        var newIndex = smallerIndex + 1;
-
-        // If the nearest two points aren't in sequence and the larger indexed one is closer,
-        // put the new point right before that one instead of right after the 2nd nearest
-        if (largerIndex - smallerIndex !== 1 && smallerIndex !== nearestIndex) {
-            newIndex = largerIndex - 1;
+        // Find the first waypoint that's after the new point
+        var insertBefore = _.find(waypoints, function (pt) {
+            return turf.pointOnLine(combinedRoute, pt).properties.index > newPointDist;
+        });
+        // And return its index or, if no later waypoint was found, add the new one to the end
+        if (insertBefore) {
+            return insertBefore.properties.index;
+        } else {
+            return waypoints.length;
         }
-
-        return newIndex;
     }
 
     /**

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -73,31 +73,32 @@ gulp.task('collectstatic', function () {
 });
 
 // turf module needs to be run through browserify to pack it with its dependencies
-var turfDistanceRoot = './node_modules/@turf/nearest/node_modules/@turf/distance';
+var turfRoot = './node_modules/@turf/point-on-line';
 
 var buildTurfHelpers = function() {
-    return browserify(turfDistanceRoot + '/node_modules/@turf/helpers', {
+    return browserify(turfRoot + '/node_modules/@turf/helpers', {
             standalone: 'turf',
             expose: ['helpers']
         })
-        .require(turfDistanceRoot + '/node_modules/@turf/helpers',
+        .require(turfRoot + '/node_modules/@turf/helpers',
                  {expose: 'turf-helpers'})
         .bundle()
         .pipe(vinylSourceStream('turf-helpers.js'));
 };
 
 var buildTurfPointOnLine = function() {
-    return browserify('./node_modules/@turf/nearest', {
-            standalone: 'turf.nearest',
-            exclude: [turfDistanceRoot + '/node_modules/@turf/helpers']
+    return browserify('./node_modules/@turf/point-on-line', {
+            standalone: 'turf.pointOnLine',
+            exclude: [turfRoot + '/node_modules/@turf/helpers']
         })
         .transform(aliasify, {aliases: {
-            'turf-helpers': turfDistanceRoot + '/node_modules/@turf/helpers',
-            'turf-invariant': turfDistanceRoot + '/node_modules/@turf/invariant',
-            'turf-distance': turfDistanceRoot
+            'turf-helpers': turfRoot + '/node_modules/@turf/helpers',
+            'turf-distance': turfRoot + '/node_modules/@turf/distance',
+            'turf-bearing': turfRoot + '/node_modules/@turf/bearing',
+            'turf-destination': turfRoot + '/node_modules/@turf/destination'
         }})
         .bundle()
-        .pipe(vinylSourceStream('turf-nearest.js'));
+        .pipe(vinylSourceStream('turf-point-on-line.js'));
 };
 
 // combine streams from turf and the other vendor dependencies

--- a/src/package.json
+++ b/src/package.json
@@ -4,7 +4,7 @@
     "node": ">=0.12.0"
   },
   "dependencies": {
-    "@turf/nearest": "~3.5.2"
+    "@turf/point-on-line": "~3.5.3"
   },
   "devDependencies": {
     "aliasify": "^2.0.0",


### PR DESCRIPTION
Implements another strategy to figure out where in the sequence to place new waypoints.  This one works by making a single lineString of the whole route then figuring out how far along the line the new point falls and comparing that to each waypoint.  The first waypoint that's farther along the line is the one we want to insert the new point before.

Example:
http://localhost:8024/map/directions?origin=39.9616133%2C-75.1541914&originText=990%20Spring%20Garden%20St%2C%20Philadelphia%2C%20Pennsylvania%2C%2019123&mode=WALK&destination=39.96581%2C-75.183494&destinationText=Fairmount%20Waterworks%20Interpretive%20Center&waypoints=39.9662504%2C-75.1696157%3B39.9637342%2C-75.1718044

![waypoint_misbehavior](https://cloud.githubusercontent.com/assets/6598836/20222359/fc75398a-a802-11e6-94bc-e02eeb710ae0.png)

Clicking to create a new waypoint just before the first existing waypoint, as shown, causes the old interpolation algorithm to put the new point between the two existing waypoints because the second waypoint is geographically closer to the click location than the origin point is.  The new algorithm properly puts the new point between the origin and the first existing waypoint.

Resolves #603.