### PR TITLE
Closes #610: Re-query transit directions on mode toggle

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -2,7 +2,7 @@
  *  View control for the directions form
  *
  */
-CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routing, Typeahead,
+CAC.Control.Directions = (function (_, $, Control, Geocoder, Routing, Typeahead,
                                     UserPreferences, Utils) {
 
     'use strict';
@@ -76,6 +76,11 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
         itineraryControl = mapControl.itineraryControl;
         urlRouter = options.urlRouter;
         modeOptionsControl = options.modeOptionsControl;
+        // TODO: We may need to manually remove these events if the DirectionsControl
+        //       is reinstantiated when the routing changes. That doesn't currently appear to be
+        //       the case though
+        modeOptionsControl.events.on(modeOptionsControl.eventNames.toggle, planTrip);
+        modeOptionsControl.events.on(modeOptionsControl.eventNames.transitChanged, planTrip);
 
         $(options.selectors.modes).change($.proxy(changeMode, this));
 
@@ -601,5 +606,5 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
         }
     }
 
-})(_, jQuery, CAC.Control, CAC.Control.ModeOptions, CAC.Search.Geocoder,
+})(_, jQuery, CAC.Control, CAC.Search.Geocoder,
     CAC.Routing.Plans, CAC.Search.Typeahead, CAC.User.Preferences, CAC.Utils);

--- a/src/app/scripts/cac/control/cac-control-mode-options.js
+++ b/src/app/scripts/cac/control/cac-control-mode-options.js
@@ -41,11 +41,16 @@ CAC.Control.ModeOptions = (function ($) {
             offClass: 'off',
             selectedModes: '.mode-option.on',
             transitIconClassPrefix: 'icon-transit-',
+            transitIconOnClass: 'icon-transit-on',
             transitIconOnOffClasses: 'icon-transit-on icon-transit-off',
             transitModeOption: '.mode-option.transit'
         }
     };
-
+    var events = $({});
+    var eventNames = {
+        toggle: 'cac:control:modeoptions:toggle',
+        transitChanged: 'cac:control:modeoptions:transitchanged'
+    };
     var options = {};
 
     function ModeOptionsControl(params) {
@@ -57,6 +62,8 @@ CAC.Control.ModeOptions = (function ($) {
     ModeOptionsControl.prototype = {
         initialize: initialize,
         changeMode: changeMode,
+        events: events,
+        eventNames: eventNames,
         getMode: getMode,
         setMode: setMode
     };
@@ -74,6 +81,8 @@ CAC.Control.ModeOptions = (function ($) {
                 .siblings(options.selectors.modeOption)
                     .removeClass(options.selectors.onClass)
                     .addClass(options.selectors.offClass);
+
+            events.trigger(eventNames.toggle, getMode());
         });
 
         $(options.selectors.transitModeOption).on('click', function(e) {
@@ -81,6 +90,9 @@ CAC.Control.ModeOptions = (function ($) {
 
             $(this).toggleClass(options.selectors.onClass + ' ' + options.selectors.offClass)
                 .find('i').toggleClass(options.selectors.transitIconOnOffClasses);
+
+            var active = $(this).find('i').hasClass(options.selectors.transitIconOnClass);
+            events.trigger(eventNames.transitChanged, active);
         });
     }
 


### PR DESCRIPTION
Toggle walk/bike/transit on the map page, the map directions should update.