### PR TITLE
Feature/fix timing browser bug

### DIFF
--- a/src/app/scripts/cac/control/cac-control-trip-options.js
+++ b/src/app/scripts/cac/control/cac-control-trip-options.js
@@ -487,11 +487,12 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
      * Helper to listen for change events on the day drop-down created by timingModalOptions
      */
     function addDayDropDownListener() {
-        $('#' + options.selectors.dayOptionsId).on('change', function(e) {
+        var $dayOptions = $('#' + options.selectors.dayOptionsId);
+        $dayOptions.on('change', function() {
             var $time = $('#' + options.selectors.timeOptionsId);
             var timeSelection = $time.val();
 
-            if (!$(e.currentTarget).val()) {
+            if (!$dayOptions.val()) {
                 // got set to current day
 
                 // set time to 'now' if selection is before next 15 minute increment
@@ -531,6 +532,9 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
 
         // reset to 'depart at'
         $(childModalSelector).find(options.selectors.departAt).click();
+
+        // trigger day drop-down change handler, to hide times before now
+        $('#' + options.selectors.dayOptionsId).trigger('change');
 
         // un-set user preferences (will revert to defaults)
         UserPreferences.setPreference('arriveBy', undefined);

--- a/src/app/scripts/cac/control/cac-control-trip-options.js
+++ b/src/app/scripts/cac/control/cac-control-trip-options.js
@@ -131,6 +131,9 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
             // set time and date selector options
             $(childModalSelector).find(options.selectors.timingFields).html(timingModalOptions());
 
+            // listen to the day drop-down on the timing modal
+            addDayDropDownListener();
+
             // read arrive by user setting and toggle if needed
             if (UserPreferences.getPreference('arriveBy')) {
                 $(childModalSelector).find(options.selectors.arriveBy).click();
@@ -235,39 +238,7 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
                 childModal.close();
             }
 
-        } else {
-            // user clicked somewhere on modal that is not a list item option
-
-            // listen to the day drop-down on the timing modal
-            if ($el.prop('id') === options.selectors.dayOptionsId) {
-                var $time = $('#' + options.selectors.timeOptionsId);
-                var timeSelection = $time.val();
-
-                if (!$el.val()) {
-                    // got set to current day
-
-                    // set time to 'now' if selection is before next 15 minute increment
-                    var nextQtrHr = $time.find('.' + options.selectors.nextQuarterHourClass).val();
-                    if (parseInt(timeSelection) < parseInt(nextQtrHr)) {
-                        $time.val($time.find('.' + options.selectors.currentTimeClass).val());
-                    }
-
-                    // hide times before 'now'
-                    $(options.selectors.timingFields).removeClass(options.selectors.notTodayClass);
-
-                } else {
-                    // selection is not today
-
-                    // set selection to next 15 minute increment if 'now' was selected
-                    if (timeSelection === $time.find('.' + options.selectors.currentTimeClass).val()) {
-                        $time.val($time.find('.' + options.selectors.nextQuarterHourClass).val());
-                    }
-
-                    // hide 'now' option and show times before now
-                    $(options.selectors.timingFields).addClass(options.selectors.notTodayClass);
-                }
-            }
-        }
+        } // else user clicked somewhere on modal that is not a list item option
     }
 
     function onChildModalClose() {
@@ -510,6 +481,40 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
         });
 
         return html;
+    }
+
+    /**
+     * Helper to listen for change events on the day drop-down created by timingModalOptions
+     */
+    function addDayDropDownListener() {
+        $('#' + options.selectors.dayOptionsId).on('change', function(e) {
+            var $time = $('#' + options.selectors.timeOptionsId);
+            var timeSelection = $time.val();
+
+            if (!$(e.currentTarget).val()) {
+                // got set to current day
+
+                // set time to 'now' if selection is before next 15 minute increment
+                var nextQtrHr = $time.find('.' + options.selectors.nextQuarterHourClass).val();
+                if (parseInt(timeSelection) < parseInt(nextQtrHr)) {
+                    $time.val($time.find('.' + options.selectors.currentTimeClass).val());
+                }
+
+                // hide times before 'now'
+                $(options.selectors.timingFields).removeClass(options.selectors.notTodayClass);
+
+            } else {
+                // selection is not today
+
+                // set selection to next 15 minute increment if 'now' was selected
+                if (timeSelection === $time.find('.' + options.selectors.currentTimeClass).val()) {
+                    $time.val($time.find('.' + options.selectors.nextQuarterHourClass).val());
+                }
+
+                // hide 'now' option and show times before now
+                $(options.selectors.timingFields).addClass(options.selectors.notTodayClass);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
Fixes #698.

Also fixes issue where times before 'now' would still be visible if a future date was selected and then 'clear' button is clicked.