### PR TITLE
Feature/step by step

### DIFF
--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -91,7 +91,8 @@
 
     <div class="directions-step-by-step">
         <header class="step-by-step-header">
-            <button name="back-to-directions-results" class="back-to-directions-results"><i class="icon-left-big"></i></button>
+            <button name="back-to-directions-results" class="back-to-directions-results">
+            <i class="icon-left-big"></i></button>
             <h1>Directions</h1>
             <button name="share-directions" class="share-directions"><i class="icon-share"></i></button>
         </header>

--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -83,82 +83,9 @@
         {% include "partials/article-card.html" with show_link=True %}
     {% endif %}
 
-    <div class="directions-results">
-        <h1>Choose a route</h1>
-        <div class="routes-list">
-        </div>
-    </div>
+    <div class="directions-results"></div>
 
-    <div class="directions-step-by-step">
-        <header class="step-by-step-header">
-            <button name="back-to-directions-results" class="back-to-directions-results">
-            <i class="icon-left-big"></i></button>
-            <h1>Directions</h1>
-            <button name="share-directions" class="share-directions"><i class="icon-share"></i></button>
-        </header>
-        <div class="directions-list-of-steps">
-            <div class="directions-leg directions-leg-origin">
-                <div class="directions-step directions-step-origin">
-                    <div class="directions-instruction">Depart 135 S 19th St</div>
-                    <div class="directions-time">at 9:47a</div>
-                </div>
-            </div>
-            <div class="directions-leg directions-leg-walk">
-                <div class="directions-step directions-step-walk">
-                    <div class="directions-instruction">Walk north on S 19th St</div>
-                    <div class="directions-distance">78 feet</div>
-                </div>
-                <div class="directions-step directions-step-arrive">
-                    <div class="directions-instruction">Arrive <strong>19th &amp; Moravian St</strong></div>
-                </div>
-            </div>
-            <div class="directions-leg directions-leg-bus">
-                <div class="directions-step directions-step-bus">
-                    <div class="directions-instruction">Board SEPTA 17 (20th &amp; Johnston)</div>
-                    <div class="directions-time">at 9:48a</div>
-                    <div class="directions-distance">1.35 miles</div>
-                </div>
-                <div class="directions-step directions-step-disembark">
-                    <div class="directions-instruction">Disembark <strong>19th St &amp; Tasker St</strong></div>
-                </div>
-            </div>
-            <div class="directions-leg directions-leg-walk">
-                <div class="directions-step directions-step-walk">
-                    <div class="directions-instruction">Walk southeast on Tasker St</div>
-                    <div class="directions-distance">98 feet</div>
-                </div>
-                <div class="directions-step directions-step-arrive">
-                    <div class="directions-instruction">Arrive <strong>Tasker St &amp; 19th St</strong></div>
-                </div>
-            </div>
-            <div class="directions-leg directions-leg-bus">
-                <div class="directions-step directions-step-bus">
-                    <div class="directions-instruction">Board SEPTA 1297 (33rd &amp; Dickinson)</div>
-                    <div class="directions-time">at 10:00a</div>
-                    <div class="directions-distance">0.8 miles</div>
-                </div>
-                <div class="directions-step directions-step-disembark">
-                    <div class="directions-instruction">Disembark <strong>Tasker St &amp; 28th St</strong></div>
-                </div>
-            </div>
-            <div class="directions-leg directions-leg-walk">
-                <div class="directions-step directions-step-walk">
-                    <div class="directions-instruction">Walk east on Tasker St</div>
-                    <div class="directions-distance">105 feet</div>
-                </div>
-                <div class="directions-step directions-step-turn-left">
-                    <div class="directions-instruction">Turn left on S Marston St</div>
-                    <div class="directions-distance">0.13 miles</div>
-                </div>
-            </div>
-            <div class="directions-leg directions-leg-destination">
-                <div class="directions-step directions-step-destination">
-                    <div class="directions-instruction">Arrive S Marston St &amp; Reed St</div>
-                    <div class="directions-time">at 10:07a</div>
-                </div>
-            </div>
-        </div>
-    </div>
+    <div class="directions-step-by-step"></div>
 
 
     <div class="modal-overlay">

--- a/src/app/scripts/cac/control/cac-control-directions-list.js
+++ b/src/app/scripts/cac/control/cac-control-directions-list.js
@@ -18,7 +18,7 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social) {
             container: '.directions-step-by-step',
             mapContainer: '.body-map',
             backButton: '.back-to-directions-results',
-            directionItem: '.directions-leg',
+            directionItem: '.directions-leg .directions-step',
             directLinkButton: '.modal-list-link',
             emailShareButton: '.modal-list-email',
             facebookShareButton: '.modal-list-facebook',

--- a/src/app/scripts/cac/control/cac-control-directions-list.js
+++ b/src/app/scripts/cac/control/cac-control-directions-list.js
@@ -15,14 +15,14 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social) {
         // Should the share button be shown in the control
         showShareButton: false,
         selectors: {
-            container: '.directions-list',
-            backButton: 'a.back',
-            directionItem: '.direction-item',
-            directLinkButton: '#directLinkBtn',
-            emailShareButton: '#emailShareBtn',
-            facebookShareButton: '#fbShareBtn',
-            twitterShareButton: '#twShareBtn',
-            googlePlusShareButton: '#gpShareBtn'
+            container: '.routes-list',
+            backButton: '.back-to-directions-results',
+            directionItem: '.directions-leg',
+            directLinkButton: '.modal-list-link',
+            emailShareButton: '.modal-list-email',
+            facebookShareButton: '.modal-list-facebook',
+            twitterShareButton: '.modal-list-twitter',
+            googlePlusShareButton: '.modal-list-google'
         }
     };
     var options = {};

--- a/src/app/scripts/cac/control/cac-control-directions-list.js
+++ b/src/app/scripts/cac/control/cac-control-directions-list.js
@@ -15,14 +15,17 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social) {
         // Should the share button be shown in the control
         showShareButton: false,
         selectors: {
-            container: '.routes-list',
+            container: '.directions-step-by-step',
+            mapContainer: '.body-map',
             backButton: '.back-to-directions-results',
             directionItem: '.directions-leg',
             directLinkButton: '.modal-list-link',
             emailShareButton: '.modal-list-email',
             facebookShareButton: '.modal-list-facebook',
             twitterShareButton: '.modal-list-twitter',
-            googlePlusShareButton: '.modal-list-google'
+            googlePlusShareButton: '.modal-list-google',
+            stepByStepClass: 'body-step-by-step',
+            sidebarBannerClass: 'body-has-sidebar-banner'
         }
     };
     var options = {};
@@ -153,15 +156,17 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social) {
     }
 
     function show() {
-        $container.removeClass('hidden');
+        $(options.selectors.mapContainer).removeClass(options.selectors.sidebarBannerClass);
+        $(options.selectors.mapContainer).addClass(options.selectors.stepByStepClass);
     }
 
     function hide() {
-        $container.addClass('hidden');
+        $(options.selectors.mapContainer).removeClass(options.selectors.stepByStepClass);
+        $(options.selectors.mapContainer).addClass(options.selectors.sidebarBannerClass);
     }
 
     function toggle() {
-        if ($container.hasClass('hidden')) {
+        if ($(options.selectors.mapContainer).hasClass(options.selectors.sidebarBannerClass)) {
             show();
         } else {
             hide();

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -90,10 +90,7 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
             showBackButton: true,
             showShareButton: true,
             selectors: {
-                container: options.selectors.itineraryList,
-                directionItem: '.direction-item',
-                backButton: 'a.back',
-                shareButton: 'a.share'
+                container: options.selectors.itineraryList
             }
         });
         directionsListControl.events.on(directionsListControl.eventNames.backButtonClicked,

--- a/src/app/scripts/cac/control/cac-control-itinerary-list.js
+++ b/src/app/scripts/cac/control/cac-control-itinerary-list.js
@@ -14,7 +14,7 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates) {
         // Should the share button be shown in the control
         showShareButton: false,
         selectors: {
-            container: '.routes-list',
+            container: '.directions-results',
             itineraryItem: '.route-summary'
         }
     };

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -340,25 +340,25 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
         switch (turnType) {
             case 'DEPART':
             case 'CONTINUE':
-                return 'glyphicon-arrow-up';
+                return 'glyphicon-arrow-up'; // TODO: update icon
             // Temporarily fall through to similar cases for left/right
             case 'LEFT':
             case 'SLIGHTLY_LEFT':
             case 'HARD_LEFT':
             case 'UTURN_LEFT':
-                return 'glyphicon-arrow-left';
+                return 'icon-turn-left';
             case 'RIGHT':
             case 'SLIGHTLY_RIGHT':
             case 'HARD_RIGHT':
             case 'UTURN_RIGHT':
-                return 'glyphicon-arrow-right';
+                return 'icon-turn-right';
             case 'CIRCLE_CLOCKWISE':
             case 'CIRCLE_COUNTERCLOCKWISE':
-                return 'glyphicon-repeat';
+                return 'glyphicon-repeat'; // TODO: update icon
             case 'ELEVATOR':
-                return 'glyphicon-cloud-upload';
+                return 'glyphicon-cloud-upload'; // TODO: update icon
             default:
-                return 'glyphicon-remove-circle';
+                return 'glyphicon-remove-circle'; // TODO: update icon
         }
     }
 

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -267,7 +267,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                         '<div class="directions-instruction">Disembark <strong>',
                             '{{this.to.name}}</strong></div>',
                     '</div>',
-                    '{{/if}}',
+                    '{{else}}',
                     // non-tranist step directions
                     '{{#each steps}}',
                         '<div class="directions-step {{directionClass this.relativeDirection ../this.mode}}" ',
@@ -276,6 +276,12 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                             '<div class="directions-distance">{{inMiles this.distance}} mi</div>',
                         '</div>',
                     '{{/each}}',
+                    '{{#unless this.lastLeg}}',
+                    '<div class="directions-step directions-step-arrive">',
+                        '<div class="directions-instruction"><strong>Arrive {{this.to.name}}</strong></div>',
+                    '</div>',
+                    '{{/unless}}', // unless last step
+                    '{{/if}}', // end if transit or not
                 '</div>',
             '{{/each}}',
             '<div class="directions-leg directions-leg-destination">',
@@ -286,7 +292,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
             '</div>'
         ].join('');
         var template = Handlebars.compile(source);
-        console.log(templateData);
+        templateData.legs[templateData.legs.length - 1].lastLeg = true;
         var html = template({data: templateData});
         return html;
     }
@@ -322,7 +328,6 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
     }
 
     function getModeClass(modeText) {
-        console.log('getting mode class for ' + modeText);
         switch (modeText) {
             case 'BIKE':
                 return 'directions-step-bike'; // TODO: bike share has separate icon

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -257,13 +257,15 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                     'data-lat="{{this.from.lat}}" data-lon="{{this.from.lon}}">',
                     // transit step directions
                     '{{#if this.transitLeg}}',
-                    '<div class="directions-step {{modeClass this.mode}}">',
+                    '<div class="directions-step {{modeClass this.mode}}" ',
+                        'data-lat="{{ this.from.lat }}" data-lon="{{ this.from.lon }}">',
                         '<div class="directions-instruction">Board {{this.agencyName}} {{this.route}} ',
                         '{{this.headsign}}</div>',
                         '<div class="directions-time">at {{datetime this.startTime}}</div>',
                         '<div class="directions-distance">{{inMiles this.distance}} mi</div>',
                     '</div>',
-                    '<div class="directions-step directions-step-disembark">',
+                    '<div class="directions-step directions-step-disembark" ',
+                        'data-lat="{{ this.to.lat }}" data-lon="{{ this.to.lon }}">',
                         '<div class="directions-instruction">Disembark <strong>',
                             '{{this.to.name}}</strong></div>',
                     '</div>',
@@ -277,7 +279,8 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                         '</div>',
                     '{{/each}}',
                     '{{#unless this.lastLeg}}',
-                    '<div class="directions-step directions-step-arrive">',
+                    '<div class="directions-step directions-step-arrive" ',
+                        'data-lat="{{ this.to.lat }}" data-lon="{{ this.to.lon }}">',
                         '<div class="directions-instruction"><strong>Arrive {{this.to.name}}</strong></div>',
                     '</div>',
                     '{{/unless}}', // unless last step
@@ -292,6 +295,8 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
             '</div>'
         ].join('');
         var template = Handlebars.compile(source);
+        // set a flag on the last leg, so we can avoid diplaying arriving there right above
+        // also arriving at the final destination
         templateData.legs[templateData.legs.length - 1].lastLeg = true;
         var html = template({data: templateData});
         return html;

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -201,7 +201,9 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
 
     // Template for itinerary summaries
     function itineraryList(itineraries) {
-        var source = ['{{#each itineraries}}',
+        var source = [
+        '<h1>Choose a route</h1><div class="routes-list"></div>',
+        '{{#each itineraries}}',
             '<div class="route-summary" data-itinerary="{{this.id}}">',
             '<svg class="route-summary-path" width="3" height="100%" xmlns="http://www.w3.org/2000/svg">',
                 '<line x1="50%" y1="6%" x2="50%" y2="94%" stroke-width="3" stroke="#e23331"></line>',
@@ -231,93 +233,76 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
     function itinerary(templateData) {
         // The &nbsp;'s are used instead of 'hide' classes because of some styling-related issues
         var source = [
-            '<div class="block block-step directions-header">',
-                'Directions',
-                '{{#if data.showBackButton}}<div class="pull-right"><a class="back pull-right">',
-                '<i class="md md-close"></i></a></div>{{/if}}',
-                '<div class="share-dropdown pull-right dropdown">{{#if data.showShareButton}}',
-                    '<a class="share dropdown-toggle" data-toggle="dropdown">',
-                    '<i class="md md-share"></i></a>',
-                    '<ul class="dropdown-menu">',
-                        '<li><a id="directLinkBtn" title="Link" data-toggle="tooltip" ',
-                            'data-target="link-modal" data-toggle="link-modal" ',
-                                '<i class="fa fa-2x fa-link"></i>',
-                        '</a></li>',
-                        '<li><a id="twShareBtn" title="Twitter" data-toggle="tooltip"',
-                            'data-target="#" <i class="fa fa-2x fa-twitter-square"></i>',
-                        '</a></li>',
-                        '<li><a id="fbShareBtn" title="Facebook" data-toggle="tooltip" ',
-                            'data-target="#" <i class="fa fa-2x fa-facebook-official"></i>',
-                        '</a></li>',
-                        '<li><a id="gpShareBtn" title="Google+" data-toggle="tooltip" ',
-                            'data-target="#" <i class="fa fa-2x fa-google-plus"></i>',
-                        '</a></li>',
-                        '<li><a id="emailShareBtn" title="E-Mail" data-toggle="tooltip" ',
-                            'data-target="#" <i class="fa fa-2x fa-envelope"></i>',
-                        '</a></li>',
-                    '</ul>{{/if}} ',
-                    '<span class="directions-header-divider">|</span> ',
+            '<header class="step-by-step-header">',
+                '{{#if data.showBackButton}}',
+                    '<button name="back-to-directions-results" class="back-to-directions-results">',
+                    '<i class="icon-left-big"></i></button>',
+                '{{/if}}',
+                '<h1>Directions</h1>',
+                '{{#if data.showShareButton}}',
+                    '<button name="share-directions" class="share-directions">',
+                        '<i class="icon-share"></i>',
+                    '</button>',
+                '{{/if}}',
+            '</header>',
+            '<div class="directions-list-of-steps">',
+                '<div class="directions-leg directions-leg-origin">',
+                    '<div class="directions-step directions-step-origin">',
+                    '<div class="directions-instruction">Depart {{data.start.text}}</div>',
+                    '<div class="directions-time">at {{datetime data.start.time}}</div>',
                 '</div>',
             '</div>',
-            '<div class="block block-step direction-depart">',
-                '<table><tr><td class="direction-icon"><i class="md md-place"></i></td>',
-                    '<td>Depart from <strong>{{data.start.text}} at {{datetime data.start.time}}</td>',
-                '</tr></table></strong>',
-            '</div>',
-            '<div class="block-legs">',
-                '{{#each data.legs}}',
-                    '<div class="block block-leg">',
-                        '<div class="trip-numbers">',
-                            '<div class="trip-duration">',
-                                '{{this.formattedDuration}}',
-                            '</div>',
-                            '<div class="trip-distance">',
-                                '{{inMiles this.distance}} mi',
-                            '</div>',
-                        '</div>',
-                        '<div class="trip-details">',
-                            '<div class="direction-section"><table><tr>',
-                            '<td class="direction-icon">',
-                            '{{modeIcon this.mode}}</td><td class="direction-text direction-item"',
-                            ' data-lat="{{this.from.lat}}" data-lon="{{this.from.lon}}" >',
-                            '{{#if this.transitLeg}}{{this.agencyName}} {{this.route}} ',
-                                '{{this.headsign}}{{/if}} ',
-                            'to {{this.to.name}}',
-                            '{{#if this.transitLeg }} at {{datetime this.startTime}}{{/if}}',
-                            '</td></tr></table></div>',
-                            '<div class="block direction-item"',
-                            ' data-lat="{{this.from.lat}}" data-lon="{{this.from.lon}}" >',
-                                '{{#each steps}}',
-                                    '<div class="block block-step direction-item"',
-                                        ' data-lat="{{ lat }}" data-lon="{{ lon }}" >',
-                                        '<span>{{ directionText }}</span>',
-                                        '<span class="pull-right">{{ inMiles this.distance }} mi</span>',
-                                    '</div>',
-                                '{{/each}}',
-                            '</div>',
-                        '</div>',
+            '{{#each data.legs}}',
+                '<div class="directions-leg" ',
+                    'data-lat="{{this.from.lat}}" data-lon="{{this.from.lon}}">',
+                    // transit step directions
+                    '{{#if this.transitLeg}}',
+                    '<div class="directions-step {{modeClass this.mode}}">',
+                        '<div class="directions-instruction">Board {{this.agencyName}} {{this.route}} ',
+                        '{{this.headsign}}</div>',
+                        '<div class="directions-time">at {{datetime this.startTime}}</div>',
+                        '<div class="directions-distance">{{inMiles this.distance}} mi</div>',
                     '</div>',
-                '{{/each}}',
-            '</div>',
-            '<div class="block block-step direction-arrive">',
-                '<table><tr><td class="direction-icon"><i class="md md-place"></i></td>',
-                    '<td>Arrive at <strong>{{data.end.text}} at {{datetime data.end.time}}</td>',
-                '</tr></table></strong>',
-            '</div>',
+                    '<div class="directions-step directions-step-disembark">',
+                        '<div class="directions-instruction">Disembark <strong>',
+                            '{{this.to.name}}</strong></div>',
+                    '</div>',
+                    '{{/if}}',
+                    // non-tranist step directions
+                    '{{#each steps}}',
+                        '<div class="directions-step {{directionClass this.relativeDirection ../this.mode}}" ',
+                            'data-lat="{{ lat }}" data-lon="{{ lon }}">',
+                            '<div class="directions-instruction">{{directionText}}</div>',
+                            '<div class="directions-distance">{{inMiles this.distance}} mi</div>',
+                        '</div>',
+                    '{{/each}}',
+                '</div>',
+            '{{/each}}',
+            '<div class="directions-leg directions-leg-destination">',
+                '<div class="directions-step directions-step-destination">',
+                    '<div class="directions-instruction">Arrive {{data.end.text}}</div>',
+                    '<div class="directions-time">at {{datetime data.end.time}}</div>',
+                '</div>',
+            '</div>'
         ].join('');
         var template = Handlebars.compile(source);
+        console.log(templateData);
         var html = template({data: templateData});
         return html;
     }
 
     function registerListItemHelpers() {
-        Handlebars.registerHelper('directionIcon', function(direction) {
-            return new Handlebars.SafeString('<span class="glyphicon '+
-                                             getTurnIconName(direction) + '"></span>');
+        Handlebars.registerHelper('directionClass', function(direction, mode) {
+            return new Handlebars.SafeString(getTurnIconClass(direction, mode));
         });
+
         Handlebars.registerHelper('directionText', function () {
             var text = turnText(this.relativeDirection, this.streetName, this.absoluteDirection);
             return new Handlebars.SafeString('<span>' + text + '</span>');
+        });
+
+        Handlebars.registerHelper('modeClass', function(modeString) {
+            return new Handlebars.SafeString(getModeClass(modeString));
         });
 
         Handlebars.registerHelper('modeIcon', function(modeString) {
@@ -336,29 +321,40 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
         });
     }
 
-    function getTurnIconName(turnType) {
+    function getModeClass(modeText) {
+        console.log('getting mode class for ' + modeText);
+        switch (modeText) {
+            case 'BIKE':
+                return 'directions-step-bike'; // TODO: bike share has separate icon
+            default:
+                return 'directions-step-' + modeText.toLowerCase();
+        }
+    }
+
+    function getTurnIconClass(turnType, modeText) {
         switch (turnType) {
             case 'DEPART':
+                return getModeClass(modeText);
             case 'CONTINUE':
-                return 'glyphicon-arrow-up'; // TODO: update icon
-            // Temporarily fall through to similar cases for left/right
+                return '';
+            // fall through to similar cases for left/right
             case 'LEFT':
             case 'SLIGHTLY_LEFT':
             case 'HARD_LEFT':
             case 'UTURN_LEFT':
-                return 'icon-turn-left';
+                return 'directions-step-turn-left';
             case 'RIGHT':
             case 'SLIGHTLY_RIGHT':
             case 'HARD_RIGHT':
             case 'UTURN_RIGHT':
-                return 'icon-turn-right';
+                return 'directions-step-turn-right';
             case 'CIRCLE_CLOCKWISE':
             case 'CIRCLE_COUNTERCLOCKWISE':
-                return 'glyphicon-repeat'; // TODO: update icon
+                return 'directions-step-circle'; // TODO: icon/class does not exist
             case 'ELEVATOR':
-                return 'glyphicon-cloud-upload'; // TODO: update icon
+                return 'directions-step-elevator'; // TODO: icon/class does not exist
             default:
-                return 'glyphicon-remove-circle'; // TODO: update icon
+                return '';
         }
     }
 

--- a/src/app/scripts/cac/utils.js
+++ b/src/app/scripts/cac/utils.js
@@ -179,7 +179,7 @@ CAC.Utils = (function (_) {
     function modeStringHelper(modeString) {
         var modeIcons = {
             // TODO: add appropriate mode icons
-            BUS: {name: 'train', font: 'icon'}, // TODO
+            BUS: {name: 'bus', font: 'icon'},
             SUBWAY: {name: 'train', font: 'icon'}, // TODO
             CAR: {name: 'train', font: 'icon'}, // TODO
             TRAIN: {name: 'train', font: 'icon'},


### PR DESCRIPTION
Implement step-by-step directions for redesign. Closes #540. On clicking an itinerary in the sidebar, displays step-by-step directions. Back button returns to the itinerary list.

Note that several of the mode and turn direction icons aren't in yet (#598).

Created #606 for the missing departure and arrival addresses.

![image](https://cloud.githubusercontent.com/assets/960264/20227955/0c37173e-a81d-11e6-9697-dc21ab7f9f20.png)
