### PR TITLE
Feature/isochrone scrubber

### DIFF
--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -41,6 +41,11 @@
                 <button class="btn-reverse" title="Swap starting point and destination"
                     tabindex="4" type="button" name="reverse"><i class="icon-reverse"></i></button>
             </div>
+            <div class="isochrone-control directions-text-input hidden">
+                <label for="isochrone-slider">time</label>
+                <input type="range" id="isochrone-slider" name="isochrone-slider" value="15"
+                    tabindex="5" min="15" max="60" step="15">
+            </div>
         </div>
     </form>
 

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -12,10 +12,9 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
 
     var defaults = {
         selectors: {
+            hiddenClass: 'hidden',
             itineraryBlock: '.route-summary',
-
             selectedItineraryClass: 'selected',
-
             spinner: '.directions-results > .sk-spinner'
         }
     };
@@ -158,7 +157,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
 
         Routing.planTrip(directions.origin, directions.destination, date, params)
         .then(function (itineraries) {
-            $(options.selectors.spinner).addClass('hidden');
+            $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
             // Add the itineraries to the map, highlighting the first one
             var isFirst = true;
             itineraryControl.clearItineraries();
@@ -189,7 +188,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
         }, function (error) {
             console.error('failed to plan trip');
             console.error(error);
-            $(options.selectors.spinner).addClass('hidden');
+            $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
             itineraryControl.clearItineraries();
             itineraryListControl.setItinerariesError(error);
             itineraryListControl.show();
@@ -223,7 +222,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
     function showSpinner() {
         itineraryListControl.hide();
         directionsListControl.hide();
-        $(options.selectors.spinner).removeClass('hidden');
+        $(options.selectors.spinner).removeClass(options.selectors.hiddenClass);
     }
 
     function onDirectionsBackClicked() {
@@ -340,7 +339,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
     // If they dragged the origin or destination and the location failed to geocode, show error
     function onGeocodeError(event, key) {
         setDirections(key, null);
-        $(options.selectors.spinner).addClass('hidden');
+        $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
         itineraryListControl.setItinerariesError({
             msg: 'Could not find street address for location.'
         });

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -169,6 +169,8 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
 
         // store search inputs to preferences
         UserPreferences.setPreference('method', 'explore');
+        UserPreferences.setPreference('exploreMinutes', exploreMinutes);
+
         // Most interactions trigger this function, so updating the URL here keeps it mostly in sync
         // (the 'detail' functions don't update the isochrone so they update the URL themselves)
         updateUrl();
@@ -259,6 +261,9 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
         } else {
             exploreLatLng = null;
         }
+
+        // set explore time preference
+        $(options.selectors.isochroneSlider).val(UserPreferences.getPreference('exploreMinutes'));
 
         if (exploreLatLng && tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
             clickedExplore();

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -12,6 +12,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
 
     var defaults = {
         selectors: {
+            isochroneControl: '.isochrone-control',
             placesList: '.places-content',
             spinner: '.places > .sk-spinner',
         }
@@ -44,6 +45,9 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
 
         if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
             setFromUserPreferences();
+            $(options.selectors.isochroneControl).removeClass('hidden');
+        } else {
+            $(options.selectors.isochroneControl).addClass('hidden');
         }
     }
 
@@ -63,9 +67,11 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
         if (tabId === tabControl.TABS.EXPLORE) {
             UserPreferences.setPreference('method', 'explore');
             setFromUserPreferences();
+            $(options.selectors.isochroneControl).removeClass('hidden');
         } else {
             mapControl.isochroneControl.clearIsochrone();
             mapControl.isochroneControl.clearDestinations();
+            $(options.selectors.isochroneControl).addClass('hidden');
         }
     }
 

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -55,7 +55,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
         }
 
         // update isochrone on slider move
-        $(options.selectors.isochroneSlider).change(debouncedFetchIsochrone);
+        $(options.selectors.isochroneSlider).change(clickedExplore);
     }
 
     ExploreControl.prototype = {

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -12,6 +12,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
 
     var defaults = {
         selectors: {
+            hiddenClass: 'hidden',
             isochroneControl: '.isochrone-control',
             placesList: '.places-content',
             spinner: '.places > .sk-spinner',
@@ -45,9 +46,9 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
 
         if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
             setFromUserPreferences();
-            $(options.selectors.isochroneControl).removeClass('hidden');
+            $(options.selectors.isochroneControl).removeClass(options.selectors.hiddenClass);
         } else {
-            $(options.selectors.isochroneControl).addClass('hidden');
+            $(options.selectors.isochroneControl).addClass(options.selectors.hiddenClass);
         }
     }
 
@@ -67,11 +68,11 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
         if (tabId === tabControl.TABS.EXPLORE) {
             UserPreferences.setPreference('method', 'explore');
             setFromUserPreferences();
-            $(options.selectors.isochroneControl).removeClass('hidden');
+            $(options.selectors.isochroneControl).removeClass(options.selectors.hiddenClass);
         } else {
             mapControl.isochroneControl.clearIsochrone();
             mapControl.isochroneControl.clearDestinations();
-            $(options.selectors.isochroneControl).addClass('hidden');
+            $(options.selectors.isochroneControl).addClass(options.selectors.hiddenClass);
         }
     }
 
@@ -84,8 +85,8 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
     // reverse geocode the new location, so show the spinner while that happens.
     function onMovePointStart() {
         if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
-            $(options.selectors.placesList).addClass('hidden');
-            $(options.selectors.spinner).removeClass('hidden');
+            $(options.selectors.placesList).addClass(options.selectors.hiddenClass);
+            $(options.selectors.spinner).removeClass(options.selectors.hiddenClass);
         }
     }
 
@@ -95,10 +96,10 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
         if (key === 'origin') {
             setAddress(null);
             setError('Could not find street address for location.');
-            $(options.selectors.spinner).addClass('hidden');
+            $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
             if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
                 directionsFormControl.setError('origin');
-                $(options.selectors.placesList).removeClass('hidden');
+                $(options.selectors.placesList).removeClass(options.selectors.hiddenClass);
             }
         }
     }
@@ -111,8 +112,8 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
         if (!exploreLatLng || !tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
             return;
         }
-        $(options.selectors.placesList).addClass('hidden');
-        $(options.selectors.spinner).removeClass('hidden');
+        $(options.selectors.placesList).addClass(options.selectors.hiddenClass);
+        $(options.selectors.spinner).removeClass(options.selectors.hiddenClass);
         mapControl.isochroneControl.clearIsochrone();
 
         debouncedFetchIsochrone();
@@ -164,8 +165,8 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
         mapControl.isochroneControl.fetchIsochrone(exploreLatLng, date, exploreMinutes, otpOptions,
                                                    true).then(
             function (destinations) {
-                $(options.selectors.spinner).addClass('hidden');
-                $(options.selectors.placesList).removeClass('hidden');
+                $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
+                $(options.selectors.placesList).removeClass(options.selectors.hiddenClass);
                 if (!destinations) {
                     setError('No destinations found.');
                 }
@@ -173,8 +174,8 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
                 // setDestinationSidebar(destinations);
             }, function (error) {
                 console.error(error);
-                $(options.selectors.spinner).addClass('hidden');
-                $(options.selectors.placesList).removeClass('hidden');
+                $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
+                $(options.selectors.placesList).removeClass(options.selectors.hiddenClass);
                 setError('Could not find travelshed.');
             }
         );

--- a/src/app/scripts/cac/control/cac-control-itinerary-list.js
+++ b/src/app/scripts/cac/control/cac-control-itinerary-list.js
@@ -15,6 +15,7 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates) {
         showShareButton: false,
         selectors: {
             container: '.directions-list',
+            hiddenClass: 'hidden',
             itineraryItem: '.route-summary'
         }
     };
@@ -93,7 +94,7 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates) {
     }
 
     function show() {
-        $container.removeClass('hidden');
+        $container.removeClass(options.selectors.hiddenClass);
     }
 
     /**
@@ -108,11 +109,11 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates) {
     }
 
     function hide() {
-        $container.addClass('hidden');
+        $container.addClass(options.selectors.hiddenClass);
     }
 
     function toggle() {
-        if ($container.hasClass('hidden')) {
+        if ($container.hasClass(options.selectors.hiddenClass)) {
             show();
         } else {
             hide();

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -245,10 +245,9 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
      * When user clicks a destination, look it up, then redirect to its details in 'explore' tab.
      */
     function clickedDestination(event) {
+        console.error('TODO: implement clickedDestination');
         event.preventDefault();
-        var exploreTime = $(options.selectors.exploreTime).val();
         UserPreferences.setPreference('method', 'explore');
-        UserPreferences.setPreference('exploreTime', exploreTime);
 
         var block = $(event.target).closest(options.selectors.placeCard);
         var placeId = block.data('destination-id');

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -19,7 +19,7 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
                          'arriveBy',
                          'dateTime'];
 
-    var EXPLORE_ENCODE = SHARED_ENCODE.concat(['placeId', 'exploreTime']);
+    var EXPLORE_ENCODE = SHARED_ENCODE.concat(['placeId', 'exploreMinutes']);
 
     var DIRECTIONS_ENCODE = SHARED_ENCODE.concat(['destination',
                                                  'destinationText',

--- a/src/app/scripts/cac/user/cac-user-preferences.js
+++ b/src/app/scripts/cac/user/cac-user-preferences.js
@@ -35,7 +35,7 @@ CAC.User.Preferences = (function(Storages, _) {
         bikeShare: false,
         bikeTriangle: 'any',
         dateTime: undefined, // explicitly list here for isDefault check
-        exploreTime: 20,
+        exploreMinutes: 15,
         maxWalk: 482802, // in meters; set large, since not user-controllable
         method: 'directions',
         mode: 'TRANSIT,WALK',

--- a/src/app/styles/components/_directions-form.scss
+++ b/src/app/styles/components/_directions-form.scss
@@ -55,6 +55,8 @@
 
     #isochrone-slider {
         width: 75%;
+        @include inputrange();
+        margin-right: 1rem;
     }
 
     .isochrone-control {

--- a/src/app/styles/components/_directions-form.scss
+++ b/src/app/styles/components/_directions-form.scss
@@ -53,6 +53,18 @@
         }
     }
 
+    #isochrone-slider {
+        width: 75%;
+    }
+
+    .isochrone-control {
+        display: flex;
+
+        &.hidden {
+            display: none;
+        }
+    }
+
     .mode-picker {
         display: flex;
         flex: 0 0 60px;

--- a/src/app/styles/components/_directions-form.scss
+++ b/src/app/styles/components/_directions-form.scss
@@ -54,9 +54,9 @@
     }
 
     #isochrone-slider {
-        width: 75%;
         @include inputrange();
         margin-right: 1rem;
+        width: 75%;
     }
 
     .isochrone-control {

--- a/src/app/styles/main.scss
+++ b/src/app/styles/main.scss
@@ -1,7 +1,11 @@
+// Vendors
+@import
+'vendors/inputrange';
+
 // Utils
 @import
-'utils/variables',
 'utils/color',
+'utils/variables',
 'utils/functions',
 'utils/mixins',
 'utils/breakpoints';

--- a/src/app/styles/utils/_variables.scss
+++ b/src/app/styles/utils/_variables.scss
@@ -16,3 +16,27 @@ $sidebar-banner-height: 50px;
 $route-summary-height: 80px;
 $route-summary-default-dasharray: 7, 7;
 $route-summary-selected-dasharray: 0;
+
+// input[type=range]
+$track-color: $white;
+$thumb-color: $white;
+
+$thumb-radius: 20px;
+$thumb-height: 17px;
+$thumb-width: 17px;
+$thumb-shadow-size: 0;
+$thumb-shadow-blur: 0;
+$thumb-shadow-color: #000;
+$thumb-border-width: 2px;
+$thumb-border-color: $gophillygo-blue;
+
+$track-width: 100%;
+$track-height: 3px;
+$track-shadow-size: 0;
+$track-shadow-blur: 0;
+$track-shadow-color: #000;
+$track-border-width: 0;
+$track-border-color: #000;
+
+$track-radius: 10px;
+$inputrange-contrast: 5%;

--- a/src/app/styles/vendors/_inputrange.scss
+++ b/src/app/styles/vendors/_inputrange.scss
@@ -1,0 +1,125 @@
+// ADAPTED FROM:
+// Styling Cross-Browser Compatible Range Inputs with Sass
+// Github: https://github.com/darlanrod/input-range-sass
+// Author: Darlan Rod https://github.com/darlanrod
+// Version 1.1.0
+// MIT License
+
+$track-color: #424242 !default;
+$thumb-color: #555bc8 !default;
+
+$thumb-radius: 8px !default;
+$thumb-height: 30px !default;
+$thumb-width: 30px !default;
+$thumb-shadow-size: 1px !default;
+$thumb-shadow-blur: 1px !default;
+$thumb-shadow-color: #111 !default;
+$thumb-border-width: 1px !default;
+$thumb-border-color: #fff !default;
+
+$track-width: 100% !default;
+$track-height: 10px !default;
+$track-shadow-size: 2px !default;
+$track-shadow-blur: 2px !default;
+$track-shadow-color: #222 !default;
+$track-border-width: 1px !default;
+$track-border-color: #000 !default;
+
+$track-radius: 5px !default;
+$inputrange-contrast: 5% !default;
+
+@mixin shadow($shadow-size, $shadow-blur, $shadow-color) {
+  box-shadow: $shadow-size $shadow-size $shadow-blur $shadow-color, 0 0 $shadow-size lighten($shadow-color, 5%);
+}
+
+@mixin track() {
+  width: $track-width;
+  height: $track-height;
+  cursor: pointer;
+  transition: all .2s ease;
+}
+
+@mixin thumb() {
+  @include shadow($thumb-shadow-size, $thumb-shadow-blur, $thumb-shadow-color);
+  border: $thumb-border-width solid $thumb-border-color;
+  height: $thumb-height;
+  width: $thumb-width;
+  border-radius: $thumb-radius;
+  background: $thumb-color;
+  cursor: pointer;
+}
+
+// [type=range] {
+@mixin inputrange() {
+  -webkit-appearance: none;
+  margin: $thumb-height / 2 0;
+  width: $track-width;
+
+  &:focus {
+    outline: none;
+  }
+
+  &::-webkit-slider-runnable-track {
+    @include track();
+    @include shadow($track-shadow-size, $track-shadow-blur, $track-shadow-color);
+    background: $track-color;
+    border: $track-border-width solid $track-border-color;
+    border-radius: $track-radius;
+  }
+
+  &::-webkit-slider-thumb {
+    @include thumb();
+    -webkit-appearance: none;
+    margin-top: ((-$track-border-width * 2 + $track-height) / 2) - ($thumb-height / 2);
+  }
+
+  &:focus::-webkit-slider-runnable-track {
+    background: lighten($track-color, $inputrange-contrast);
+  }
+
+  &::-moz-range-track {
+    @include track();
+    @include shadow($track-shadow-size, $track-shadow-blur, $track-shadow-color);
+    background: $track-color;
+    border: $track-border-width solid $track-border-color;
+    border-radius: $track-radius;
+  }
+
+  &::-moz-range-thumb {
+    @include thumb();
+  }
+
+  &::-ms-track {
+    @include track();
+    background: transparent;
+    border-color: transparent;
+    border-width: $thumb-width 0;
+    color: transparent;
+  }
+
+  &::-ms-fill-lower {
+    @include shadow($track-shadow-size, $track-shadow-blur, $track-shadow-color);
+    background: darken($track-color, $inputrange-contrast);
+    border: $track-border-width solid $track-border-color;
+    border-radius: $track-radius * 2;
+  }
+
+  &::-ms-fill-upper {
+    @include shadow($track-shadow-size, $track-shadow-blur, $track-shadow-color);
+    background: $track-color;
+    border: $track-border-width solid $track-border-color;
+    border-radius: $track-radius * 2;
+  }
+
+  &::-ms-thumb {
+    @include thumb();
+  }
+
+  &:focus::-ms-fill-lower {
+    background: $track-color;
+  }
+
+  &:focus::-ms-fill-upper {
+    background: lighten($track-color, $inputrange-contrast);
+  }
+}


### PR DESCRIPTION
Closes #594.

![image](https://cloud.githubusercontent.com/assets/960264/21364073/44a1132c-c6bd-11e6-93e0-31b99ffc0122.png)


Adds a slider to the explore view in the place where the `to` field appears in directions view.

Does not attempt to cache response client side (would be too much to store on mobile). Limits options to 15, 30, 45, and 60 minutes, to minimize server load.

@lederer this could probably use some styling attention; wasn't sure where to label selected value. Also, should the selection be also reflected in the green bar? If so, will likely overflow to a second line.