### PR TITLE
Add bike share arrivals, use mode icon for first step

### DIFF
--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -235,6 +235,15 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
     }
 
     function itinerary(templateData) {
+        // set a flag on the last leg, so we can avoid diplaying arriving there right above
+        // also arriving at the final destination
+        templateData.legs[templateData.legs.length - 1].lastLeg = true;
+        // And set a flag on legs that end at bike share stations (whether on a bike or walking
+        // to a station), so we can show the icon
+        _.forEach(templateData.legs, function (leg) {
+            leg.toBikeShareStation = leg.to.vertexType === 'BIKESHARE';
+        });
+
         // The &nbsp;'s are used instead of 'hide' classes because of some styling-related issues
         var source = [
             '<header class="step-by-step-header">',
@@ -258,36 +267,41 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
             '</div>',
             '{{#each data.legs}}',
                 '<div class="directions-leg" ',
-                    'data-lat="{{this.from.lat}}" data-lon="{{this.from.lon}}">',
-                    // transit step directions
+                'data-lat="{{this.from.lat}}" data-lon="{{this.from.lon}}">',
                     '{{#if this.transitLeg}}',
-                    '<div class="directions-step {{modeClass this.mode}}" ',
-                        'data-lat="{{ this.from.lat }}" data-lon="{{ this.from.lon }}">',
-                        '<div class="directions-instruction">Board {{this.agencyName}} {{this.route}} ',
-                        '{{this.headsign}}</div>',
-                        '<div class="directions-time">at {{datetime this.startTime}}</div>',
-                        '<div class="directions-distance">{{inMiles this.distance}} mi</div>',
-                    '</div>',
-                    '<div class="directions-step directions-step-disembark" ',
-                        'data-lat="{{ this.to.lat }}" data-lon="{{ this.to.lon }}">',
-                        '<div class="directions-instruction">Disembark <strong>',
-                            '{{this.to.name}}</strong></div>',
-                    '</div>',
-                    '{{else}}',
-                    // non-tranist step directions
-                    '{{#each steps}}',
-                        '<div class="directions-step {{directionClass this.relativeDirection ../this.mode}}" ',
-                            'data-lat="{{ lat }}" data-lon="{{ lon }}">',
-                            '<div class="directions-instruction">{{directionText}}</div>',
+                        // transit step directions
+                        '<div class="directions-step {{modeClass this.mode}}" ',
+                            'data-lat="{{ this.from.lat }}" data-lon="{{ this.from.lon }}">',
+                            '<div class="directions-instruction">Board {{this.agencyName}} ',
+                            '{{this.route}} {{this.headsign}}</div>',
+                            '<div class="directions-time">at {{datetime this.startTime}}</div>',
                             '<div class="directions-distance">{{inMiles this.distance}} mi</div>',
                         '</div>',
-                    '{{/each}}',
-                    '{{#unless this.lastLeg}}',
-                    '<div class="directions-step directions-step-arrive" ',
-                        'data-lat="{{ this.to.lat }}" data-lon="{{ this.to.lon }}">',
-                        '<div class="directions-instruction"><strong>Arrive {{this.to.name}}</strong></div>',
-                    '</div>',
-                    '{{/unless}}', // unless last step
+                        '<div class="directions-step directions-step-disembark" ',
+                            'data-lat="{{ this.to.lat }}" data-lon="{{ this.to.lon }}">',
+                            '<div class="directions-instruction">Disembark <strong>',
+                                '{{this.to.name}}</strong></div>',
+                        '</div>',
+                    '{{else}}',
+                        // non-tranist step directions
+                        '{{#each steps}}',
+                            '<div class="directions-step ',
+                                '{{directionClass this.relativeDirection ../this.mode @index}}" ',
+                                'data-lat="{{ lat }}" data-lon="{{ lon }}">',
+                                '<div class="directions-instruction">{{directionText ../this.mode @index}}</div>',
+                                '<div class="directions-distance">{{inMiles this.distance}} mi</div>',
+                            '</div>',
+                        '{{/each}}',
+                        '{{#unless this.lastLeg}}',
+                            '<div class="directions-step ',
+                                '{{#if this.toBikeShareStation}}directions-step-indego"',
+                                '{{else}}directions-step-arrive"{{/if}}',
+                                'data-lat="{{ this.to.lat }}" data-lon="{{ this.to.lon }}">',
+                                '<div class="directions-instruction"><strong>Arrive ',
+                                '{{#if this.toBikeShareStation}}Indego station, {{/if}}',
+                                '{{this.to.name}}</strong></div>',
+                            '</div>',
+                        '{{/unless}}', // unless last step
                     '{{/if}}', // end if transit or not
                 '</div>',
             '{{/each}}',
@@ -299,20 +313,18 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
             '</div>'
         ].join('');
         var template = Handlebars.compile(source);
-        // set a flag on the last leg, so we can avoid diplaying arriving there right above
-        // also arriving at the final destination
-        templateData.legs[templateData.legs.length - 1].lastLeg = true;
         var html = template({data: templateData});
         return html;
     }
 
     function registerListItemHelpers() {
-        Handlebars.registerHelper('directionClass', function(direction, mode) {
-            return new Handlebars.SafeString(getTurnIconClass(direction, mode));
+        Handlebars.registerHelper('directionClass', function(direction, mode, index) {
+            return new Handlebars.SafeString(getTurnIconClass(direction, mode, index));
         });
 
-        Handlebars.registerHelper('directionText', function () {
-            var text = turnText(this.relativeDirection, this.streetName, this.absoluteDirection);
+        Handlebars.registerHelper('directionText', function (mode, index) {
+            var text = turnText(this.relativeDirection, this.streetName, this.absoluteDirection,
+                                mode, index);
             return new Handlebars.SafeString('<span>' + text + '</span>');
         });
 
@@ -339,13 +351,17 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
     function getModeClass(modeText) {
         switch (modeText) {
             case 'BICYCLE':
-                return 'directions-step-bike'; // TODO: bike share has separate icon
+                return 'directions-step-bike';
             default:
                 return 'directions-step-' + modeText.toLowerCase();
         }
     }
 
-    function getTurnIconClass(turnType, modeText) {
+    // Get icon class for step. The first step in a leg gets the mode icon (and absolute direction)
+    function getTurnIconClass(turnType, modeText, index) {
+        if (index === 0) {
+            return getModeClass(modeText);
+        }
         switch (turnType) {
             case 'DEPART':
                 return getModeClass(modeText);
@@ -373,13 +389,25 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
         }
     }
 
-    function turnText(turn, street, direction) {
+    function getModeText(mode) {
+        switch (mode) {
+            case 'BICYCLE':
+                return 'Bike';
+            case 'WALK':
+                return 'Walk';
+            default:
+                return 'Head';
+        }
+    }
+
+    // Get the text for a step. The first step in a leg gets absolute direction.
+    function turnText(turn, street, direction, mode, index) {
         var turnTextString = '';
         var turnLower = turn.toLowerCase();
         var turnSplit = turnLower.replace('_', ' ');
         street = Utils.abbrevStreetName(street);
-        if (turn === 'DEPART') {
-            turnTextString = 'Head ' + direction.toLowerCase() + ' on ' + street;
+        if (turn === 'DEPART' || index === 0) {
+            turnTextString = getModeText(mode) + ' ' + direction.toLowerCase() + ' on ' + street;
         } else if (turn === 'CONTINUE') {
             turnTextString = 'Continue on to ' + street;
         } else if (turn === 'ELEVATOR') {

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -288,7 +288,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                             '<div class="directions-step ',
                                 '{{directionClass this.relativeDirection ../this.mode @index}}" ',
                                 'data-lat="{{ lat }}" data-lon="{{ lon }}">',
-                                '<div class="directions-instruction">{{directionText ../this.mode @index}}</div>',
+                                '<div class="directions-instruction">{{directionText ../this @index}}</div>',
                                 '<div class="directions-distance">{{inMiles this.distance}} mi</div>',
                             '</div>',
                         '{{/each}}',
@@ -322,9 +322,8 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
             return new Handlebars.SafeString(getTurnIconClass(direction, mode, index));
         });
 
-        Handlebars.registerHelper('directionText', function (mode, index) {
-            var text = turnText(this.relativeDirection, this.streetName, this.absoluteDirection,
-                                mode, index);
+        Handlebars.registerHelper('directionText', function (leg, index) {
+            var text = turnText(this, leg, index);
             return new Handlebars.SafeString('<span>' + text + '</span>');
         });
 
@@ -389,25 +388,28 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
         }
     }
 
-    function getModeText(mode) {
-        switch (mode) {
+    function getModeText(leg) {
+        switch (leg.mode) {
             case 'BICYCLE':
                 return 'Bike';
             case 'WALK':
-                return 'Walk';
+                return 'Walk' + (leg.rentedBike ? ' the bike' : '');
             default:
                 return 'Head';
         }
     }
 
     // Get the text for a step. The first step in a leg gets absolute direction.
-    function turnText(turn, street, direction, mode, index) {
+    function turnText(step, leg, index) {
+        var turn = step.relativeDirection;
+        var street = step.streetName;
+        var direction = step.absoluteDirection;
         var turnTextString = '';
         var turnLower = turn.toLowerCase();
         var turnSplit = turnLower.replace('_', ' ');
         street = Utils.abbrevStreetName(street);
         if (turn === 'DEPART' || index === 0) {
-            turnTextString = getModeText(mode) + ' ' + direction.toLowerCase() + ' on ' + street;
+            turnTextString = getModeText(leg) + ' ' + direction.toLowerCase() + ' on ' + street;
         } else if (turn === 'CONTINUE') {
             turnTextString = 'Continue on to ' + street;
         } else if (turn === 'ELEVATOR') {

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -235,15 +235,6 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
     }
 
     function itinerary(templateData) {
-        // set a flag on the last leg, so we can avoid diplaying arriving there right above
-        // also arriving at the final destination
-        templateData.legs[templateData.legs.length - 1].lastLeg = true;
-        // And set a flag on legs that end at bike share stations (whether on a bike or walking
-        // to a station), so we can show the icon
-        _.forEach(templateData.legs, function (leg) {
-            leg.toBikeShareStation = leg.to.vertexType === 'BIKESHARE';
-        });
-
         // The &nbsp;'s are used instead of 'hide' classes because of some styling-related issues
         var source = [
             '<header class="step-by-step-header">',
@@ -267,7 +258,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
             '</div>',
             '{{#each data.legs}}',
                 '<div class="directions-leg" ',
-                'data-lat="{{this.from.lat}}" data-lon="{{this.from.lon}}">',
+                    'data-lat="{{this.from.lat}}" data-lon="{{this.from.lon}}">',
                     '{{#if this.transitLeg}}',
                         // transit step directions
                         '<div class="directions-step {{modeClass this.mode}}" ',
@@ -283,7 +274,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                                 '{{this.to.name}}</strong></div>',
                         '</div>',
                     '{{else}}',
-                        // non-tranist step directions
+                        // non-transit step directions
                         '{{#each steps}}',
                             '<div class="directions-step ',
                                 '{{directionClass this.relativeDirection ../this.mode @index}}" ',


### PR DESCRIPTION
Adds the bike share icon and the text "Indego station" to the steps list
at the end of any leg that ends at a bike share station. Currently
doesn't distinguish between picking up a bike and dropping one off.

Resolves #631.

Also resolves #645 by changing the first step of each non-transit leg to
use a mode icon and the absolute direction (e.g. 'Bike west on ...')
rather than a turn icon and the relative direction.

**To Test**
To enable bike share directions before issue #630 is done, assuming your OTP instance was provisioned with bike share (PR #642), change `'BICYCLE'` to `'BICYCLE_RENT'` in the `modes` object in [`cac-control-mode-options.js`](https://github.com/azavea/cac-tripplanner/blob/feature/bike-share-steps/src/app/scripts/cac/control/cac-control-mode-options.js#L32).

What that done, get bike directions, e.g. http://localhost:8024/?origin=39.9616133%2C-75.1541914&originText=990%20Spring%20Garden%20St%2C%20Philadelphia%2C%20Pennsylvania%2C%2019123&mode=BICYCLE_RENT&destination=39.965811%2C-75.183494&destinationText=Fairmount%20Waterworks%20Interpretive%20Center, and you should see Indego icons and text at the point where you pick up and drop off the bike and also mode icons at the beginning of each leg.

![share_steps1](https://cloud.githubusercontent.com/assets/6598836/20563964/d250a72a-b158-11e6-91ae-69a7ba245c11.png)
![share_steps2](https://cloud.githubusercontent.com/assets/6598836/20563967/d4813bea-b158-11e6-93e6-6e7820bd29a9.png)
![share_steps3](https://cloud.githubusercontent.com/assets/6598836/20563969/d6ad53d6-b158-11e6-83a8-cb4c64b00a79.png)
