### PR TITLE
Feature/fixup transit toggle

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -30,7 +30,7 @@ cac_python_dependencies:
     - { name: 'ipython', version: '4.2.1' }
     - { name: 'pillow', version: '3.4.2' }
     - { name: 'psycopg2', version: '2.6.2' }
-    - { name: 'pytz', version: '2016.7' }
+    - { name: 'pytz', version: '2016.10' }
     - { name: 'pyyaml', version: '3.12' }
     - { name: 'troposphere', version: '0.7.2'}
     # Note: django-wpadmin is installed manually to work around the fact that ansible-pip

--- a/src/app/scripts/cac/control/cac-control-mode-options.js
+++ b/src/app/scripts/cac/control/cac-control-mode-options.js
@@ -2,29 +2,6 @@ CAC.Control.ModeOptions = (function ($) {
     'use strict';
 
     var defaults = {
-        // Note:  the three bike options must sum to 1, or OTP won't plan the trip
-        bikeTriangle: {
-            any: {
-                triangleSafetyFactor: 0.34,
-                triangleSlopeFactor: 0.33,
-                triangleTimeFactor: 0.33
-            },
-            flat: {
-                triangleSafetyFactor: 0.17,
-                triangleSlopeFactor: 0.66,
-                triangleTimeFactor: 0.17
-            },
-            fast: {
-                triangleSafetyFactor: 0.17,
-                triangleSlopeFactor: 0.17,
-                triangleTimeFactor: 0.66
-            },
-            safe: {
-                triangleSafetyFactor: 0.66,
-                triangleSlopeFactor: 0.17,
-                triangleTimeFactor: 0.17
-            }
-        },
         defaultMode: 'WALK,TRANSIT',
         // map button class names to OpenTripPlanner mode parameters
         modes: {
@@ -48,8 +25,7 @@ CAC.Control.ModeOptions = (function ($) {
     };
     var events = $({});
     var eventNames = {
-        toggle: 'cac:control:modeoptions:toggle',
-        transitChanged: 'cac:control:modeoptions:transitchanged'
+        toggle: 'cac:control:modeoptions:toggle'
     };
     var options = {};
 
@@ -91,7 +67,7 @@ CAC.Control.ModeOptions = (function ($) {
 
             var active = $(this).find('i').hasClass(options.selectors.transitIconOnClass);
             $(this).attr('title', active ? 'Click to disable transit' : 'Click to enable transit');
-            events.trigger(eventNames.transitChanged, active);
+            events.trigger(eventNames.toggle, getMode());
         });
     }
 

--- a/src/app/scripts/cac/control/cac-control-trip-options.js
+++ b/src/app/scripts/cac/control/cac-control-trip-options.js
@@ -182,8 +182,8 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
             }
         }
 
-        childModal = new Modal(childModalOptions);
         modal.close();
+        childModal = new Modal(childModalOptions);
         childModal.open();
         $(childModalSelector).addClass(options.selectors.visibleClass);
     }

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -108,8 +108,6 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
         mapControl.events.on(mapControl.eventNames.mapMoved, SearchParams.updateMapCenter);
 
         modeOptionsControl.events.on(modeOptionsControl.eventNames.toggle, toggledMode);
-        modeOptionsControl.events.on(modeOptionsControl.eventNames.transitChanged,
-                                     directionsControl.setOptions);
 
 
         if ($(options.selectors.map).is(':visible')) {


### PR DESCRIPTION
Fixes up some transit-toggle related refactor work from #693 that was missing in #694.

Also bumps `pytz` timezone library version to latest release.