### PR TITLE
Configure OTP for bike share

### DIFF
--- a/deployment/ansible/group_vars/development_template
+++ b/deployment/ansible/group_vars/development_template
@@ -24,3 +24,6 @@ use_s3_storage: false
 default_admin_username: 'admin'
 default_admin_password: 'admin'
 default_admin_email: 'systems+cac@azavea.com'
+
+# for bike share directions
+bcycle_api_key: ''

--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -6,7 +6,7 @@ postgres_host: "192.168.8.25"
 django_workers: 5
 production: False
 
-app_sass_version: "3.4.9"
+app_sass_version: "3.4.22"
 
 app_log: "/var/log/cac-tripplanner-app.log"
 app_cron_event_feed_log: "/var/log/event-feed.log"
@@ -20,18 +20,18 @@ root_media_dir: "/media/cac"
 app_cron_event_feed: "cd {{ root_app_dir }} && python manage.py load_events >> {{ app_cron_event_feed_log }} 2>&1"
 
 cac_python_dependencies:
-    - { name: 'base58', version: '0.2.3' }
-    - { name: 'boto', version: '2.41.0' }
-    - { name: 'django', version: '1.8.13' }
-    - { name: 'django-ckeditor', version: '5.0.3' }
-    - { name: 'django-extensions', version: '1.6.7' }
+    - { name: 'base58', version: '0.2.4' }
+    - { name: 'boto', version: '2.43.0' }
+    - { name: 'django', version: '1.8.16' }
+    - { name: 'django-ckeditor', version: '5.1.1' }
+    - { name: 'django-extensions', version: '1.7.4' }
     - { name: 'django-storages-redux', version: '1.3.2' }
     - { name: 'gunicorn', version: '19.6.0'}
     - { name: 'ipython', version: '4.2.1' }
-    - { name: 'pillow', version: '3.3.0' }
-    - { name: 'psycopg2', version: '2.6.1' }
-    - { name: 'pytz', version: '2016.4' }
-    - { name: 'pyyaml', version: '3.11' }
+    - { name: 'pillow', version: '3.4.2' }
+    - { name: 'psycopg2', version: '2.6.2' }
+    - { name: 'pytz', version: '2016.7' }
+    - { name: 'pyyaml', version: '3.12' }
     - { name: 'troposphere', version: '0.7.2'}
     # Note: django-wpadmin is installed manually to work around the fact that ansible-pip
     # ignores editable=False

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+bikeshare_update_interval_s: 500
+bikeshare_update_network_name: 'Indego'
+bikeshare_update_url: 'https://publicapi.bcycle.com/api/1.0/ListProgramKiosks/3'

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
@@ -42,6 +42,16 @@
 - name: Create Graph Directory
   file: path="{{ otp_data_dir}}/{{ otp_router }}" state=directory
 
+- name: Copy Router Configuration to Graph Directory
+  template: src=router-config.json.j2 dest={{ otp_data_dir }}/{{ otp_router }}/router-config.json
+  when: not(
+          (bcycle_api_key is undefined)
+          or
+          (bcycle_api_key is none)
+          or
+          (bcycle_api_key | trim == '')
+        )
+
 - name: Move Graph to Graph Directory (test/develop)
   command: mv {{ otp_data_dir }}/Graph.obj {{ otp_data_dir }}/{{ otp_router }}
   notify: Restart OpenTripPlanner
@@ -49,4 +59,5 @@
 
 - name: Copy Local Graph to Graph Directory (production)
   copy: src=./otp_data/Graph.obj dest="{{ otp_data_dir }}/{{ otp_router }}/Graph.obj" owner={{ansible_user_id}} group={{ansible_user_id}} mode=0664
+  notify: Restart OpenTripPlanner
   when: production

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/templates/router-config.json.j2
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/templates/router-config.json.j2
@@ -1,0 +1,12 @@
+{
+    updaters: [
+        {
+            type: "bike-rental",
+            frequencySec: {{ bikeshare_update_interval_s}},
+            network: "{{ bikeshare_update_network_name }}",
+            sourceType: "b-cycle",
+            url: "{{ bikeshare_update_url }}",
+            apiKey: "{{ bcycle_api_key }}"
+        }
+    ]
+}


### PR DESCRIPTION
If bcycle_api_key ansible parameter is defined and non-empty in the group vars,
add router configuration to OpenTripPlanner server to support bike share routing
via the BICYCLE_RENT mode.

Closes #627.

To test, set the `bcycle_api_key` in your development group_vars. See #627 for how to query; something like [this](http://192.168.8.26/otp/routers/default/plan?fromPlace=39.9611421%2C-75.1546293&toPlace=39.9535847%2C-75.1735277&time=02%3A45pm&date=11-18-2016&fromText=N%2010th%20St%20%26%20Nectarine%20St%2C%20Philadelphia%2C%20Pennsylvania%2C%2019123&toText=2020%20Market%20St%2C%20Philadelphia%2C%20Pennsylvania%2C%2019103%2F&mode=BICYCLE_RENT&arriveBy=false&maxWalkDistance=482802) should work.