### PR TITLE
Order destinations by priority

### DIFF
--- a/python/cac_tripplanner/destinations/admin.py
+++ b/python/cac_tripplanner/destinations/admin.py
@@ -8,7 +8,7 @@ from .models import Destination
 class DestinationAdmin(admin.OSMGeoAdmin):
     form = DestinationForm
 
-    list_display = ('name', 'published', 'address', 'city', 'state', 'zip')
+    list_display = ('name', 'published', 'priority', 'address', 'city', 'state', 'zip')
     actions = ('make_published', 'make_unpublished')
     ordering = ('name', )
 

--- a/python/cac_tripplanner/destinations/migrations/0017_destination_priority.py
+++ b/python/cac_tripplanner/destinations/migrations/0017_destination_priority.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('destinations', '0016_auto_20150318_1704'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='destination',
+            name='priority',
+            field=models.IntegerField(default=9999),
+        ),
+    ]

--- a/python/cac_tripplanner/destinations/models.py
+++ b/python/cac_tripplanner/destinations/models.py
@@ -15,14 +15,14 @@ class DestinationManager(models.GeoManager):
     """Custom manager for Destinations allows filtering on published"""
 
     def published(self):
-        return self.get_queryset().filter(published=True).order_by('priority')
-
-    def get_queryset(self):
-        return super(DestinationManager, self).get_queryset()
+        return self.get_queryset().filter(published=True)
 
 
 class Destination(models.Model):
     """Represents a destination"""
+
+    class Meta:
+        ordering = ['priority', '?']
 
     name = models.CharField(max_length=50)
     website_url = models.URLField(blank=True, null=True)

--- a/python/cac_tripplanner/destinations/models.py
+++ b/python/cac_tripplanner/destinations/models.py
@@ -15,7 +15,7 @@ class DestinationManager(models.GeoManager):
     """Custom manager for Destinations allows filtering on published"""
 
     def published(self):
-        return self.get_queryset().filter(published=True)
+        return self.get_queryset().filter(published=True).order_by('priority')
 
     def get_queryset(self):
         return super(DestinationManager, self).get_queryset()
@@ -41,6 +41,7 @@ class Destination(models.Model):
     wide_image = models.ImageField(upload_to=generate_filename, null=True,
                                    help_text='The half-height image. Will be displayed at 400x200.')
     published = models.BooleanField(default=False)
+    priority = models.IntegerField(default=9999, null=False)
 
     objects = DestinationManager()
 

--- a/python/cac_tripplanner/destinations/views.py
+++ b/python/cac_tripplanner/destinations/views.py
@@ -38,8 +38,8 @@ def base_view(request, page, context):
 def home(request):
     # Load one random article
     article = Article.objects.random()
-    # Show all destinations, in random order
-    destinations = Destination.objects.order_by('?').all()
+    # Show all destinations
+    destinations = Destination.objects.published().all()
     context = {
         'tab': 'home',
         'article': article,
@@ -67,7 +67,7 @@ def directions(request):
 
 def place_detail(request, pk):
     destination = get_object_or_404(Destination.objects.published(), pk=pk)
-    more_destinations = Destination.objects.published().order_by('?').exclude(pk=destination.pk)[:3]
+    more_destinations = Destination.objects.published().exclude(pk=destination.pk)[:3]
     context = dict(tab='explore', destination=destination, more_destinations=more_destinations,
                    **DEFAULT_CONTEXT)
     return base_view(request, 'place-detail.html', context=context)


### PR DESCRIPTION
Add priority value to destinations; defaults to a high number (9999).
By default, order published destinations by priority.
Closes #592.

Involves a migration, so will need to run that to test.