### PR TITLE
Configure OTP for bike share

### DIFF
--- a/deployment/ansible/group_vars/development_template
+++ b/deployment/ansible/group_vars/development_template
@@ -24,3 +24,6 @@ use_s3_storage: false
 default_admin_username: 'admin'
 default_admin_password: 'admin'
 default_admin_email: 'systems+cac@azavea.com'
+
+# for bike share directions
+bcycle_api_key: ''

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+bikeshare_update_interval_s: 500
+bikeshare_update_network_name: 'Indego'
+bikeshare_update_url: 'https://publicapi.bcycle.com/api/1.0/ListProgramKiosks/3'

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
@@ -42,6 +42,16 @@
 - name: Create Graph Directory
   file: path="{{ otp_data_dir}}/{{ otp_router }}" state=directory
 
+- name: Copy Router Configuration to Graph Directory
+  template: src=router-config.json.j2 dest={{ otp_data_dir }}/{{ otp_router }}/router-config.json
+  when: not(
+          (bcycle_api_key is undefined)
+          or
+          (bcycle_api_key is none)
+          or
+          (bcycle_api_key | trim == '')
+        )
+
 - name: Move Graph to Graph Directory (test/develop)
   command: mv {{ otp_data_dir }}/Graph.obj {{ otp_data_dir }}/{{ otp_router }}
   notify: Restart OpenTripPlanner
@@ -49,4 +59,5 @@
 
 - name: Copy Local Graph to Graph Directory (production)
   copy: src=./otp_data/Graph.obj dest="{{ otp_data_dir }}/{{ otp_router }}/Graph.obj" owner={{ansible_user_id}} group={{ansible_user_id}} mode=0664
+  notify: Restart OpenTripPlanner
   when: production

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/templates/router-config.json.j2
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/templates/router-config.json.j2
@@ -1,0 +1,12 @@
+{
+    updaters: [
+        {
+            type: "bike-rental",
+            frequencySec: {{ bikeshare_update_interval_s}},
+            network: "{{ bikeshare_update_network_name }}",
+            sourceType: "b-cycle",
+            url: "{{ bikeshare_update_url }}",
+            apiKey: "{{ bcycle_api_key }}"
+        }
+    ]
+}


### PR DESCRIPTION
Cherry-pick back server configuration for bike share, so production and staging can share an OTP stack and staging can use bike share routing.