### PR TITLE
Display user selections for trip options

### DIFF
--- a/src/app/scripts/cac/user/cac-user-preferences.js
+++ b/src/app/scripts/cac/user/cac-user-preferences.js
@@ -29,6 +29,7 @@ CAC.User.Preferences = (function(_) {
         arriveBy: false, // depart at set time, by default
         bikeShare: false,
         bikeTriangle: 'any',
+        dateTime: undefined, // explicitly list here for isDefault check
         exploreTime: 20,
         maxWalk: 482802, // in meters; set large, since not user-controllable
         method: 'directions',


### PR DESCRIPTION
Closes #663.

Display user selections in top-level trip options modal if set; if using defaults,
use default menu option text.

After making a selection from a sub-menu, on returning to the main options menu or closing/re-opening the trip options will display the selection instead of the default menu text.
