### PR TITLE
Enable embedding media in articles

### DIFF
--- a/python/cac_tripplanner/cac_tripplanner/settings.py
+++ b/python/cac_tripplanner/cac_tripplanner/settings.py
@@ -211,7 +211,13 @@ CKEDITOR_CONFIGS = {
             ["Table", "HorizontalRule"],
             ["SpecialChar"],
             ["Source"]
-        ]
+        ],
+        'extraPlugins': ','.join(
+            ['autolink',
+             'autoembed',
+             'embed',
+             'embedsemantic',
+             'autogrow']),
     }
 }
 


### PR DESCRIPTION
Add extensions to support embedding media in the ckeditor CMS plugin. These extensions are already supported by django-ckeditor, but not enabled by default.

Allows user to post link to media (like a YouTube URL) directly in the WYSIWYG editor. Link auto-expands to show video in editor preview, presents it in a data-oembed-url div in the published HTML, and persists across article edits. User will no longer need to edit source HTML directly.

Closes #407.

Also adds `autogrow` plugin, which will expand edit area to accommodate large articles, and `autolink`, which automatically expands pasted URLs to anchor tags.