### PR TITLE
Share modal redesign

### DIFF
--- a/python/cac_tripplanner/destinations/views.py
+++ b/python/cac_tripplanner/destinations/views.py
@@ -62,7 +62,7 @@ def directions(request):
     :param request: Request object
     :returns: A rendered response
     """
-    return base_view(request, 'directions.html')
+    return base_view(request, 'directions.html', {})
 
 
 def place_detail(request, pk):

--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -111,7 +111,6 @@
     <script src="{% static 'scripts/main/cac/search/cac-search-params.js' %}"></script>
     <script src="{% static 'scripts/main/cac/search/cac-geocoder.js' %}"></script>
     <script src="{% static 'scripts/main/cac/search/cac-typeahead.js' %}"></script>
-    <script src="{% static 'scripts/main/cac/share/cac-social-sharing.js' %}"></script>
     <script src="{% static 'scripts/main/cac/routing/cac-routing-itinerary.js' %}"></script>
     <script src="{% static 'scripts/main/cac/routing/cac-routing-plans.js' %}"></script>
     <script src="{% static 'scripts/main/cac/urlrouting/cac-urlrouting.js' %}"></script>
@@ -122,7 +121,9 @@
     <script src="{% static 'scripts/main/cac/map/cac-map-templates.js' %}"></script>
     <script src="{% static 'scripts/main/cac/control/cac-control-mode-options.js' %}"></script>
     <script src="{% static 'scripts/main/cac/control/cac-control-modal.js' %}"></script>
+    <script src="{% static 'scripts/main/cac/control/cac-control-modal.js' %}"></script>
     <script src="{% static 'scripts/main/cac/control/cac-control-tab.js' %}"></script>
+    <script src="{% static 'scripts/main/cac/share/cac-share-modal.js' %}"></script>
     <script src="{% static 'scripts/main/cac/control/cac-control-sidebar-explore.js' %}"></script>
     <script src="{% static 'scripts/main/cac/control/cac-control-directions.js' %}"></script>
     <script src="{% static 'scripts/main/cac/control/cac-control-itinerary-list.js' %}"></script>

--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -87,39 +87,7 @@
 
     <div class="directions-step-by-step"></div>
 
-
-    <div class="modal-overlay">
-        <div class="modal-panel modal-options">
-            <header class="modal-header">
-                Bike options
-            </header>
-            <ul class="modal-list modal-contents">
-                <li class="modal-list-indego">Indego bike sharing</li>
-                <li class="modal-list-timing">Arrive/depart at…</li>
-                <li class="modal-list-ride">Ride quality</li>
-            </ul>
-            <footer class="modal-footer">
-                <button name="close-modal" class="btn-close-modal">Close</button>
-            </footer>
-        </div>
-
-        <div class="modal-panel modal-share">
-            <header class="modal-header">
-                <i class="icon-share"></i>
-                Share
-            </header>
-            <ul class="modal-list modal-contents">
-                <li class="modal-list-link">Get a link</li>
-                <li class="modal-list-twitter">Twitter</li>
-                <li class="modal-list-facebook">Facebook</li>
-                <li class="modal-list-google">Google+</li>
-                <li class="modal-list-email">Email</li>
-            </ul>
-            <footer class="modal-footer">
-                <button name="close-modal" class="btn-close-modal">Close</button>
-            </footer>
-        </div>
-    </div>
+    {% include "partials/modals.html" %}
 
     {% include "partials/footer.html" %}
 {% endblock %}

--- a/python/cac_tripplanner/templates/partials/modals.html
+++ b/python/cac_tripplanner/templates/partials/modals.html
@@ -1,0 +1,32 @@
+<div class="modal-overlay">
+    <div class="modal-panel modal-options">
+        <header class="modal-header">
+            Bike options
+        </header>
+        <ul class="modal-list modal-contents">
+            <li class="modal-list-indego">Indego bike sharing</li>
+            <li class="modal-list-timing">Arrive/depart at…</li>
+            <li class="modal-list-ride">Ride quality</li>
+        </ul>
+        <footer class="modal-footer">
+            <button name="close-modal" class="btn-close-modal">Close</button>
+        </footer>
+    </div>
+
+    <div class="modal-panel modal-share">
+        <header class="modal-header">
+            <i class="icon-share"></i>
+            Share
+        </header>
+        <ul class="modal-list modal-contents">
+            <li class="modal-list-link">Get a link</li>
+            <li class="modal-list-twitter">Twitter</li>
+            <li class="modal-list-facebook">Facebook</li>
+            <li class="modal-list-google">Google+</li>
+            <li class="modal-list-email">Email</li>
+        </ul>
+        <footer class="modal-footer">
+            <button name="close-modal" class="btn-close-modal">Close</button>
+        </footer>
+    </div>
+</div>

--- a/python/cac_tripplanner/templates/partials/modals.html
+++ b/python/cac_tripplanner/templates/partials/modals.html
@@ -15,18 +15,23 @@
 
     <div class="modal-panel modal-share">
         <header class="modal-header">
-            <i class="icon-share"></i>
-            Share
+            <span class="default"><i class="icon-share"></i>Share </span>
+            <span class="secondary share-link"><i class="icon-link"></i> Get a link </span>
         </header>
-        <ul class="modal-list modal-contents">
+        <ul class="modal-list modal-contents default">
             <li class="modal-list-link">Get a link</li>
             <li class="modal-list-twitter">Twitter</li>
             <li class="modal-list-facebook">Facebook</li>
             <li class="modal-list-google">Google+</li>
             <li class="modal-list-email">Email</li>
         </ul>
+        <div class="modal-contents secondary share-link">
+            <p>Here's a link to these directions:</p>
+            <p><a id="modalDirectionsLink" href=""></a></p>
+        </div>
         <footer class="modal-footer">
             <button name="close-modal" class="btn-close-modal">Close</button>
         </footer>
     </div>
+
 </div>

--- a/python/cac_tripplanner/templates/partials/modals.html
+++ b/python/cac_tripplanner/templates/partials/modals.html
@@ -15,8 +15,12 @@
 
     <div class="modal-panel modal-share">
         <header class="modal-header">
-            <span class="default"><i class="icon-share"></i>Share </span>
-            <span class="secondary share-link"><i class="icon-link"></i> Get a link </span>
+            <div class="default">
+                <div class="modal-header-contents"><i class="icon-share"></i>Share </div>
+            </div>
+            <div class="secondary share-link">
+                <div class="modal-header-contents"><i class="icon-link"></i> Get a link </div>
+            </div>
         </header>
         <ul class="modal-list modal-contents default">
             <li class="modal-list-link">Get a link</li>

--- a/src/app/scripts/cac/control/cac-control-directions-list.js
+++ b/src/app/scripts/cac/control/cac-control-directions-list.js
@@ -3,7 +3,7 @@
  *  View control for the sidebar directions list
  *
  */
-CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social) {
+CAC.Control.DirectionsList = (function (_, $, MapTemplates) {
 
     'use strict';
 
@@ -39,13 +39,11 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social) {
 
     var $container = null;
     var itinerary = {};
-    var socialSharing = null;
 
     function DirectionsListControl(params) {
         // recursively extend objects, so those not overridden will still exist
         options = $.extend(true, {}, defaults, params);
         $container = $(options.selectors.container);
-        socialSharing = new Social();
     }
 
     DirectionsListControl.prototype = {
@@ -103,42 +101,13 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social) {
             $container.append($alert);
         }
 
-        $container.append($html);
-
-        // Share link to directions list page, which is relative to the current URL, has all of
-        // the current URL's parameters and has an added parameter for the selected itinerary.
-        var href = window.location.href;
-        var directionsUrl = ['/directions/',
-                             href.slice(href.indexOf('?')),
-                             '&',
-                             $.param({itineraryIndex: itinerary.id})
-                            ].join('');
-
-        // TODO: postpone shortening link until user chooses to share directions
-        socialSharing.shortenLink(directionsUrl).then(function(shortened) {
-            // set up click handlers for social sharing with shortened link
-            $(options.selectors.twitterShareButton).on('click',
-                                                       {url: shortened},
-                                                       socialSharing.shareOnTwitter);
-            $(options.selectors.facebookShareButton).on('click',
-                                                        {url: shortened},
-                                                        socialSharing.shareOnFacebook);
-            $(options.selectors.googlePlusShareButton).on('click',
-                                                          {url: shortened},
-                                                          socialSharing.shareOnGooglePlus);
-            $(options.selectors.emailShareButton).on('click',
-                                                     {url: shortened},
-                                                     socialSharing.shareViaEmail);
-            $(options.selectors.directLinkButton).on('click',
-                                                     {url: shortened},
-                                                     socialSharing.shareDirectLink);
-        });
-    }
+        $container.append($html);    }
 
     function getTemplate(itinerary) {
         var templateData = {
             showBackButton: options.showBackButton,
             showShareButton: options.showShareButton,
+            id: itinerary.id,
             start: {
                 text: itinerary.fromText,
                 time: itinerary.startTime
@@ -171,4 +140,4 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates, Social) {
         }
     }
 
-})(_, jQuery, CAC.Map.Templates, CAC.Share.Social);
+})(_, jQuery, CAC.Map.Templates);

--- a/src/app/scripts/cac/control/cac-control-modal.js
+++ b/src/app/scripts/cac/control/cac-control-modal.js
@@ -45,12 +45,18 @@ CAC.Control.Modal = (function ($) {
         if (event && event.preventDefault) {
             event.preventDefault();
         }
+        if (this.options.onOpen) {
+            return this.options.onOpen(event);
+        }
     }
 
     function _close(event) {
         $(this.options.selectors.body).removeClass(_getBodyClass(this));
         if (event && event.preventDefault) {
             event.preventDefault();
+        }
+        if (this.options.onClose) {
+            return this.options.onClose(event);
         }
     }
 

--- a/src/app/scripts/cac/control/cac-control-modal.js
+++ b/src/app/scripts/cac/control/cac-control-modal.js
@@ -14,49 +14,48 @@ CAC.Control.Modal = (function ($) {
         clickHandler: function (event) { }
     };
 
-    var options = {};
-
     function Modal(params) {
-        options = $.extend({}, defaults, params);
+        var options = $.extend({}, defaults, params);
         this.options = options;
         this.initialize();
     }
 
     Modal.prototype = {
         initialize: initialize,
-        open: open,
-        close: close
     };
 
     return Modal;
 
     function initialize() {
-        if (!options.modalClass) {
+        if (!this.options.modalClass) {
             throw 'CAC.Control.Modal options.modalClass required.';
         }
 
-        $(options.selectors.modal + ' .' + options.modalClass).on('click',
-            options.selectors.clickHandlerFilter, options.clickHandler);
-        $(options.selectors.modal + ' .' + options.modalClass).on('click',
-            options.selectors.buttonClose, close);
+        this.open = _open.bind(this);
+        this.close = _close.bind(this);
+
+        $(this.options.selectors.modal + ' .' + this.options.modalClass).on('click',
+            this.options.selectors.clickHandlerFilter, this.options.clickHandler);
+        $(this.options.selectors.modal + ' .' + this.options.modalClass).on('click',
+            this.options.selectors.buttonClose, this.close);
     }
 
-    function open(event) {
-        $(options.selectors.body).addClass(_getBodyClass());
+    function _open(event) {
+        $(this.options.selectors.body).addClass(_getBodyClass(this));
         if (event && event.preventDefault) {
             event.preventDefault();
         }
     }
 
-    function close(event) {
-        $(options.selectors.body).removeClass(_getBodyClass());
+    function _close(event) {
+        $(this.options.selectors.body).removeClass(_getBodyClass(this));
         if (event && event.preventDefault) {
             event.preventDefault();
         }
     }
 
-    function _getBodyClass() {
-        return 'body-modal body-' + options.modalClass;
+    function _getBodyClass(modal) {
+        return 'body-modal body-' + modal.options.modalClass;
     }
 
 })(jQuery);

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -245,7 +245,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                     '</button>',
                 '{{/if}}',
             '</header>',
-            '<div class="directions-list-of-steps">',
+            '<div class="directions-list-of-steps" data-itinerary-id="{{data.id}}">',
                 '<div class="directions-leg directions-leg-origin">',
                     '<div class="directions-step directions-step-origin">',
                     '<div class="directions-instruction">Depart {{data.start.text}}</div>',

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -1,5 +1,5 @@
-CAC.Pages.Home = (function ($, ModeOptions,  MapControl, Modal, TabControl, Templates, UserPreferences,
-                            UrlRouter) {
+CAC.Pages.Home = (function ($, ModeOptions,  MapControl, Modal, ShareModal, TabControl, Templates,
+                            UserPreferences, UrlRouter) {
     'use strict';
 
     var defaults = {
@@ -7,8 +7,6 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, Modal, TabControl, Temp
             // modal
             optionsButton: '.btn-options',
             optionsModalClass: 'modal-options',
-            shareModalClass: 'modal-share',
-            shareModalButton: '.share-directions',
 
             // destinations
             placeCard: '.place-card',
@@ -49,8 +47,7 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, Modal, TabControl, Temp
         options = $.extend({}, defaults, params);
         modeOptionsControl = new ModeOptions();
 
-        shareModal = new Modal({modalClass: options.selectors.shareModalClass});
-        $('body').on('click', options.selectors.shareModalButton, shareModal.open);
+        shareModal = new ShareModal({});
 
         transitOptionsModal = new Modal({
             modalClass: options.selectors.optionsModalClass,
@@ -186,5 +183,5 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, Modal, TabControl, Temp
         directionsControl.moveOriginDestination('destination', position);
     }
 
-})(jQuery, CAC.Control.ModeOptions, CAC.Map.Control, CAC.Control.Modal, CAC.Control.Tab, CAC.Home.Templates, CAC.User.Preferences,
-    CAC.UrlRouting.UrlRouter);
+})(jQuery, CAC.Control.ModeOptions, CAC.Map.Control, CAC.Control.Modal, CAC.Share.ShareModal,
+    CAC.Control.Tab, CAC.Home.Templates, CAC.User.Preferences, CAC.UrlRouting.UrlRouter);

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -6,7 +6,9 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, Modal, TabControl, Temp
         selectors: {
             // modal
             optionsButton: '.btn-options',
+            optionsModalClass: 'modal-options',
             shareModalClass: 'modal-share',
+            shareModalButton: '.share-directions',
 
             // destinations
             placeCard: '.place-card',
@@ -48,10 +50,10 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, Modal, TabControl, Temp
         modeOptionsControl = new ModeOptions();
 
         shareModal = new Modal({modalClass: options.selectors.shareModalClass});
-        // TODO: Open share modal once view with button exists
+        $('body').on('click', options.selectors.shareModalButton, shareModal.open);
 
         transitOptionsModal = new Modal({
-            modalClass: options.selectors.shareModalClass,
+            modalClass: options.selectors.optionsModalClass,
             clickHandler: onOptionsModalItemClicked
         });
         $(options.selectors.optionsButton).on('click', transitOptionsModal.open);

--- a/src/app/scripts/cac/share/cac-share-modal.js
+++ b/src/app/scripts/cac/share/cac-share-modal.js
@@ -1,176 +1,74 @@
-/**
- *  Share links on social media.
- *
- */
-CAC.Share.Social = (function ($, Settings) {
+CAC.Share.ShareModal = (function ($, Settings, Modal) {
     'use strict';
 
     var defaults = {
-        useHost: window.location.protocol + '//' + window.location.host,
         selectors: {
-            modal: '#linkModal',
+            shareModalClass: 'modal-share',
+            shareModalButton: '.share-directions',
+            itinerary: '.directions-list-of-steps',
+            defaultView: '.default',
+            linkView: '.share-link',
             modalLink: '#modalDirectionsLink'
+        },
+
+        modalClass: 'modal-share',
+        clickHandler: onClick,
+
+        optionClassPrefix: 'modal-list-',
+        useHost: window.location.protocol + '//' + window.location.host,
+        shareFunctions: {
+            link: shareDirectLink,
+            facebook: shareOnFacebook,
+            google: shareOnGooglePlus,
+            twitter: shareOnTwitter,
+            email: shareViaEmail,
         }
     };
+
     var options = {};
+    var modal = null;
 
-    function Social(params) {
-        // recursively extend objects, so those not overridden will still exist
-        options = $.extend(true, {}, defaults, params);
+    function ShareModal(params) {
+        options = $.extend({}, defaults, params);
+        this.initialize();
     }
 
-    Social.prototype = {
-        shareDirectLink: shareDirectLink,
-        shareOnFacebook: shareOnFacebook,
-        shareOnGooglePlus: shareOnGooglePlus,
-        shareOnTwitter: shareOnTwitter,
-        shareViaEmail: shareViaEmail,
-        shortenLink: shortenLink
+    ShareModal.prototype = {
+        initialize: initialize,
     };
 
-    return Social;
+    return ShareModal;
 
-    /**
-     * Open popup for user to post directions link to their timeline.
-     *
-     * @param {object} event Triggering click event; expected to have data.url set to link to share
-    */
-    function shareOnFacebook(event) {
-        var caption = 'Trip Plan on GoPhillyGo';
+    function initialize() {
+        modal = new Modal({
+            modalClass: options.selectors.shareModalClass,
+            clickHandler: onClick,
+            onClose: onClose
+        });
 
-        // TODO: get a screenshot of the map page to post? Shouldn't be using logo.
-        var pictureUrl = [options.useHost,
-                          '/static/images/logo_color.png'
-                         ].join('');
+        $('body').on('click', options.selectors.shareModalButton, modal.open);
+    }
 
-        if (typeof FB !== 'undefined') {
-            // prompt user to log in, if they aren't already
-            FB.getLoginStatus(function(response) {
-                if (response.status !== 'connected') {
-                    FB.login();
-                }
-            });
+    function onClose() {
+        toggleLinkView(false);
+    }
 
-            FB.ui({
-                method: 'feed',
-                link: event.data.url,
-                caption: caption,
-                picture: pictureUrl,
-            }, function(response){
-                if (!response || _.has(response, 'error_code')) {
-                    console.warn(response);
-                    console.warn('did not post to facebook');
-                }
-            });
-        } else {
-            console.warn('FB unavailable. Is script loaded?');
-            // redirect to URL if API unavailable
-
-            var feedUrl = 'https://www.facebook.com/dialog/feed?';
-
-            /* jshint camelcase:false */
-            var params = {
-                app_id: Settings.fbAppId,
-                display: 'popup',
-                caption: caption,
-                picture: pictureUrl,
-                link: event.data.url,
-                redirect_uri: options.useHost + '/map'
-            };
-            /* jshint camelcase:true */
-
-            var url = feedUrl + $.param(params);
-            window.open(url, '_blank');
+    function onClick(event) {
+        var typeMatch = event.target.className.match(new RegExp('modal-list-' + '(\\w+)'));
+        if (typeMatch.length > 1) {
+            var shareFunction = options.shareFunctions[typeMatch[1]];
+            getShortLink().then(shareFunction);
         }
     }
 
-    /**
-     * Open popup for user to post directions link to Google+.
-     *
-     * @param {object} event Triggering click event; expected to have data.url set to link to share
-    */
-    function shareOnGooglePlus(event) {
-        // TODO: make interactive post instead?
-        // https://developers.google.com/+/web/share/interactive
-
-        // use the share endpoint directly
-        // https://developers.google.com/+/web/share/#sharelink-endpoint
-        var shareUrl = 'https://plus.google.com/share';
-        var windowOpts = 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600';
-
-        var params = {
-            url: event.data.url
-        };
-        var url = shareUrl + '?' + $.param(params);
-        window.open(url, '', windowOpts);
-    }
-
-    /**
-     * Open popup for user to tweet directions link.
-     *
-     * @param {object} event Triggering click event; expected to have data.url set to link to share
-    */
-    function shareOnTwitter(event) {
-        var intentUrl = 'https://twitter.com/intent/tweet';
-        // TODO: change tweet wording?
-        var tweet = 'Check out my trip on GoPhillyGo!';
-        // @go_philly_go twitter account is "related" to tweet (might suggest to follow)
-        var related ='go_philly_go:GoPhillyGo on Twitter';
-        // TODO: use via?
-
-        // open in a popup like standard Twitter button; see 'Limited Dependencies' section here:
-        // https://dev.twitter.com/web/intents
-        var winWidth = screen.width;
-        var winHeight = screen.height;
-        var width = 550;
-        var height = 420;
-        var left = Math.round((winWidth / 2) - (width / 2));
-        var top = 0;
-        if (winHeight > height) {
-            top = Math.round((winHeight / 2) - (height / 2));
-        }
-
-        var windowOptions = ['scrollbars=yes,resizable=yes,toolbar=no,location=yes',
-                             ',width=', + width,
-                             ',height=' + height,
-                             ',left=' + left,
-                             ',top=' + top
-                            ].join('');
-
-        var tweetParams = {
-                url: event.data.url,
-                text: tweet,
-                related: related
-            };
-            var url = intentUrl + '?' + $.param(tweetParams);
-            window.open(url, 'intent', windowOptions);
-            event.returnValue = false;
-            event.preventDefault();
-    }
-
-    /**
-     * Open email client with message pre-populated with directions link.
-     *
-     * @param {object} event Triggering click event; expected to have data.url set to link to share
-     */
-    function shareViaEmail(event) {
-        var mailToLink = ['mailto:?subject=My Trip on GoPhillyGo',
-                          '&body=Check out my trip on GoPhillyGo: ',
-                          event.data.url
-                         ].join('');
-        mailToLink = encodeURI(mailToLink);
-        window.location.href = mailToLink;
-    }
-
-     /**
-     * Open modal to display directions link.
-     *
-     * @param {object} event Triggering click event; expected to have data.url set to link to share
-     */
-    function shareDirectLink(event) {
-        $(options.selectors.modalLink).text(event.data.url);
-        $(options.selectors.modalLink).attr('href', event.data.url);
-        $(options.selectors.modal).modal();
+    function getShortLink() {
+        // Share link to directions list page, which is relative to the current URL, has all of
+        // the current URL's parameters and has an added parameter for the selected itinerary.
+        var href = window.location.href;
+        var itineraryId = $(options.selectors.itinerary).data('itineraryId');
+        var url = ['/directions/', href.slice(href.indexOf('?')), '&',
+                   $.param({itineraryIndex: itineraryId}) ].join('');
+        return shortenLink(url);
     }
 
     /**
@@ -204,4 +102,156 @@ CAC.Share.Social = (function ($, Settings) {
         return dfd.promise();
     }
 
-})(jQuery, CAC.Settings);
+    /**
+     * Open popup for user to post directions link to their timeline.
+     *
+     * @param {object} event Triggering click event; expected to have data.url set to link to share
+    */
+    function shareOnFacebook(shortUrl) {
+        var caption = 'Trip Plan on GoPhillyGo';
+
+        // TODO: get a screenshot of the map page to post? Shouldn't be using logo.
+        var pictureUrl = [options.useHost,
+                          '/static/images/logo_color.png'
+                         ].join('');
+
+        if (typeof FB !== 'undefined') {
+            // prompt user to log in, if they aren't already
+            FB.getLoginStatus(function(response) {
+                if (response.status !== 'connected') {
+                    FB.login();
+                }
+            });
+
+            FB.ui({
+                method: 'feed',
+                link: shortUrl,
+                caption: caption,
+                picture: pictureUrl,
+            }, function(response){
+                if (!response || _.has(response, 'error_code')) {
+                    console.warn(response);
+                    console.warn('did not post to facebook');
+                }
+            });
+        } else {
+            console.warn('FB unavailable. Is script loaded?');
+            // redirect to URL if API unavailable
+
+            var feedUrl = 'https://www.facebook.com/dialog/feed?';
+
+            /* jshint camelcase:false */
+            var params = {
+                app_id: Settings.fbAppId,
+                display: 'popup',
+                caption: caption,
+                picture: pictureUrl,
+                link: shortUrl,
+                redirect_uri: options.useHost + '/map'
+            };
+            /* jshint camelcase:true */
+
+            var url = feedUrl + $.param(params);
+            window.open(url, '_blank');
+        }
+    }
+
+    /**
+     * Open popup for user to post directions link to Google+.
+     *
+     * @param {object} event Triggering click event; expected to have data.url set to link to share
+    */
+    function shareOnGooglePlus(shortUrl) {
+        // TODO: make interactive post instead?
+        // https://developers.google.com/+/web/share/interactive
+
+        // use the share endpoint directly
+        // https://developers.google.com/+/web/share/#sharelink-endpoint
+        var shareUrl = 'https://plus.google.com/share';
+        var windowOpts = 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600';
+
+        var params = {
+            url: shortUrl
+        };
+        var url = shareUrl + '?' + $.param(params);
+        window.open(url, '', windowOpts);
+    }
+
+    /**
+     * Open popup for user to tweet directions link.
+     *
+     * @param {object} event Triggering click event; expected to have data.url set to link to share
+    */
+    function shareOnTwitter(shortUrl) {
+        var intentUrl = 'https://twitter.com/intent/tweet';
+        // TODO: change tweet wording?
+        var tweet = 'Check out my trip on GoPhillyGo!';
+        // @go_philly_go twitter account is "related" to tweet (might suggest to follow)
+        var related ='go_philly_go:GoPhillyGo on Twitter';
+        // TODO: use via?
+
+        // open in a popup like standard Twitter button; see 'Limited Dependencies' section here:
+        // https://dev.twitter.com/web/intents
+        var winWidth = screen.width;
+        var winHeight = screen.height;
+        var width = 550;
+        var height = 420;
+        var left = Math.round((winWidth / 2) - (width / 2));
+        var top = 0;
+        if (winHeight > height) {
+            top = Math.round((winHeight / 2) - (height / 2));
+        }
+
+        var windowOptions = ['scrollbars=yes,resizable=yes,toolbar=no,location=yes',
+                             ',width=', + width,
+                             ',height=' + height,
+                             ',left=' + left,
+                             ',top=' + top
+                            ].join('');
+
+        var tweetParams = {
+                url: shortUrl,
+                text: tweet,
+                related: related
+            };
+            var url = intentUrl + '?' + $.param(tweetParams);
+            window.open(url, 'intent', windowOptions);
+    }
+
+    /**
+     * Open email client with message pre-populated with directions link.
+     *
+     * @param {object} event Triggering click event; expected to have data.url set to link to share
+     */
+    function shareViaEmail(shortUrl) {
+        var mailToLink = ['mailto:?subject=My Trip on GoPhillyGo',
+                          '&body=Check out my trip on GoPhillyGo: ',
+                          shortUrl
+                         ].join('');
+        mailToLink = encodeURI(mailToLink);
+        window.location.href = mailToLink;
+    }
+
+     /**
+     * Open modal to display directions link.
+     *
+     * @param {object} event Triggering click event; expected to have data.url set to link to share
+     */
+    function shareDirectLink(shortUrl) {
+        $(options.selectors.modalLink).text(shortUrl);
+        $(options.selectors.modalLink).attr('href', shortUrl);
+        toggleLinkView(true);
+    }
+
+    function toggleLinkView(show) {
+        var defaultView = $(modal.options.selectors.modal).find(options.selectors.defaultView);
+        var linkView = $(modal.options.selectors.modal).find(options.selectors.linkView);
+        if (show) {
+            defaultView.hide();
+            linkView.show();
+        } else {
+            linkView.hide();
+            defaultView.show();
+        }
+    }
+})(jQuery, CAC.Settings, CAC.Control.Modal);

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -20,7 +20,7 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
     var router = null;
 
     function UrlRouter() {
-        router = new Navigo();
+        router = new Navigo('/');
         router.on('/', setPrefsFromUrl);
         router.resolve();
     }
@@ -35,7 +35,7 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
     // Updates the displayed URL without triggering any routing callbacks
     function updateUrl(url) {
         router.pause(true);
-        router.navigate(url);
+        router.navigate(url, true);
         router.pause(false);
     }
 
@@ -44,7 +44,7 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
     }
 
     function buildExploreUrlFromPrefs() {
-        return '?' + buildUrlParamsFromPrefs(EXPLORE_ENCODE);
+        return '/?' + buildUrlParamsFromPrefs(EXPLORE_ENCODE);
     }
 
     /* Read URL parameters into user preferences
@@ -67,7 +67,7 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
     }
 
     function buildDirectionsUrlFromPrefs() {
-        return '?' + buildUrlParamsFromPrefs(DIRECTIONS_ENCODE);
+        return '/?' + buildUrlParamsFromPrefs(DIRECTIONS_ENCODE);
     }
 
 

--- a/src/app/styles/components/_modal.scss
+++ b/src/app/styles/components/_modal.scss
@@ -46,6 +46,13 @@
     color: $white;
     text-transform: uppercase;
 
+    .modal-header-contents {
+        display: flex;
+        flex-flow: column nowrap;
+        align-items: center;
+        justify-content: center;
+    }
+
     .modal-sub-menu & {
         text-transform: none;
     }

--- a/src/app/styles/components/_modal.scss
+++ b/src/app/styles/components/_modal.scss
@@ -32,6 +32,9 @@
         display: flex;
     }
 
+    .secondary {
+        display: none;
+    }
 }
 
 .modal-header {


### PR DESCRIPTION
Implements the share modal, which replaces the share links popup.  The logic was partly in CAC.Share.Social and partly in CAC.Control.DirectionsList, now it's almost all in CAC.Share.Modal.

Makes some changes to CAC.Control.Modal to make it create independent instances, and also adds onOpen and onClose callback options.

Most of the items pop up the same 3rd-party windows they created before, but the direct link option shows in the modal itself.

![share_modal](https://cloud.githubusercontent.com/assets/6598836/20405144/ec020dc6-acd5-11e6-88e7-371aaa3f1799.png)

![get_link](https://cloud.githubusercontent.com/assets/6598836/20405145/edd68032-acd5-11e6-985a-dfaa1f8d2c80.png)
