### PR TITLE
Feature/itinerary alert

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions-list.js
+++ b/src/app/scripts/cac/control/cac-control-directions-list.js
@@ -15,10 +15,12 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates) {
         // Should the share button be shown in the control
         showShareButton: false,
         selectors: {
+            alertCloseButton: '.close',
             container: '.directions-step-by-step',
             mapContainer: '.body-map',
             backButton: '.back-to-directions-results',
             directionItem: '.directions-leg .directions-step',
+            directionsHeader: '.step-by-step-header',
             directLinkButton: '.modal-list-link',
             emailShareButton: '.modal-list-email',
             facebookShareButton: '.modal-list-facebook',
@@ -94,14 +96,18 @@ CAC.Control.DirectionsList = (function (_, $, MapTemplates) {
 
 
         $container.empty();
+        $container.append($html);
 
         // Show alert with link to transit agency bicycle policy for bike+transit itineraries
         if (_.includes(itinerary.modes, 'BICYCLE') && itinerary.agencies.length) {
-            var $alert = MapTemplates.bicycleWarningAlert(itinerary.agencies);
-            $container.append($alert);
+            var alert = MapTemplates.bicycleWarningAlert(itinerary.agencies);
+            var $alert = $(alert);
+            $alert.one('click', options.selectors.alertCloseButton, function () {
+                $alert.remove();
+            });
+            $container.find(options.selectors.directionsHeader).after($alert);
         }
-
-        $container.append($html);    }
+    }
 
     function getTemplate(itinerary) {
         var templateData = {

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -79,15 +79,19 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
 
         // message is not templated, so we can embed links
         var source = [
-            '<div class="alert-container">',
-            '<div class="alert alert-{{type}} alert-dismissible" role="alert">',
-            '<button type="button" class="close" data-dismiss="alert" aria-label="Close">',
-            '<span aria-hidden="true">&times;</span></button>',
+            '<div class="alert alert-bicycle">',
+            '<div class="alert-title">',
+            'Notice',
+            '<button title="Dismiss this message" name="close" class="close" aria-label="Close">',
+            '<i class="icon-cancel"></i></button>',
+            '</div>',
+            '<div class="alert-body">',
             msg,
-            '</div></div>'
+            '</div>',
+            '</div>'
         ].join('');
         var template = Handlebars.compile(source);
-        var html = template({type: 'warning'});
+        var html = template();
         return html;
     }
 

--- a/src/app/styles/components/_alerts.scss
+++ b/src/app/styles/components/_alerts.scss
@@ -1,0 +1,23 @@
+.alert {
+    padding: 1rem;
+    text-align: center;
+
+    .alert-title {
+        position: relative;
+        margin-top: 0;
+        margin-bottom: 1rem;
+    }
+
+    .close {
+        position: absolute;
+        top: 0;
+        right: 0;
+        background: none;
+        border: none;
+        cursor: pointer;
+    }
+}
+
+.alert-bicycle {
+    background-color: $alert-color-bicycle;
+}

--- a/src/app/styles/main.scss
+++ b/src/app/styles/main.scss
@@ -16,6 +16,7 @@
 
 // Components
 @import
+'components/alerts',
 'components/app-header',
 'components/app-footer',
 'components/map',

--- a/src/app/styles/utils/_color.scss
+++ b/src/app/styles/utils/_color.scss
@@ -10,6 +10,7 @@ $gophillygo-blue-dark: #245280;
 
 $indego-purple: #16216a;
 
+$alert-color-bicycle: #f0a438;
 
 $white: #fff;
 $lt-gray: #777;


### PR DESCRIPTION
## Overview

Re-adds the alert displayed for trips involving public transit + bike. 

## Demo

![cac-itinerary-bike-alert](https://cloud.githubusercontent.com/assets/1818302/20497332/c9874f76-aff6-11e6-87fc-1724cab2a9bc.png)

## Testing

Plan a trip using public transit + bike, the alert will appear below the directions header. If removed, it will reappear each time the directions list is re-rendered.

A bit of styling cleanup potentially necessary before #614 can be closed.
