### PR TITLE
Add migration for destinations meta

### DIFF
--- a/python/cac_tripplanner/destinations/migrations/0018_auto_20161213_1615.py
+++ b/python/cac_tripplanner/destinations/migrations/0018_auto_20161213_1615.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('destinations', '0017_destination_priority'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='destination',
+            options={'ordering': ['priority', '?']},
+        ),
+    ]


### PR DESCRIPTION
Add missing migration for change to destinations model meta default sort.

Meta change made in 649465b25d7fe82891e93d512657c23137702f4b and apparently requires a database migration.