### PR TITLE
Feature/fix bike route layer

### DIFF
--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -92,7 +92,7 @@
     }(document, 'script', 'facebook-jssdk'));</script>
     {% endif %}
 
-    <script src="{% static 'scripts/vendor/cartodb.js' %}"></script>
+    <script src="{% static 'scripts/vendor/cartodb.uncompressed.js' %}"></script>
     <script src="{% static 'scripts/vendor/leaflet.awesome-markers.js' %}"></script>
     <script src="{% static 'scripts/vendor/js.storage.js' %}"></script>
     <script src="{% static 'scripts/vendor/lodash.js' %}"></script>

--- a/src/bower.json
+++ b/src/bower.json
@@ -7,7 +7,7 @@
     "jquery": "~3.1.1",
     "js-storage": "~1.0.1",
     "leaflet": "~0.7.7",
-    "cartodb.js": "~3.15",
+    "cartodb.js": "~3.15.9",
     "Leaflet.awesome-markers": "~2.0.2",
     "Leaflet.encoded": "~0.0.8",
     "moment": "~2.16.0",

--- a/src/package.json
+++ b/src/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "aliasify": "^2.0.0",
     "apache-server-configs": "~2.14.0",
-    "bower": "~1.7.9",
+    "bower": "~1.8.0",
     "browserify": "~13.1.0",
     "chai": "~3.5.0",
     "connect": "~3.5.0",
@@ -19,7 +19,7 @@
     "gulp-add-src": "~0.2.0",
     "gulp-autoprefixer": "~3.1.1",
     "gulp-cache": "~0.4.5",
-    "gulp-concat": "~2.6.0",
+    "gulp-concat": "~2.6.1",
     "gulp-csso": "~2.0.0",
     "gulp-debug": "~2.1.2",
     "gulp-filter": "~4.0.0",


### PR DESCRIPTION
Fixes #611.

cartodb.js uses jQuery, which we run in `noConflict` mode for JotForms, which is necessary because JotForms uses prototype.js. Consequently, references to `$.` for jQuery in third-party libraries such as CartoDB will fail.

This fixes the specific case of references to `$.ajax`, as a global search-and-replace of `$.` for `jQuery.` caused other issues.
