### PR TITLE
Restore url routing for directions

### DIFF
--- a/python/cac_tripplanner/cac_tripplanner/settings.py
+++ b/python/cac_tripplanner/cac_tripplanner/settings.py
@@ -230,6 +230,8 @@ FB_APP_ID = secrets['fb_app_id']
 
 # OTP CONFIGURATION
 OTP_URL = secrets['otp_url']
+ROUTING_URL = OTP_URL.format(router='default') + 'plan'
+ISOCHRONE_URL = OTP_URL.format(router='default') + 'isochrone'
 
 # Settings for S3 storage
 # No need to specify AWS access and secret keys -- they are pulled from

--- a/python/cac_tripplanner/cac_tripplanner/urls.py
+++ b/python/cac_tripplanner/cac_tripplanner/urls.py
@@ -1,30 +1,32 @@
 from django.conf.urls import include, url
+from django.views.generic import RedirectView
 from django.contrib.gis import admin
 
 from django.contrib.staticfiles import views as staticviews
 
 from cms import views as cms_views
-from destinations.views import (FindReachableDestinations,
-                                SearchDestinations,
-                                FeedEvents,
-                                map as map_view,
-                                directions as directions_view,
-                                place_detail as place_detail_view)
+from destinations import views as dest_views
+
 import settings
 
 urlpatterns = [
-    # Home
-    url(r'^$', cms_views.home, name='home'),
+    # Home view, which is also the directions and explore views
+    url(r'^$', dest_views.home, name='home'),
 
     # Map
-    url(r'^api/destinations/search$', SearchDestinations.as_view(), name='api_destinations_search'),
-    url(r'^api/feedevents$', FeedEvents.as_view(), name='api_feedevents'),
-    url(r'^map/reachable$', FindReachableDestinations.as_view(), name='reachable'),
-    url(r'^map/', map_view, name='map'),
-    url(r'^directions/', directions_view, name='directions'),
+    url(r'^api/destinations/search$', dest_views.SearchDestinations.as_view(),
+        name='api_destinations_search'),
+    url(r'^api/feedevents$', dest_views.FeedEvents.as_view(), name='api_feedevents'),
+    url(r'^map/reachable$', dest_views.FindReachableDestinations.as_view(), name='reachable'),
+
+    url(r'^directions/', dest_views.directions, name='directions'),
+
+    # Handle pre-redesign URLs by redirecting
+    url(r'^map/directions/', RedirectView.as_view(pattern_name='home', query_string=True,
+                                                  permanent=True)),
 
     # Places
-    url(r'^place/(?P<pk>[\d-]+)/$', place_detail_view, name='place-detail'),
+    url(r'^place/(?P<pk>[\d-]+)/$', dest_views.place_detail, name='place-detail'),
 
     # About (no more FAQ)
     url(r'^(?P<slug>about)/$', cms_views.about_faq, name='about'),

--- a/python/cac_tripplanner/cms/views.py
+++ b/python/cac_tripplanner/cms/views.py
@@ -1,20 +1,19 @@
 import json
-from random import shuffle
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from django.shortcuts import render, get_object_or_404
 from django.views.generic import View
 
-from .models import AboutFaq, Article
 from destinations.models import Destination
-from cac_tripplanner.settings import FB_APP_ID, HOMEPAGE_RESULTS_LIMIT, DEBUG, OTP_URL
+from .models import AboutFaq, Article
 
 
 DEFAULT_CONTEXT = {
-    'debug': DEBUG,
-    'fb_app_id': FB_APP_ID,
-    'routing_url': OTP_URL.format(router='default') + 'plan'
+    'debug': settings.DEBUG,
+    'fb_app_id': settings.FB_APP_ID,
+    'routing_url': settings.ROUTING_URL
 }
 
 def home(request):
@@ -67,7 +66,7 @@ class AllArticles(View):
         try:
             limit = int(request.GET.get('limit'))
         except (ValueError, TypeError):
-            limit = HOMEPAGE_RESULTS_LIMIT
+            limit = settings.HOMEPAGE_RESULTS_LIMIT
 
         results = Article.objects.published().order_by('-publish_date')[:limit]
         response = [self.serialize_article(request, article) for article in results]

--- a/python/cac_tripplanner/cms/views.py
+++ b/python/cac_tripplanner/cms/views.py
@@ -6,7 +6,6 @@ from django.http import HttpResponse
 from django.shortcuts import render, get_object_or_404
 from django.views.generic import View
 
-from destinations.models import Destination
 from .models import AboutFaq, Article
 
 
@@ -15,23 +14,6 @@ DEFAULT_CONTEXT = {
     'fb_app_id': settings.FB_APP_ID,
     'routing_url': settings.ROUTING_URL
 }
-
-def home(request):
-
-    # Get a random article
-    article = Article.objects.random()
-
-    # get a few randomized destinations
-    destination_ids = list(Destination.objects.published().values_list('id', flat=True))
-    shuffle(destination_ids)
-    destinations = Destination.objects.filter(id__in=destination_ids[:4])
-
-    context = dict(tab='home',
-                   article=article,
-                   destinations=destinations,
-                   **DEFAULT_CONTEXT)
-    return render(request, 'home.html', context=context)
-
 
 def about_faq(request, slug):
     page = get_object_or_404(AboutFaq.objects.all(), slug=slug)

--- a/python/cac_tripplanner/destinations/views.py
+++ b/python/cac_tripplanner/destinations/views.py
@@ -11,6 +11,7 @@ from django.shortcuts import get_object_or_404, render
 from django.views.generic import View
 
 from .models import Destination, FeedEvent
+from cms.models import Article
 
 
 DEFAULT_CONTEXT = {
@@ -32,6 +33,27 @@ def base_view(request, page, context):
     all_context = dict(**DEFAULT_CONTEXT)
     all_context.update(**context)
     return render(request, page, context=all_context)
+
+
+def home(request):
+    if request.GET.get('destination') is not None:
+        # If there's a destination in the URL, go right to directions
+        context = {'tab': 'map'}
+    elif request.GET.get('origin') is not None:
+        # If there's no destination but there is an origin, go to Explore
+        context = {'tab': 'explore'}
+    else:
+        # Otherwise show the home view
+        # Show one random article
+        article = Article.objects.random()
+        # Show all destinations, in random order
+        destinations = Destination.objects.order_by('?').all()
+        context = {
+            'tab': 'home',
+            'article': article,
+            'destinations': destinations
+        }
+    return base_view(request, 'home.html', context=context)
 
 
 def directions(request):

--- a/src/app/scripts/cac/control/cac-control-directions-list.js
+++ b/src/app/scripts/cac/control/cac-control-directions-list.js
@@ -105,13 +105,11 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social) {
 
         $container.append($html);
 
-        // Share link to directions list page, which is relative to the current URL,
-        // has all of the current URL's parameters,
-        // does *not* have the map path (just directions, with a trailing slash),
-        // and has an added parameter for the selected itinerary.
+        // Share link to directions list page, which is relative to the current URL, has all of
+        // the current URL's parameters and has an added parameter for the selected itinerary.
         var href = window.location.href;
         var directionsUrl = ['/directions/',
-                             href.slice(href.indexOf('/map/directions') + '/map/directions'.length),
+                             href.slice(href.indexOf('?')),
                              '&',
                              $.param({itineraryIndex: itinerary.id})
                             ].join('');

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -141,8 +141,7 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
             setDirectionsError('origin');
             setDirectionsError('input-directions-to');
 
-            // TODO: fix URL routing for redesign
-            //updateUrl();  // Still update the URL if they request one-sided directions
+            updateUrl();  // Still update the URL if they request one-sided directions
             return;
         }
 
@@ -201,9 +200,8 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
         UserPreferences.setPreference('mode', mode);
         UserPreferences.setPreference('arriveBy', arriveBy);
 
-        // TODO: fix URL handling for redesign
         // Most changes trigger this function, so doing this here keeps the URL mostly in sync
-        //updateUrl();
+        updateUrl();
 
         var params = {
             fromText: UserPreferences.getPreference('originText'),
@@ -401,22 +399,6 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
 
         event.preventDefault();  // do not submit form
 
-        var $input;
-        var prefKey;
-
-        // Make sure to keep the directionsFrom origin in sync with the explore origin
-        if (key === 'origin') {
-            prefKey = 'origin';
-            $input = $(options.selectors.directionsFrom);
-        } else if (key === 'destination') {
-            prefKey = 'destination';
-            $input = $(options.selectors.typeaheadTo);
-        } else {
-            console.error('unrecognized typeahead key ' + key);
-            return;
-        }
-
-
         if (!location) {
             UserPreferences.clearLocation(key);
             setDirections(key, null);
@@ -589,16 +571,20 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
             typeaheadFrom.setValue(originText);
         }
 
-        if (tabControl.isTabShowing('directions')) {
-            if (origin && destination) {
-                planTrip();
-            } else if (origin || destination) {
-                mapControl.setDirectionsMarkers(directions.origin, directions.destination, true);
-                clearItineraries();
-            } else {
-                clearDirections();
-            }
+        // TODO: rework tab control
+        if (origin && destination) {
+            planTrip();
         }
+        // if (tabControl.isTabShowing('directions')) {
+        //     if (origin && destination) {
+        //         planTrip();
+        //     } else if (origin || destination) {
+        //         mapControl.setDirectionsMarkers(directions.origin, directions.destination, true);
+        //         clearItineraries();
+        //     } else {
+        //         clearDirections();
+        //     }
+        // }
     }
 
 })(_, jQuery, CAC.Control, CAC.Control.ModeOptions, CAC.Search.Geocoder,

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -222,10 +222,11 @@ CAC.Control.Directions = (function (_, $, Control, ModeOptions, Geocoder, Routin
         Routing.planTrip(directions.origin, directions.destination, date, params)
         .then(function (itineraries) {
             $(options.selectors.spinner).addClass('hidden');
-            if (!tabControl.isTabShowing('directions')) {
-                // if user has switched away from the directions tab, do not show trip
-                return;
-            }
+            // TODO: rework tab control
+            // if (!tabControl.isTabShowing('directions')) {
+            //     // if user has switched away from the directions tab, do not show trip
+            //     return;
+            // }
             // Add the itineraries to the map, highlighting the first one
             var isFirst = true;
             itineraryControl.clearItineraries();

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -113,7 +113,7 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, Modal, Templates, UserP
         // once routing figured out. Currently there is no way to go back
         // to the home page, so if there is an origin and destination in
         // preferences, the app will jump directly to the map page with no way back.
-        //$(document).ready(directionsControl.setFromUserPreferences());
+        $(document).ready(directionsControl.setFromUserPreferences());
     };
 
     return Home;

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -20,10 +20,13 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
     var router = null;
 
     function UrlRouter() {
-        router = new Navigo('/map');
+        router = new Navigo('');
 
-        router.on(new RegExp('/places/?\?'), setExplorePrefsFromUrl);
-        router.on(new RegExp('/directions/?\?'), setDirectionsPrefsFromUrl);
+        // TODO: disabling explore since it's not re-implemented yet for redesign.
+        //       probably explore will also be on the root path and we'll need one URL parsing
+        //       function that handles both cases
+        // router.on(new RegExp('/places/?\?'), setExplorePrefsFromUrl);
+        router.on(new RegExp('/\\?'), setDirectionsPrefsFromUrl);
 
         router.resolve();
     }
@@ -63,7 +66,7 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
     }
 
     function buildDirectionsUrlFromPrefs() {
-        return '/directions?' + buildUrlParamsFromPrefs(DIRECTIONS_ENCODE);
+        return '?' + buildUrlParamsFromPrefs(DIRECTIONS_ENCODE);
     }
 
 

--- a/src/app/scripts/cac/user/cac-user-preferences.js
+++ b/src/app/scripts/cac/user/cac-user-preferences.js
@@ -18,29 +18,6 @@ CAC.User.Preferences = (function(Storages, _) {
         get: function (pref) { return options[pref]; }
     };
 
-    // store to use for default location
-    var cityHall = {
-        name: 'City Hall, Philadelphia, Pennsylvania, USA',
-        extent: {
-            xmax: -75.158978,
-            xmin: -75.168978,
-            ymax: 39.958449,
-            ymin: 39.948449
-        },
-        feature: {
-            attributes: {
-                City: 'Philadelphia',
-                Postal: '',
-                Region: 'Pennsylvania',
-                StAddr: '1450 John F Kennedy Blvd'
-            },
-            geometry: {
-                x: -75.16397666699964,
-                y: 39.95344911900048
-            }
-        }
-    };
-
     var defaults = {
         arriveBy: false, // depart at set time, by default
         bikeTriangle: 'neutral',
@@ -48,8 +25,8 @@ CAC.User.Preferences = (function(Storages, _) {
         maxWalk: 2,
         method: 'explore',
         mode: 'TRANSIT,WALK',
-        origin: cityHall,
-        originText: cityHall.name,
+        origin: undefined,
+        originText: '',
         destination: undefined,
         destinationText: '',
         waypoints: [],

--- a/src/app/scripts/cac/user/cac-user-preferences.js
+++ b/src/app/scripts/cac/user/cac-user-preferences.js
@@ -1,10 +1,22 @@
 CAC.User.Preferences = (function(Storages, _) {
     'use strict';
 
+    // TODO: figure out local storage strategy
     // set up local storage
-    var namespace = 'cac_otp';
-    var namespaceStorage = Storages.initNamespaceStorage(namespace);
-    var storage = namespaceStorage.localStorage;
+    // var namespaceStorage = Storages.initNamespaceStorage('cac_otp');
+    // var storage = namespaceStorage.localStorage;
+
+    // Initialize preference storage object.
+    // Currently it just uses an 'options' dictionary, so preferences lives only as long as
+    // the page for which this is initialized.
+    // With this setup we have the flexibility to store all or some of the parameters to local
+    // storage if we decide that's valuable, and components that use these parameters don't need
+    // to know the difference.
+    var options = {};
+    var storage = {
+        set: function (pref, val) { options[pref] = val; },
+        get: function (pref) { return options[pref]; }
+    };
 
     // store to use for default location
     var cityHall = {


### PR DESCRIPTION
Re-enables reading and updating of URL parameters for interactive directions.

Also converts the UserPreferences component to just store values in a variable rather than in user storage, as a very rough first pass at issue #589.  Maybe this will be fine, maybe we still want to put some things in local storage, maybe things break, or maybe we want to go further and not use UserPreferences as an interface for sharing parameters between components.  Anyway, doing this was enough to get URL routing working.

I also moved the `home` view from the `cms` app to the `destinations` app because it seemed to fit in better there, and spruced up the shared view logic in `destinations/views.py` a bit.

And since I was in UserPreferences, I removed the City Hall default (resolves #574).

**To test**
- Following a link to directions should take you to the directions, e.g. http://localhost:8024/?origin=39.9616133%2C-75.1541914&originText=990%20Spring%20Garden%20St%2C%20Philadelphia%2C%20Pennsylvania%2C%2019123&mode=WALK%2CTRANSIT&destination=39.96581%2C-75.183494&destinationText=Fairmount%20Waterworks%20Interpretive%20Center
- Following the same link in the old format (with `map/directions` at the beginning) should redirect you to `/` and work, e.g. http://localhost:8024/map/directions?origin=39.9616133%2C-75.1541914&originText=990%20Spring%20Garden%20St%2C%20Philadelphia%2C%20Pennsylvania%2C%2019123&mode=WALK%2CTRANSIT&destination=39.96581%2C-75.183494&destinationText=Fairmount%20Waterworks%20Interpretive%20Center
- Since there's no more local storage, clearing the URL (i.e. going to http://localhost:8024/) should get you back to the home view with empty origin/destination and the default mode options.