### PR TITLE
Feature/update alerts

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -342,12 +342,12 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Ty
 
     // If they dragged the origin or destination and the location failed to geocode, show error
     function onGeocodeError(event, key) {
-        setDirections(key, null);
-        $(options.selectors.spinner).addClass('hidden');
-        itineraryListControl.setItinerariesError({
-            msg: 'Could not find street address for location.'
-        });
         if (tabControl.isTabShowing(tabControl.TABS.DIRECTIONS)) {
+            setDirections(key, null);
+            $(options.selectors.spinner).addClass('hidden');
+            itineraryListControl.setItinerariesError({
+                msg: 'Could not find street address for location.'
+            });
             itineraryListControl.show();
         }
     }

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -76,12 +76,23 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
         clickedExplore();
     }
 
+    // Helper to hide loading spinner and show places list
+    function showPlacesList() {
+        $(options.selectors.spinner).addClass('hidden');
+        $(options.selectors.placesList).removeClass('hidden');
+    }
+
+    // Helper to hide places list and show loading spinner in its place
+    function showSpinner() {
+        $(options.selectors.placesList).addClass('hidden');
+        $(options.selectors.spinner).removeClass('hidden');
+    }
+
     // If they move the marker, that invalidates the old isochrone and triggers the form to
     // reverse geocode the new location, so show the spinner while that happens.
     function onMovePointStart() {
         if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
-            $(options.selectors.placesList).addClass('hidden');
-            $(options.selectors.spinner).removeClass('hidden');
+            showSpinner();
         }
     }
 
@@ -92,9 +103,8 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
             if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
                 setAddress(null);
                 setError('Could not find street address for location.');
-                $(options.selectors.spinner).addClass('hidden');
                 directionsFormControl.setError('origin');
-                $(options.selectors.placesList).removeClass('hidden');
+                showPlacesList();
             }
         }
     }
@@ -107,8 +117,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
         if (!exploreLatLng || !tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
             return;
         }
-        $(options.selectors.placesList).addClass('hidden');
-        $(options.selectors.spinner).removeClass('hidden');
+        showSpinner();
         $(options.selectors.alert).remove();
         mapControl.isochroneControl.clearIsochrone();
 
@@ -161,8 +170,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
         mapControl.isochroneControl.fetchIsochrone(exploreLatLng, date, exploreMinutes, otpOptions,
                                                    true).then(
             function (destinations) {
-                $(options.selectors.spinner).addClass('hidden');
-                $(options.selectors.placesList).removeClass('hidden');
+                showPlacesList();
                 if (!destinations) {
                     setError('No destinations found.');
                 }
@@ -170,8 +178,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
                 // setDestinationSidebar(destinations);
             }, function (error) {
                 console.error(error);
-                $(options.selectors.spinner).addClass('hidden');
-                $(options.selectors.placesList).removeClass('hidden');
+                showPlacesList();
                 setError('Could not find travelshed for given origin.');
             }
         );
@@ -185,8 +192,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
         $container.one('click', '.close', function () {
             $alert.remove();
         });
-        $(options.selectors.spinner).addClass('hidden');
-        $container.removeClass('hidden');
+        showPlacesList();
     }
 
     function onTypeaheadCleared(event, key) {

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -12,6 +12,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
 
     var defaults = {
         selectors: {
+            alert: '.alert',
             placesList: '.places-content',
             spinner: '.places > .sk-spinner',
         }
@@ -64,6 +65,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
             UserPreferences.setPreference('method', 'explore');
             setFromUserPreferences();
         } else {
+            $(options.selectors.alert).remove();
             mapControl.isochroneControl.clearIsochrone();
             mapControl.isochroneControl.clearDestinations();
         }
@@ -87,10 +89,10 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
     // Since the drag event activates the spinner, this needs to restore the sidebar list.
     function onGeocodeError(event, key) {
         if (key === 'origin') {
-            setAddress(null);
-            setError('Could not find street address for location.');
-            $(options.selectors.spinner).addClass('hidden');
             if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
+                setAddress(null);
+                setError('Could not find street address for location.');
+                $(options.selectors.spinner).addClass('hidden');
                 directionsFormControl.setError('origin');
                 $(options.selectors.placesList).removeClass('hidden');
             }
@@ -107,6 +109,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
         }
         $(options.selectors.placesList).addClass('hidden');
         $(options.selectors.spinner).removeClass('hidden');
+        $(options.selectors.alert).remove();
         mapControl.isochroneControl.clearIsochrone();
 
         debouncedFetchIsochrone();
@@ -169,15 +172,19 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
                 console.error(error);
                 $(options.selectors.spinner).addClass('hidden');
                 $(options.selectors.placesList).removeClass('hidden');
-                setError('Could not find travelshed.');
+                setError('Could not find travelshed for given origin.');
             }
         );
     }
 
     function setError(message) {
-        var $alert = MapTemplates.alert(message, 'danger');
+        var $alert = $(MapTemplates.alert(message, 'Cannot show travelshed', 'danger'));
         var $container = $(options.selectors.placesList);
         $container.html($alert);
+        // handle close button
+        $container.one('click', '.close', function () {
+            $alert.remove();
+        });
         $(options.selectors.spinner).addClass('hidden');
         $container.removeClass('hidden');
     }
@@ -186,6 +193,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
         if (key === 'origin') {
             exploreLatLng = null;
             // selectedPlaceId = null;
+            $(options.selectors.alert).remove();
             mapControl.isochroneControl.clearIsochrone();
         }
     }
@@ -214,6 +222,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, Routing, Typeahea
             }
         } else {
             exploreLatLng = null;
+            $(options.selectors.alert).remove();
             mapControl.isochroneControl.clearIsochrone();
         }
     }

--- a/src/app/scripts/cac/control/cac-control-itinerary-list.js
+++ b/src/app/scripts/cac/control/cac-control-itinerary-list.js
@@ -14,6 +14,7 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates) {
         // Should the share button be shown in the control
         showShareButton: false,
         selectors: {
+            alert: '.alert',
             container: '.directions-list',
             itineraryItem: '.route-summary'
         }
@@ -66,8 +67,13 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates) {
      * @param {Object} Error object returned from OTP
      */
     function setItinerariesError(error) {
-        var $alert = MapTemplates.alert('Could not plan trip: ' + error.msg, 'danger');
-        $container.html($alert);
+        var alert = MapTemplates.alert(error.msg, 'Could not plan trip', 'danger');
+        $container.html(alert);
+
+        // handle alert close button click
+        $container.one('click', options.selectors.alert, function() {
+            $(options.selectors.alert).remove();
+        });
     }
 
     function getItineraryById(id) {

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -31,22 +31,30 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
      * http://getbootstrap.com/components/#alerts
      *
      * @param {string} message Message to display
+     * @param {string} title Header for message
      * @param {string} type Alert type (success, warning, info, or danger)
      * @returns {String} Compiled Handlebars template for the Bootstrap alert
      */
-    function alert(message, type) {
+    function alert(message, title, type) {
         var info = {
             message: message,
+            title: title,
             type: type
         };
+
         var source = [
-            '<div class="alert-container">',
-            '<div class="alert alert-{{info.type}} alert-dismissible" role="alert">',
-            '<button type="button" class="close" data-dismiss="alert" aria-label="Close">',
-            '<span aria-hidden="true">&times;</span></button>',
+            '<div class="alert alert-{{info.type}}">',
+            '<div class="alert-title">',
+            '{{info.title}}',
+            '<button title="Dismiss this message" name="close" class="close" aria-label="Close">',
+            '<i class="icon-cancel"></i></button>',
+            '</div>',
+            '<div class="alert-body">',
             '{{info.message}}',
-            '</div></div>'
+            '</div>',
+            '</div>'
         ].join('');
+
         var template = Handlebars.compile(source);
         var html = template({info: info});
         return html;

--- a/src/app/styles/components/_alerts.scss
+++ b/src/app/styles/components/_alerts.scss
@@ -34,3 +34,19 @@
 .alert-bicycle {
     background-color: $alert-color-bicycle;
 }
+
+.alert-success {
+    background-color: $gophillygo-green;
+}
+
+.alert-warning {
+    background-color: $gophillygo-yellow;
+}
+
+.alert-info {
+    background-color: $gophillygo-blue;
+}
+
+.alert-danger {
+    background-color: $gophillygo-red;
+}

--- a/src/app/styles/pages/_home.scss
+++ b/src/app/styles/pages/_home.scss
@@ -12,8 +12,4 @@
     height: 100%;
     overflow: auto;
     -webkit-overflow-scrolling: touch;
-
-    .places {
-        display: none;
-    }
 }

--- a/src/app/styles/pages/_home.scss
+++ b/src/app/styles/pages/_home.scss
@@ -12,4 +12,8 @@
     height: 100%;
     overflow: auto;
     -webkit-overflow-scrolling: touch;
+
+    .places {
+        display: none;
+    }
 }


### PR DESCRIPTION
Updates sidebar alerts for new styling. Closes #614 and #721.

#648 only updated the bicycle message alert, which is handled separately to allow for the embedded links. This updates the sidebar alerts for directions and isochrone errors. Easy way to check: try dragging a marker into the Atlantic. Alerts should be close with a click on the 'x' button and disappear on requery or page/tab change.

@lederer: I added some alert classes in keeping with the Bootstrap alert types we'd been using before; currently we're only using the `danger` type.

Also fixed an issue where navigating back to the home tab from the map page would leave behind a little white box between the form controls and the destinations list.
