### PR TITLE
Feature/add back layer switch minimizer

### DIFF
--- a/src/app/scripts/cac/control/cac-control-mode-options.js
+++ b/src/app/scripts/cac/control/cac-control-mode-options.js
@@ -72,7 +72,6 @@ CAC.Control.ModeOptions = (function ($) {
 
     function initialize() {
         // update classes on mode toggle buttons
-        // TODO: trigger event to notify that input changed
         $(options.selectors.modeToggle).on('click', options.selectors.modeOption, function(e) {
             e.preventDefault();
 

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -3,7 +3,13 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
 
     var defaults = {
         id: 'map',
-        selector: '#map',
+        selectors: {
+            id: '#map',
+            leafletMinimizer: '.leaflet-minimize',
+            leafletLayerList: '.leaflet-control-layers-list',
+            leafletLayerControl: '.leaflet-control-layers',
+            layerListMinimizedClass: 'minimized'
+        },
         center: [39.95, -75.1667],
         zoom: 14,
     };
@@ -31,6 +37,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
     var layerControl = null;
     var tabControl = null;
     var zoomControl = null;
+
 
     var loaded = false; // whether map tiles loaded yet (delay on mobile until in view)
 
@@ -105,6 +112,9 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         map = new cartodb.L.map(this.options.id, { zoomControl: false })
                            .setView(this.options.center, this.options.zoom);
 
+        tabControl = this.options.tabControl;
+        homepage = this.options.homepage;
+
         // put zoom control on top right
         zoomControl = new cartodb.L.Control.Zoom({ position: 'topright' });
 
@@ -160,24 +170,25 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                 collapsed: false
             });
             // add minimize button to layer control
-    	    var leafletMinimizer = '.leaflet-minimize';
-    	    var leafletLayerList = '.leaflet-control-layers-list';
-    	    var $layerContainer = $('.leaflet-control-layers');
+		var $layerContainer = $(this.options.selectors.leafletLayerControl);
+		$layerContainer.prepend('<div class="leaflet-minimize"><i class="icon-layers"></i></div>');
 
-    	    $layerContainer.prepend('<div class="leaflet-minimize"><i class="icon-layers"></i></div>');
-    	    $(leafletMinimizer).click(function() {
-    	        if ($(leafletMinimizer).hasClass('minimized')) {
-    		    // show again
-    		    $(leafletLayerList).show();
-    		    $(leafletMinimizer).html('<i class="icon-layers"></i>');
-    		    $(leafletMinimizer).removeClass('minimized');
-    	        } else {
-    		    // minimize it
-    		    $(leafletMinimizer).html('<i class="icon-layers"></i>');
-    		    $(leafletMinimizer).addClass('minimized');
-    		    $(leafletLayerList).hide();
-    	        }
-    	    });
+		var $minimizer = $(this.options.selectors.leafletMinimizer);
+		var selectors = this.options.selectors;
+		$minimizer.click(function() {
+		    if ($minimizer.hasClass(selectors.layerListMinimizedClass)) {
+		        // show again
+		        $(selectors.leafletLayerList).show();
+		        // TODO: use a separeate icon/styling for minimize button?
+		        $minimizer.html('<i class="icon-layers"></i>');
+		        $minimizer.removeClass(selectors.layerListMinimizedClass);
+		    } else {
+		        // minimize it
+		        $minimizer.html('<i class="icon-layers"></i>');
+		        $minimizer.addClass(selectors.layerListMinimizedClass);
+		        $(selectors.leafletLayerList).hide();
+		    }
+		});
         }
 
         layerControl.addTo(map);

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -113,7 +113,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                            .setView(this.options.center, this.options.zoom);
 
         tabControl = this.options.tabControl;
-        homepage = this.options.homepage;
 
         // put zoom control on top right
         zoomControl = new cartodb.L.Control.Zoom({ position: 'topright' });
@@ -169,29 +168,33 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                 position: 'bottomright',
                 collapsed: false
             });
-            // add minimize button to layer control
-		var $layerContainer = $(this.options.selectors.leafletLayerControl);
-		$layerContainer.prepend('<div class="leaflet-minimize"><i class="icon-layers"></i></div>');
-
-		var $minimizer = $(this.options.selectors.leafletMinimizer);
-		var selectors = this.options.selectors;
-		$minimizer.click(function() {
-		    if ($minimizer.hasClass(selectors.layerListMinimizedClass)) {
-		        // show again
-		        $(selectors.leafletLayerList).show();
-		        // TODO: use a separeate icon/styling for minimize button?
-		        $minimizer.html('<i class="icon-layers"></i>');
-		        $minimizer.removeClass(selectors.layerListMinimizedClass);
-		    } else {
-		        // minimize it
-		        $minimizer.html('<i class="icon-layers"></i>');
-		        $minimizer.addClass(selectors.layerListMinimizedClass);
-		        $(selectors.leafletLayerList).hide();
-		    }
-		});
         }
 
         layerControl.addTo(map);
+
+        // Add minimize button to layer control.
+        // This needs to happen after the layer control has been added to the map,
+        // or else the selectors will not find it.
+        var $layerContainer = $(this.options.selectors.leafletLayerControl);
+        window.lc = $layerContainer;
+
+        $layerContainer.prepend('<div class="leaflet-minimize"><i class="icon-layers"></i></div>');
+
+        var $minimizer = $(this.options.selectors.leafletMinimizer);
+        var selectors = this.options.selectors;
+        $minimizer.click(function() {
+            if ($minimizer.hasClass(selectors.layerListMinimizedClass)) {
+                // show again
+                $(selectors.leafletLayerList).show();
+                $minimizer.html('<i class="icon-layers"></i>');
+                $minimizer.removeClass(selectors.layerListMinimizedClass);
+            } else {
+                // minimize it
+                $minimizer.html('<i class="icon-layers"></i>');
+                $minimizer.addClass(selectors.layerListMinimizedClass);
+                $(selectors.leafletLayerList).hide();
+            }
+        });
     }
 
     function setGeocodeMarker(latLng) {
@@ -319,7 +322,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
     function loadMapComponents() {
         zoomControl.addTo(map);
         initializeOverlays();
-        initializeLayerControl();
+        initializeLayerControl.apply(this, null);
     }
 
     function clearMapComponents() {

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -160,24 +160,24 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                 collapsed: false
             });
             // add minimize button to layer control
-            var leafletMinimizer = '.leaflet-minimize';
-            var leafletLayerList = '.leaflet-control-layers-list';
-            var $layerContainer = $('.leaflet-control-layers');
+    	    var leafletMinimizer = '.leaflet-minimize';
+    	    var leafletLayerList = '.leaflet-control-layers-list';
+    	    var $layerContainer = $('.leaflet-control-layers');
 
-            $layerContainer.prepend('<div class="leaflet-minimize"><i class="fa fa-minus"></i></div>');
-            $(leafletMinimizer).click(function() {
-                if ($(leafletMinimizer).hasClass('minimized')) {
-                    // show again
-                    $(leafletLayerList).show();
-                    $(leafletMinimizer).html('<i class="fa fa-minus"></i>');
-                    $(leafletMinimizer).removeClass('minimized');
-                } else {
-                    // minimize it
-                    $(leafletMinimizer).html('<i class="fa fa-map-marker"></i>');
-                    $(leafletMinimizer).addClass('minimized');
-                    $(leafletLayerList).hide();
-                }
-            });
+    	    $layerContainer.prepend('<div class="leaflet-minimize"><i class="icon-layers"></i></div>');
+    	    $(leafletMinimizer).click(function() {
+    	        if ($(leafletMinimizer).hasClass('minimized')) {
+    		    // show again
+    		    $(leafletLayerList).show();
+    		    $(leafletMinimizer).html('<i class="icon-layers"></i>');
+    		    $(leafletMinimizer).removeClass('minimized');
+    	        } else {
+    		    // minimize it
+    		    $(leafletMinimizer).html('<i class="icon-layers"></i>');
+    		    $(leafletMinimizer).addClass('minimized');
+    		    $(leafletLayerList).hide();
+    	        }
+    	    });
         }
 
         layerControl.addTo(map);

--- a/src/app/styles/components/_map.scss
+++ b/src/app/styles/components/_map.scss
@@ -40,4 +40,39 @@
             border: 0;
         }
     }
+
+    .leaflet-control-layers {
+        margin-right: 30px;
+        margin-bottom: 30px;
+        position: relative;
+        padding: 15px 20px 18px;
+        border-radius: 0;
+        box-shadow: 0 0 12px rgba(0,0,0,0.35);
+
+        .leaflet-control-layers-separator {
+            margin: 15px -20px 15px -20px;
+        }
+        .leaflet-control-layers-selector {
+            margin-right: 8px;
+            top: 0;
+        }
+    }
+
+    .leaflet-minimize {
+        color: #707070;
+        cursor: pointer;
+        position: absolute;
+        border-radius: 3px;
+        line-height: 10px;
+        padding: 13px 15px;
+        bottom: 0;
+        z-index: 99999;
+        right: 0;
+
+        &.minimized {
+            height: 38px;
+            line-height: 0;
+            background: white;
+        }
+    }
 }

--- a/src/karma/karma-coverage.conf.js
+++ b/src/karma/karma-coverage.conf.js
@@ -19,7 +19,7 @@ module.exports = function(config) {
       // load moment before other vendor scripts; is requirement for bootstrap datetime picker
       '/srv/cac/scripts/vendor/moment.js',
       '/srv/cac/scripts/vendor/moment-duration-format.js',
-      '/srv/cac/scripts/vendor/cartodb.js',
+      '/srv/cac/scripts/vendor/cartodb.uncompressed.js',
       '/srv/cac/scripts/vendor/Polyline.encoded.js',
       '/srv/cac/scripts/vendor/!(cartodb|Polyline|moment).js',
 

--- a/src/karma/karma-dev.conf.js
+++ b/src/karma/karma-dev.conf.js
@@ -19,7 +19,7 @@ module.exports = function(config) {
       // load moment before other vendor scripts; is requirement for bootstrap datetime picker
       '/srv/cac/scripts/vendor/moment.js',
       '/srv/cac/scripts/vendor/moment-duration-format.js',
-      '/srv/cac/scripts/vendor/cartodb.js',
+      '/srv/cac/scripts/vendor/cartodb.uncompressed.js',
       '/srv/cac/scripts/vendor/Polyline.encoded.js',
       '/srv/cac/scripts/vendor/!(cartodb|Polyline|moment).js',
 

--- a/src/karma/karma.conf.js
+++ b/src/karma/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       '/srv/cac/scripts/vendor/jquery.js',
-      '/srv/cac/scripts/vendor/cartodb.js',
+      '/srv/cac/scripts/vendor/cartodb.uncompressed.js',
       '/srv/cac/scripts/vendor.js',
       '/srv/cac/scripts/main.js',
       'test/spec/*.js',


### PR DESCRIPTION
Re-implements the layer switcher minimize button and shuffles around some selectors.

Fixes #612.

@lederer: this could use some styling help. Since we no longer have a minus icon, I just went with the layer icon for both minimize and maximize. Tried just using a textual minus sign in a span, but it was too small to be easily seen. Also it doesn't pull right any more in the maximized layer switcher.

![image](https://cloud.githubusercontent.com/assets/960264/20325677/b0884c66-ab53-11e6-93d8-db02d35cc4dd.png)
