### PR TITLE
Fix prototype options copy bug

### DIFF
--- a/src/prototype/app/extras.html
+++ b/src/prototype/app/extras.html
@@ -144,7 +144,7 @@
         </header>
         <ul class="modal-list modal-contents">
             <li class="modal-list-indego selected">Use Indego bike sharing</li>
-            <li class="modal-list-timing selected">Arrive 2:30p today</li>
+            <li class="modal-list-timing selected">Arrive today 2:30p</li>
             <li class="modal-list-ride selected">Fast ride</li>
         </ul>
         <footer class="modal-footer">
@@ -184,8 +184,8 @@
             Walk options
         </header>
         <ul class="modal-list modal-contents">
-            <li class="modal-list-timing selected">Arrive/depart at…</li>
-            <li class="modal-list-accessibility selected">Accessibility</li>
+            <li class="modal-list-timing selected">Depart 12/14 11:00a</li>
+            <li class="modal-list-accessibility selected">I have a wheelchair</li>
         </ul>
         <footer class="modal-footer">
             <button name="close-modal" class="btn-close-modal">Close</button>


### PR DESCRIPTION
Trivial prototype fix. The last Walk options modal, showing active options, was using the copy for inactive options.