### PR TITLE
Handle itinerary hover in CSS

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -31,6 +31,8 @@ CAC.Control.Directions = (function (_, $, Control, Geocoder, Routing, Typeahead,
 
             itineraryBlock: '.route-summary',
 
+            selectedItineraryClass: 'selected',
+
             // TODO: update or remove below components (from before refactor)
             bikeTriangleDiv: '#directionsBikeTriangle',
             datepicker: '#datetimeDirections',
@@ -330,8 +332,9 @@ CAC.Control.Directions = (function (_, $, Control, Geocoder, Routing, Typeahead,
      */
     function onItineraryHover(event, itinerary) {
         if (itinerary) {
-            findItineraryBlock(currentItinerary.id).css('background-color', 'white');
-            findItineraryBlock(itinerary.id).css('background-color', 'lightgray');
+            findItineraryBlock(currentItinerary.id)
+                .removeClass(options.selectors.selectedItineraryClass);
+            findItineraryBlock(itinerary.id).addClass(options.selectors.selectedItineraryClass);
             currentItinerary.highlight(false);
             itinerary.highlight(true);
             currentItinerary = itinerary;

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -206,7 +206,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
         '{{#each itineraries}}',
             '<div class="route-summary" data-itinerary="{{this.id}}">',
             '<svg class="route-summary-path" width="3" height="100%" xmlns="http://www.w3.org/2000/svg">',
-                '<line x1="50%" y1="6%" x2="50%" y2="94%" stroke-width="3" stroke="#e23331"></line>',
+                '<line x1="50%" y1="6%" x2="50%" y2="94%"></line>',
             '</svg>',
             '<div class="route-summary-details">',
                 '<div class="route-summary-primary-details">',

--- a/src/app/styles/components/_directions-results.scss
+++ b/src/app/styles/components/_directions-results.scss
@@ -43,9 +43,23 @@
             margin: 0;
         }
 
+        &.selected {
+
+            background-color: $v-lt-gray;
+
+            .route-summary-path {
+                stroke: #e23331;
+                stroke-dasharray: 0;
+            }
+        }
+
         .route-summary-path {
             flex: 0 0 4px;
             margin-right: 13px;
+
+            stroke: #5c99c6;
+            stroke-dasharray: 7, 7;
+            stroke-width: 3;
         }
 
         .route-summary-details {

--- a/src/app/styles/components/_directions-results.scss
+++ b/src/app/styles/components/_directions-results.scss
@@ -48,8 +48,8 @@
             background-color: $v-lt-gray;
 
             .route-summary-path {
-                stroke: #e23331;
-                stroke-dasharray: 0;
+                stroke: $route-summary-path-selected-color;
+                stroke-dasharray: $route-summary-selected-dasharray;
             }
         }
 
@@ -57,8 +57,8 @@
             flex: 0 0 4px;
             margin-right: 13px;
 
-            stroke: #5c99c6;
-            stroke-dasharray: 7, 7;
+            stroke: $route-summary-path-default-color;
+            stroke-dasharray: $route-summary-default-dasharray;
             stroke-width: 3;
         }
 

--- a/src/app/styles/utils/_color.scss
+++ b/src/app/styles/utils/_color.scss
@@ -34,3 +34,6 @@ $directions-form-text-input-background-color: $white;
 $home-section-bg-color: rgba(250, 252, 255, .8);
 
 $place-card-bg-color: $white;
+
+$route-summary-path-selected-color: #e23331;
+$route-summary-path-default-color: #5c99c6;

--- a/src/app/styles/utils/_variables.scss
+++ b/src/app/styles/utils/_variables.scss
@@ -14,3 +14,5 @@ $directions-form-sidebar-height: 140px;
 $sidebar-banner-height: 50px;
 
 $route-summary-height: 80px;
+$route-summary-default-dasharray: 7, 7;
+$route-summary-selected-dasharray: 0;


### PR DESCRIPTION
Use CSS to modify SVG bar on itinerary hover. Also modify existing style changes to
happen via class toggle, rather than direct style manipulation.

Closes #599.

Hovering over an itinerary in the sidebar changes the SVG bar on the left of the card solid orange, and changes it back to dotted blue line on hovering over a different itinerary.