### PR TITLE
Back to home via full page refresh

### DIFF
--- a/python/cac_tripplanner/templates/partials/header.html
+++ b/python/cac_tripplanner/templates/partials/header.html
@@ -3,7 +3,7 @@
         <div class="slogan-start">
             Walk. Ride. Pedal. Discover.
         </div>
-        <div class="logo"><a href="#"></a></div>
+        <div class="logo"><a href="{% url 'home' %}"></a></div>
         <div class="slogan-end">
             Next time bring your bike onboard.
         </div>


### PR DESCRIPTION
This feels ridiculously trivial, but now that the routing stuff is (mostly) setup, this is all that's necessary. If we wanted to trigger a back operation without a full page refresh I think we're in for a much larger world of hurt. 

That would involve the following I think, if I'm following what's going on correctly:
- Resetting the homepage flag in map control
- Destroying the map elements manually
- Removing any added event handlers
- Triggering a change to the urlRouter
That doesn't feel very easy, since we can't hook into any destroy hooks throughout the application -- most of the jQuery elements on the page aren't destroyed in transition, they're just hidden and shown. 

Thoughts?