### PR TITLE
Feature/more mode icons

### DIFF
--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -346,7 +346,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
             case 'DEPART':
                 return getModeClass(modeText);
             case 'CONTINUE':
-                return '';
+                return 'directions-step-continue';
             // fall through to similar cases for left/right
             case 'LEFT':
             case 'SLIGHTLY_LEFT':
@@ -359,10 +359,11 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
             case 'UTURN_RIGHT':
                 return 'directions-step-turn-right';
             case 'CIRCLE_CLOCKWISE':
+                return 'directions-step-clockwise';
             case 'CIRCLE_COUNTERCLOCKWISE':
-                return 'directions-step-circle'; // TODO: icon/class does not exist
+                return 'directions-step-counterclockwise';
             case 'ELEVATOR':
-                return 'directions-step-elevator'; // TODO: icon/class does not exist
+                return 'directions-step-elevator';
             default:
                 return '';
         }

--- a/src/app/scripts/cac/utils.js
+++ b/src/app/scripts/cac/utils.js
@@ -178,22 +178,21 @@ CAC.Utils = (function (_) {
 
     function modeStringHelper(modeString) {
         var modeIcons = {
-            // TODO: add appropriate mode icons
             BUS: {name: 'bus', font: 'icon'},
-            SUBWAY: {name: 'train', font: 'icon'}, // TODO
-            CAR: {name: 'train', font: 'icon'}, // TODO
+            SUBWAY: {name: 'subway', font: 'icon'},
+            CAR: {name: 'car', font: 'icon'},
             TRAIN: {name: 'train', font: 'icon'},
-            RAIL: {name: 'train', font: 'icon'}, // TODO
+            RAIL: {name: 'train', font: 'icon'},
             BICYCLE: {name: 'bike', font: 'icon'},
             WALK: {name: 'walk', font: 'icon'},
-            TRAM: {name: 'train', font: 'icon'}, // TODO
-            FERRY: {name: 'train', font: 'icon'} // TODO
+            TRAM: {name: 'tram', font: 'icon'},
+            FERRY: {name: 'ferry', font: 'icon'}
         };
 
         var mode = modeIcons[modeString];
 
         if (!mode) {
-            mode = {name: 'transit', font: 'icon'};
+            mode = {name: 'default', font: 'icon'};
             console.error('Unrecognized transit mode: ' + modeString + '. Using default icon.');
         }
 

--- a/src/app/styles/components/_directions-step-by-step.scss
+++ b/src/app/styles/components/_directions-step-by-step.scss
@@ -180,6 +180,12 @@
         }
     }
 
+    .directions-step-continue {
+        &::before {
+            content: '\e814';
+        }
+    }
+
     .directions-step-bike {
         &::before {
             content: '\e801';
@@ -193,6 +199,12 @@
         }
     }
 
+    .directions-step-car {
+        &::before {
+            content: '\f1b9';
+        }
+    }
+
     .directions-step-bus {
         &::before {
             content: '\e802';
@@ -202,6 +214,54 @@
     .directions-step-train {
         &::before {
             content: '\f238';
+        }
+    }
+
+    .directions-step-rail {
+        &::before {
+            content: '\f238';
+        }
+    }
+
+    .directions-step-subway {
+        &::before {
+            content: '\e811';
+        }
+    }
+
+    .directions-step-ferry {
+        &::before {
+            content: '\e816';
+        }
+    }
+
+    .directions-step-tram {
+        &::before {
+            content: '\e812';
+        }
+    }
+
+    .directions-step-elevator {
+        &::before {
+            content: '\e813';
+        }
+    }
+
+    .directions-step-continue {
+        &::before {
+            content: '\e814';
+        }
+    }
+
+    .directions-step-clockwise {
+        &::before {
+            content: '\e815';
+        }
+    }
+
+    .directions-step-counterclockwise {
+        &::before {
+            content: '\e817';
         }
     }
 }


### PR DESCRIPTION
Use the new icons for modes and step directions from #621. Closes #598.

Modified some classes/icons in the browser to test:
![image](https://cloud.githubusercontent.com/assets/960264/20323033/329c8f24-ab49-11e6-90ab-1edaec8ad97d.png)

![image](https://cloud.githubusercontent.com/assets/960264/20323113/8442fec6-ab49-11e6-8b1c-9f8a2605e9fa.png)

