### PR TITLE
Feature/sync on load

### DIFF
--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -133,6 +133,7 @@
     <script src="{% static 'scripts/main/cac/control/cac-control-directions-list.js' %}"></script>
     <script src="{% static 'scripts/main/cac/home/cac-home-templates.js' %}"></script>
     <script src="{% static 'scripts/main/cac/pages/cac-pages-home.js' %}"></script>
+    <script src="{% static 'scripts/main/cac/pages/cac-pages-directions.js' %}"></script>
 
     {% else %}
 

--- a/python/cac_tripplanner/templates/directions.html
+++ b/python/cac_tripplanner/templates/directions.html
@@ -3,7 +3,7 @@
 {% include "partials/header.html" %}
 <div class="print container">
   <section class="directions directions-print">
-    <div id="directions-map"></div>
+    <div class="the-map" id="directions-map"></div>
     <div class="directions-list">
     </div>
   </section>

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -99,7 +99,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
     }
 
     DirectionsControl.prototype = {
-        clearDirections: clearDirections,
+        clearUserSettings: clearUserSettings,
         moveOriginDestination: moveOriginDestination,
         setDestination: setDestination,
         setDirections: setDirections,
@@ -223,6 +223,18 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
         itineraryControl.clearItineraries();
         itineraryListControl.hide();
         directionsListControl.hide();
+    }
+
+    /**
+     * Wipe out user-set trip options and clear controls
+     */
+    function clearUserSettings() {
+        UserPreferences.clearSettings();
+        typeaheadFrom.setValue(null);
+        typeaheadTo.setValue(null);
+        setDirections('origin', null);
+        setDirections('destination', null);
+        clearDirections();
     }
 
     function onDirectionsBackClicked() {

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -45,7 +45,6 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
         destination: null
     };
 
-    var modeOptionsControl = null;
     var mapControl = null;
     var itineraryControl = null;
     var tabControl = null;
@@ -61,9 +60,6 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
         tabControl = options.tabControl;
         itineraryControl = mapControl.itineraryControl;
         urlRouter = options.urlRouter;
-        modeOptionsControl = options.modeOptionsControl;
-        modeOptionsControl.events.on(modeOptionsControl.eventNames.toggle, planTrip);
-        modeOptionsControl.events.on(modeOptionsControl.eventNames.transitChanged, planTrip);
 
         $(options.selectors.reverseButton).click($.proxy(reverseOriginDestination, this));
 
@@ -132,7 +128,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
         var date = UserPreferences.getPreference('dateTime');
         date = date ? moment.unix(date) : moment(); // default to now
 
-        var mode = modeOptionsControl.getMode();
+        var mode = UserPreferences.getPreference('mode');
         var arriveBy = UserPreferences.getPreference('arriveBy');
 
         // options to pass to OTP as-is
@@ -150,19 +146,10 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
         if (mode.indexOf('BICYCLE') > -1) {
             // set bike trip optimization option
             var bikeTriangle = UserPreferences.getPreference('bikeTriangle');
-
-            if (_.has(modeOptionsControl.options.bikeTriangle, bikeTriangle)) {
-                $.extend(otpOptions, {optimize: 'TRIANGLE'},
-                     modeOptionsControl.options.bikeTriangle[bikeTriangle]);
-            } else {
-                console.error('unrecognized bike triangle option ' + bikeTriangle);
+            bikeTriangle = Utils.getBikeTriangle(bikeTriangle);
+            if (bikeTriangle) {
+                $.extend(otpOptions, {optimize: 'TRIANGLE'}, bikeTriangle);
             }
-
-            // check user preference for bike share here, and update query mode if so
-            if (UserPreferences.getPreference('bikeShare')) {
-                mode = mode.replace('BICYCLE', 'BICYCLE_RENT');
-            }
-
         } else {
             $.extend(otpOptions, { wheelchair: UserPreferences.getPreference('wheelchair') });
         }
@@ -433,8 +420,6 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
         };
 
         // set in UI
-        var mode = UserPreferences.getPreference('mode');
-        modeOptionsControl.setMode(mode);
         typeaheadFrom.setValue(originText);
         typeaheadTo.setValue(destinationText);
 

--- a/src/app/scripts/cac/control/cac-control-modal.js
+++ b/src/app/scripts/cac/control/cac-control-modal.js
@@ -49,6 +49,11 @@ CAC.Control.Modal = (function ($) {
             event.preventDefault();
         }
 
+        // unbind events before potentially re-binding them
+        $(this.options.selectors.modalOption).off('click');
+        $(this.options.selectors.modalCloseButton).off('click');
+        $(this.options.selectors.modalClearButton).off('click');
+
         // bind events; these must also be unbound during _close
         $(this.options.selectors.modalOption).on('click', this.options.clickHandler);
         $(this.options.selectors.modalCloseButton).on('click', this.close);
@@ -64,12 +69,6 @@ CAC.Control.Modal = (function ($) {
         if (event && event.preventDefault) {
             event.preventDefault();
         }
-
-        // remove click handlers. otherwise will trigger click events repeatedly
-        // on subsequent modal open
-        $(this.options.selectors.modalOption).off('click');
-        $(this.options.selectors.modalCloseButton).off('click');
-        $(this.options.selectors.modalClearButton).off('click');
 
         if (this.options.onClose) {
             return this.options.onClose(event);

--- a/src/app/scripts/cac/control/cac-control-mode-options.js
+++ b/src/app/scripts/cac/control/cac-control-mode-options.js
@@ -2,29 +2,6 @@ CAC.Control.ModeOptions = (function ($) {
     'use strict';
 
     var defaults = {
-        // Note:  the three bike options must sum to 1, or OTP won't plan the trip
-        bikeTriangle: {
-            any: {
-                triangleSafetyFactor: 0.34,
-                triangleSlopeFactor: 0.33,
-                triangleTimeFactor: 0.33
-            },
-            flat: {
-                triangleSafetyFactor: 0.17,
-                triangleSlopeFactor: 0.66,
-                triangleTimeFactor: 0.17
-            },
-            fast: {
-                triangleSafetyFactor: 0.17,
-                triangleSlopeFactor: 0.17,
-                triangleTimeFactor: 0.66
-            },
-            safe: {
-                triangleSafetyFactor: 0.66,
-                triangleSlopeFactor: 0.17,
-                triangleTimeFactor: 0.17
-            }
-        },
         defaultMode: 'WALK,TRANSIT',
         // map button class names to OpenTripPlanner mode parameters
         modes: {
@@ -48,8 +25,7 @@ CAC.Control.ModeOptions = (function ($) {
     };
     var events = $({});
     var eventNames = {
-        toggle: 'cac:control:modeoptions:toggle',
-        transitChanged: 'cac:control:modeoptions:transitchanged'
+        toggle: 'cac:control:modeoptions:toggle'
     };
     var options = {};
 
@@ -89,13 +65,13 @@ CAC.Control.ModeOptions = (function ($) {
             $(this).toggleClass(options.selectors.onClass + ' ' + options.selectors.offClass)
                 .find('i').toggleClass(options.selectors.transitIconOnOffClasses);
 
-            var active = $(this).find('i').hasClass(options.selectors.transitIconOnClass);
-            events.trigger(eventNames.transitChanged, active);
+            events.trigger(eventNames.toggle, getMode());
         });
     }
 
     /**
      * Helper to return the mode string based on the buttons within the given input selector.
+     * Does not reflect whether in bike share mode or not, which is controlled separately.
      *
      * @returns {String} comma-separated list of OpenTripPlanner mode parameters
      */
@@ -113,7 +89,8 @@ CAC.Control.ModeOptions = (function ($) {
 
     /**
      * Helper to set the appropriate buttons within the given input selector
-     * so that they match the mode string.
+     * so that they match the mode string. Does not affect the bike share mode setting,
+     * which is managed separately by the trip options modal.
      *
      * @param mode {String} OpenTripPlanner mode string like 'WALK,TRANSIT'
      */
@@ -125,6 +102,10 @@ CAC.Control.ModeOptions = (function ($) {
         }
 
         _.each(options.modes, function(val, key) {
+            // for purposes of the bike toggle button, BICYCLE and BICYCLE_RENT are the same
+            if (key.indexOf('_RENT') >= 0) {
+                key = key.replace('_RENT', '');
+            }
             var $thisMode = $modes.find('.' + key);
 
             var addClass = options.selectors.offClass;

--- a/src/app/scripts/cac/control/cac-control-trip-options.js
+++ b/src/app/scripts/cac/control/cac-control-trip-options.js
@@ -62,8 +62,12 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
                 'bikeTriangleAny': {name: 'bikeTriangle', value: 'any'},
                 'bikeTriangleFast': {name: 'bikeTriangle', value: 'fast'},
                 'bikeTriangleFlat': {name: 'bikeTriangle', value: 'flat'},
-                'bikeTriangleSafe': {name: 'bikeTriangle', value: 'safe'}
-            }
+                'bikeTriangleSafe': {name: 'bikeTriangle', value: 'safe'},
+                'arriveBy': {name: 'arriveBy', value: true},
+                'departAt': {name: 'arriveBy', value: false}
+            },
+            // distinct 'name' in optionPreferences above
+            preferences: ['wheelchair', 'bikeShare', 'bikeTriangle', 'arriveBy']
         }
     };
     var events = $({});
@@ -200,6 +204,9 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
         var ul = isBike ? bikeModalOptions() : walkModalOptions();
         $(modalSelector).find(options.selectors.modalListContents).html(ul);
 
+        // set user selections in child modals
+        setSelections();
+
         modal = new Modal({
             modalSelector: modalSelector,
             bodyModalClass: options.selectors.bodyModalClass,
@@ -209,6 +216,23 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
 
         $(modalSelector).addClass(options.selectors.visibleClass);
         modal.open();
+    }
+
+    /**
+     * Set the selections in child modals based on user preferences.
+     * Does not manage date/time, which the timing modal controls directly.
+     */
+    function setSelections() {
+        _.forEach(options.selectors.preferences, function(option) {
+            var setting = UserPreferences.getPreference(option);
+            var toSelect = _.findKey(options.selectors.optionPreferences, function(pref) {
+                return option === pref.name && setting === pref.value;
+            });
+
+            var $toSelect = $('#' + toSelect);
+            $toSelect.siblings().removeClass(options.selectors.selectedClass);
+            $toSelect.addClass(options.selectors.selectedClass);
+        });
     }
 
     function childModalClick(e) {

--- a/src/app/scripts/cac/control/cac-control-trip-options.js
+++ b/src/app/scripts/cac/control/cac-control-trip-options.js
@@ -92,7 +92,8 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
     return TripOptionsControl;
 
     function initialize() {
-        if (options.currentMode.indexOf('BICYCLE') > -1) {
+        var currentMode = UserPreferences.getPreference('mode');
+        if (currentMode.indexOf('BICYCLE') > -1) {
             modalSelector = options.selectors.bikeOptionsModal;
             isBike = true;
         } else {
@@ -173,8 +174,10 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
             }
         }
 
-        childModal = new Modal(childModalOptions);
+        // close parent before declaring child modal
+        // FIXME: otherwise event bindings of parent are overwritten by child
         modal.close();
+        childModal = new Modal(childModalOptions);
         childModal.open();
         $(childModalSelector).addClass(options.selectors.visibleClass);
     }
@@ -184,7 +187,7 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
         // trigger plan re-query by calling onClose handler
         // check if child modal exists to determine whether closing out of options altogether
         // or just closing to go to another options modal
-        if (!childModal && options.onClose) {
+        if (!childModalSelector && options.onClose) {
             options.onClose();
         }
 

--- a/src/app/scripts/cac/control/cac-control-trip-options.js
+++ b/src/app/scripts/cac/control/cac-control-trip-options.js
@@ -174,10 +174,8 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
             }
         }
 
-        // close parent before declaring child modal
-        // FIXME: otherwise event bindings of parent are overwritten by child
-        modal.close();
         childModal = new Modal(childModalOptions);
+        modal.close();
         childModal.open();
         $(childModalSelector).addClass(options.selectors.visibleClass);
     }

--- a/src/app/scripts/cac/pages/cac-pages-directions.js
+++ b/src/app/scripts/cac/pages/cac-pages-directions.js
@@ -1,0 +1,159 @@
+CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings) {
+    'use strict';
+
+    var center = [39.95, -75.1667];
+    var zoom = 12;
+
+    // TODO: Remove duplicate from cac-map-control.js
+    var cartodbAttribution = [
+        '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, ',
+        '&copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+    ].join('');
+
+    var defaults = {
+        selectors: {
+            directionsContainer: '.directions-list'
+        }
+    };
+
+    var map = null;
+
+    function Directions(options) {
+        this.options = $.extend({}, defaults, options);
+    }
+
+    Directions.prototype.initialize = function () {
+
+        // Note: date/time does not get passed and so always defaults to departing now
+
+        var rawParams = _.map(location.search.slice(1).split('&'), function(p) {
+            return p.split('=');
+        });
+
+        // Pull out the itinerary index and validate it
+        var itineraryIndex = _.remove(rawParams, function(p) {
+            return p[0] === 'itineraryIndex';
+        });
+
+        if (!itineraryIndex || itineraryIndex.length < 1) {
+            console.error('Must specify itineraryIndex URL parameter');
+            return;
+        } else {
+            itineraryIndex = parseInt(itineraryIndex[0][1]);
+            if (isNaN(itineraryIndex)) {
+                console.error('itineraryIndex URL parameter must be an integer');
+                return;
+            }
+        }
+
+        // Rules for rewriting GoPhillyGo URL params to OTP query params.
+        // If 'values' is defined, parse out the value into multiple copies of the param,
+        // one per item in the array returned by calling 'values' with the URL parameter value.
+        // Any URL param not in the mapping is passed through unchanged.
+        var mapping = {
+            origin: { paramName: 'fromPlace' },
+            originText: { paramName: 'fromText' },
+            destination: { paramName: 'toPlace' },
+            destinationText: { paramName: 'toText' },
+            waypoints: {
+                paramName: 'intermediatePlaces',
+                values: function (val) {
+                    return _.map(decodeURIComponent(val).split(';'), encodeURIComponent);
+                }
+            },
+        };
+
+        // Rewrites an array of [URLparam, value] pairs into an array of [OTPparam, value] pairs,
+        // using the mapping above.
+        var otpParams = _(rawParams).map(function (param) {
+            if (!mapping[param[0]]) {
+                return [param];
+            } else {
+                var config = mapping[param[0]];
+                if (!config.values) {
+                    return [[config.paramName, param[1]]];
+                } else {
+                    return _.map(config.values(param[1]), function (val) {
+                        return [config.paramName, val];
+                    });
+                }
+            }
+        }).flatten().value();
+        // Join array into param string
+        otpParams = _(otpParams).map(function (item) { return item.join('='); }).join('&');
+
+        var directionsListControl = new DirectionsList({
+            showBackButton: false,
+            showShareButton: false,
+            selectors: {
+                container: this.options.selectors.directionsContainer
+            }
+        });
+
+        loadMap();
+
+        $.ajax({
+            url: Settings.routingUrl,
+            type: 'GET',
+            crossDomain: true,
+            data: otpParams,
+            processData: false
+        }).then(function(data) {
+            var itineraries = data.plan.itineraries;
+            var itinerary = new Itinerary(itineraries[itineraryIndex], itineraryIndex);
+            setMapItinerary(itinerary);
+            directionsListControl.setItinerary(itinerary);
+        }, function (error) {
+            console.error(error);
+        });
+
+        function loadMap() {
+            var mapOptions = {
+                zoomControl: false
+            };
+            var retina = '';
+            if (window.devicePixelRatio > 1) {
+                retina = '@2x';
+            }
+            map = cartodb.L.map('directions-map', mapOptions).setView(center, zoom);
+            // TODO: Remove duplicate from cac-map-control.js
+            var basemap = cartodb.L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}' + retina + '.png', {
+                attribution: cartodbAttribution
+            });
+            basemap.addTo(map);
+        }
+
+        function setMapItinerary(itinerary) {
+            map.fitBounds(itinerary.geojson.getBounds(), {
+                padding: [30,30]
+            });
+            itinerary.geojson.addTo(map);
+
+            var originIcon = L.AwesomeMarkers.icon({
+                icon: 'home',
+                prefix: 'fa',
+                markerColor: 'purple'
+            });
+
+            var destIcon = L.AwesomeMarkers.icon({
+                icon: 'flag-o',
+                prefix: 'fa',
+                markerColor: 'red'
+            });
+
+            var origin = [itinerary.from.lat, itinerary.from.lon];
+            var destination = [itinerary.to.lat, itinerary.to.lon];
+            var originOptions = {icon: originIcon, title: 'origin' };
+            var originMarker = new cartodb.L.marker(origin, originOptions);
+
+            var destOptions = {icon: destIcon, title: 'destination' };
+            var destinationMarker = new cartodb.L.marker(destination, destOptions);
+
+            originMarker.addTo(map);
+            destinationMarker.addTo(map);
+        }
+    };
+
+    return Directions;
+
+})(jQuery, _, CAC.Control.DirectionsList, CAC.Routing.Itinerary, CAC.Settings);

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -134,6 +134,11 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
             event.preventDefault();
             event.stopPropagation();
 
+            // clear user set trip options on navigation back to home page
+            directionsControl.clearUserSettings();
+            // reset mode control
+            modeOptionsControl.setMode(UserPreferences.getPreference('mode'));
+
             tabControl.setTab(tabControl.TABS.HOME);
         });
 

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -14,18 +14,6 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
 
             map: '.the-map',
 
-            // TODO: update or remove old selectors below
-            errorClass: 'error',
-            exploreForm: '#explore',
-            exploreMode: '#exploreMode input',
-            exploreOrigin: '#exploreOrigin',
-            exploreTime: '#exploreTime',
-            submitErrorModal: '#submit-error-modal',
-            toggleButton: '.toggle-search button',
-            toggleDirectionsButton: '#toggle-directions',
-            toggleExploreButton: '#toggle-explore',
-            typeaheadExplore: '#exploreOrigin',
-
             homeLink: '.home-link',
             tabControl: '.tab-control',
             tabControlLink: '.nav-item'
@@ -80,10 +68,10 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
         });
 
         modeOptionsControl = new ModeOptions();
+        modeOptionsControl.setMode(UserPreferences.getPreference('mode'));
 
         directionsControl = new CAC.Control.Directions({
             mapControl: mapControl,
-            modeOptionsControl: modeOptionsControl,
             tabControl: tabControl,
             urlRouter: urlRouter
         });
@@ -97,8 +85,7 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
         $(options.selectors.optionsButton).on('click', function() {
             // initialize trip options modal with current mode selection
             new TripOptions({
-                currentMode: modeOptionsControl.getMode(),
-                onClose: directionsControl.setOptions
+                onClose: closedTripModal
             }).open();
         });
 
@@ -113,6 +100,8 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
                              $.proxy(moveDestination, this));
 
         mapControl.events.on(mapControl.eventNames.mapMoved, SearchParams.updateMapCenter);
+
+        modeOptionsControl.events.on(modeOptionsControl.eventNames.toggle, toggledMode);
 
 
         if ($(options.selectors.map).is(':visible')) {
@@ -178,11 +167,9 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
      */
     function clickedDestination(event) {
         event.preventDefault();
-        var mode = modeOptionsControl.getMode();
         var exploreTime = $(options.selectors.exploreTime).val();
         UserPreferences.setPreference('method', 'explore');
         UserPreferences.setPreference('exploreTime', exploreTime);
-        UserPreferences.setPreference('mode', mode);
 
         var block = $(event.target).closest(options.selectors.placeCard);
         var placeId = block.data('destination-id');
@@ -200,6 +187,30 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
     function moveDestination(event, position) {
         event.preventDefault();
         directionsControl.moveOriginDestination('destination', position);
+    }
+
+    /**
+     * Updates mode user preference when mode button toggled and triggers trip re-query.
+     *
+     * Listen to toggles of the mode buttons for walk, bike, and transit;
+     * receives OTP mode string for those options. If in bike mode, check
+     * if bike rental option set, and update mode appropriately; this option
+     * is controlled separately from the mode toggle buttons.
+     */
+    function toggledMode(event, mode) {
+        if (mode.indexOf('BICYCLE') >= 0) {
+            var bikeShare = UserPreferences.getPreference('bikeShare');
+            if (bikeShare) {
+                mode = mode.replace('BICYCLE', 'BICYCLE_RENT');
+            }
+        }
+        UserPreferences.setPreference('mode', mode);
+        directionsControl.setOptions();
+    }
+
+    function closedTripModal(event) {
+        // update mode, then requery
+        toggledMode(event, modeOptionsControl.getMode());
     }
 
     /**

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -48,7 +48,7 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
     }
 
     function clearUrl() {
-        updateUrl('');
+        updateUrl('/');
     }
 
     function buildExploreUrlFromPrefs() {

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -10,12 +10,20 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
     'use strict';
 
     // User pref parameters for different views
-    var SHARED_ENCODE = ['origin', 'originText', 'mode'];
-    var SHARED_READ = ['maxWalk', 'wheelchair', 'bikeTriangle'];
+    var SHARED_ENCODE = ['origin',
+                         'originText',
+                         'mode',
+                         'maxWalk',
+                         'wheelchair',
+                         'bikeTriangle',
+                         'arriveBy',
+                         'dateTime'];
+
     var EXPLORE_ENCODE = SHARED_ENCODE.concat(['placeId', 'exploreTime']);
-    var EXPLORE_READ = EXPLORE_ENCODE.concat(SHARED_READ);
-    var DIRECTIONS_ENCODE = SHARED_ENCODE.concat(['destination', 'destinationText', 'waypoints']);
-    var DIRECTIONS_READ = DIRECTIONS_ENCODE.concat(SHARED_READ).concat(['arriveBy']);
+
+    var DIRECTIONS_ENCODE = SHARED_ENCODE.concat(['destination',
+                                                 'destinationText',
+                                                 'waypoints']);
 
     var router = null;
 
@@ -59,10 +67,16 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
         var params = Utils.getUrlParams();
         if (params.destination) {
             UserPreferences.setPreference('method', 'directions');
-            setPrefs(DIRECTIONS_READ, params);
+            setPrefs(DIRECTIONS_ENCODE, params);
         } else if (params.origin) {
             UserPreferences.setPreference('method', 'explore');
-            setPrefs(EXPLORE_READ, params);
+            setPrefs(EXPLORE_ENCODE, params);
+        }
+
+        // set bike share preference separate from mode
+        if (params.mode) {
+            var bikeShare = params.mode.indexOf('_RENT') >= 0;
+            UserPreferences.setPreference('bikeShare', bikeShare);
         }
     }
 
@@ -105,6 +119,12 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
                         }
                     });
                     UserPreferences.setPreference(field, waypoints);
+                } else if (field === 'dateTime') {
+                    if (!params[field]) {
+                        UserPreferences.setPreference(field, undefined);
+                    } else {
+                        UserPreferences.setPreference(field, parseInt(params[field]));
+                    }
                 } else {
                     UserPreferences.setPreference(field, params[field]);
                 }

--- a/src/app/scripts/cac/utils.js
+++ b/src/app/scripts/cac/utils.js
@@ -2,6 +2,7 @@ CAC.Utils = (function (_) {
     'use strict';
 
     var module = {
+        getBikeTriangle: getBikeTriangle,
         convertReverseGeocodeToLocation: convertReverseGeocodeToLocation,
         getImageUrl: getImageUrl,
         abbrevStreetName: abbrevStreetName,
@@ -62,7 +63,47 @@ CAC.Utils = (function (_) {
         wy: 'Wy',
     };
 
-    return module;
+    // Note:  the three bike options must sum to 1, or OTP won't plan the trip
+    var bikeTriangle = {
+        any: {
+            triangleSafetyFactor: 0.34,
+            triangleSlopeFactor: 0.33,
+            triangleTimeFactor: 0.33
+        },
+        flat: {
+            triangleSafetyFactor: 0.17,
+            triangleSlopeFactor: 0.66,
+            triangleTimeFactor: 0.17
+        },
+        fast: {
+            triangleSafetyFactor: 0.17,
+            triangleSlopeFactor: 0.17,
+            triangleTimeFactor: 0.66
+        },
+        safe: {
+            triangleSafetyFactor: 0.66,
+            triangleSlopeFactor: 0.17,
+            triangleTimeFactor: 0.17
+        }
+    };
+
+    return Object.freeze(module);
+
+    /**
+     * Get OTP values for the bikeTriangle parameter, which weights based on
+     * relative preference for safety, speed, or flatness of route.
+     *
+     * @param {string} option Key for which option to prefer
+     * @returns {Object} Values that sum to 1 and weight for the preferred option
+     */
+    function getBikeTriangle(option) {
+        if (_.has(bikeTriangle, option)) {
+            return bikeTriangle[option];
+        }
+
+        console.error('bike triangle option ' + option + ' not found');
+        return bikeTriangle.any;
+    }
 
     /**
      * Convert ESRI reverse geocode response into location formatted like typeahead results.

--- a/src/karma/karma-coverage.conf.js
+++ b/src/karma/karma-coverage.conf.js
@@ -49,6 +49,7 @@ module.exports = function(config) {
       'app/scripts/cac/control/cac-control-directions-list.js',
       'app/scripts/cac/home/cac-home-templates.js',
       'app/scripts/cac/pages/cac-pages-home.js',
+      'app/scripts/cac/pages/cac-pages-directions.js',
 
       'test/spec/*.js',
       'test/spec/**/*.js'

--- a/src/karma/karma-dev.conf.js
+++ b/src/karma/karma-dev.conf.js
@@ -49,6 +49,7 @@ module.exports = function(config) {
       'app/scripts/cac/control/cac-control-directions-list.js',
       'app/scripts/cac/home/cac-home-templates.js',
       'app/scripts/cac/pages/cac-pages-home.js',
+      'app/scripts/cac/pages/cac-pages-directions.js',
 
       'test/spec/*.js',
       'test/spec/**/*.js'


### PR DESCRIPTION
Keep user preferences in sync with URL and the controls, and ensure router can manage reading/setting all the preferences. Clear all preferences, controls, and URL on navigation back to home view.

Closes #660 and closes #661.

* After page refresh, URL options should be reflected in trip options list pickers and top-level modal text
* Clicking logo button on map page to go home should reset all trip options