### PR TITLE
Use article title for page title

### DIFF
--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -5,13 +5,18 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0">
+
+    {% block pagetitle %}
     <title>{% block title %}GoPhillyGo | Trip Planning for Bikes, Public Transit, and Walking | Clean Air Council{% endblock %}</title>
+
+    <meta property="og:title" content="Trip Planner" />
+    <meta name="twitter:title" content="GoPhillyGo" />
+    {% endblock %}
 
     {% block extrametatags %}
     <meta property="fb:app_id" content="{{ fb_app_id }}" />
     <meta property="og:url"
     content="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}" />
-    <meta property="og:title" content="Trip Planner" />
     <meta property="og:description"
         content="CAC Trip Planner, for planning transit, walking, and biking trips around the Delaware Valley region.  Features parks and other destinations." />
     <meta property="og:image" content="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}/static/images/logo_blue.png" />
@@ -21,7 +26,6 @@
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@go_philly_go" />
-    <meta name="twitter:title" content="GoPhillyGo" />
     <meta name="twitter:description" content="Helping you get around greater Philly" />
     <meta name="twitter:image" content="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}/static/images/logo_blue.png" />
     {% endblock %}

--- a/python/cac_tripplanner/templates/learn-detail.html
+++ b/python/cac_tripplanner/templates/learn-detail.html
@@ -1,5 +1,13 @@
 {% extends "base.html" %}
 {% load staticfiles %}
+
+{% block pagetitle %}
+<title>{% block title %}GoPhillyGo | {{ article.title }}{% endblock %}</title>
+
+<meta property="og:title" content="GoPhillyGo | {{ article.title }}" />
+<meta name="twitter:title" content="GoPhillyGo | {{ article.title }}" />
+{% endblock %}
+
 {% block content %}
     {% include "partials/header.html" %}
     <div class="main">


### PR DESCRIPTION
In article details view, put the article title in the page title.
Closes #623.

Sets page title to "GoPhillyGo | {article title}". Also changes title attribute for Facebook and Twitter tags.

![image](https://cloud.githubusercontent.com/assets/960264/20494303/3ebf01c4-afea-11e6-94e0-867a94168941.png)
