### PR TITLE
Support browser history navigation

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions-form.js
+++ b/src/app/scripts/cac/control/cac-control-directions-form.js
@@ -47,7 +47,8 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
         eventNames: eventNames,
         moveOriginDestination: moveOriginDestination,
         clearAll: clearAll,
-        setError: setError
+        setError: setError,
+        setFromUserPreferences: setFromUserPreferences
     };
 
     return DirectionsFormControl;

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -209,7 +209,6 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
 
     function clearDirections() {
         mapControl.setDirectionsMarkers(null, null);
-        urlRouter.clearUrl();
         clearItineraries();
     }
 
@@ -409,7 +408,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
             directions.destination = [destination.location.y, destination.location.x ];
         }
 
-        if (origin && destination) {
+        if (origin && destination && tabControl.isTabShowing(tabControl.TABS.DIRECTIONS)) {
             planTrip();
         }
     }

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -229,7 +229,6 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
     }
 
     function setFromUserPreferences() {
-        var method = UserPreferences.getPreference('method');
         var exploreOrigin = UserPreferences.getPreference('origin');
 
         if (exploreOrigin) {
@@ -238,7 +237,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
             exploreLatLng = null;
         }
 
-        if (method === 'explore' && exploreLatLng) {
+        if (exploreLatLng && tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
             clickedExplore();
         }
     }

--- a/src/app/scripts/cac/control/cac-control-tab.js
+++ b/src/app/scripts/cac/control/cac-control-tab.js
@@ -61,6 +61,8 @@ CAC.Control.Tab = (function ($) {
         return tabId === currentTab;
     }
 
+    // Activates the given tab and broadcasts a 'tab shown' event, but does nothing if the
+    // requested tab is already active.
     function setTab(tabId) {
         if (!TABS[tabId]) { return; }
 


### PR DESCRIPTION
The URL routing package we're using supports pushing to browser history,
but it was turned off because it would create a weird loop when we update
the URL from the directions or explore controllers.

This enables it, which required
1. Some checking in the URL router to figure out when we're
   a) updating from code, in which it updates the URL but skips the routing
      callback or
   b) updating from code to the same URL, in which case it does nothing
2. Getting the relevant controllers (tab, directions form, mode options,
   trip options, directions, explore) to update for the new user
   preferences set by the URL router. This is done by throwing an event
   that the Home controller uses to call the relevant methods on all the
   subcontrollers.

**To test**
Click around!  Any change that affects the URL (changing tabs, changing mode, changing settings) should now cause the resulting view to get pushed to browser history as though it were a normal page.  The back button should work and, after going back, forward should work as well.

Resolves #707.