### PR TITLE
Add `Orange` stack color for app server only staging/demo instance

### DIFF
--- a/deployment/cac-stack.py
+++ b/deployment/cac-stack.py
@@ -79,9 +79,9 @@ def main():
                             default=None,
                             help='One of "dev", "staging", "prod"')
     cac_stacks.add_argument('--stack-color', type=str, required=True,
-                            choices=['green', 'blue'],
+                            choices=['green', 'blue', 'orange'],
                             default=None,
-                            help='One of "green", "blue"')
+                            help='One of "green", "blue", "orange"')
     cac_stacks.set_defaults(func=launch_stacks)
 
     # AMI Management

--- a/deployment/cloudformation/app.py
+++ b/deployment/cloudformation/app.py
@@ -93,7 +93,7 @@ class AppServerStack(StackNode):
 
         self.param_color = self.add_parameter(Parameter(
             'StackColor', Type='String',
-            Description='Stack color', AllowedValues=['Blue', 'Green']),
+            Description='Stack color', AllowedValues=['Blue', 'Green', 'Orange']),
             source='StackColor')
 
         self.param_stacktype = self.add_parameter(Parameter(

--- a/deployment/cloudformation/stacks.py
+++ b/deployment/cloudformation/stacks.py
@@ -17,7 +17,8 @@ stack_types = {
 
 stack_colors = {
     'green': 'Green',
-    'blue': 'Blue'
+    'blue': 'Blue',
+    'orange': 'Orange'
 }
 
 
@@ -39,5 +40,6 @@ def build_stacks(options, stack_type, stack_color):
     if not stack_color:
         d.go()
     else:
-        OtpServerStack(globalconfig=g, VPC=v, DataPlane=d).go()
+        if options['StackColor'] != 'Orange':
+            OtpServerStack(globalconfig=g, VPC=v, DataPlane=d).go()
         WebServerStack(globalconfig=g, VPC=v, DataPlane=d).go()


### PR DESCRIPTION
This PR adds an `orange` stack color that only deploys the app/web server stack. The intent is to use this new color as a read only staging instance that uses the production database and production OTP instances. When `orange` is specified as a stack color, an OTP stack will not be brought up.

## Caveats

* An AMI needs to be generated for this stack with the database credentials changed in `group_vars/production` with the read only database user
* The `orange` app stack depends on an OTP instance from the `green` or `blue` stack colors. When a regular production deploy happens, the `orange` stack will break.