### PR TITLE
Activate directions button on place cards

### DIFF
--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -66,7 +66,9 @@
             </header>
             <ul class="place-list">
                 {% for destination in destinations %}
-                <li class="place-card no-origin">
+                <li class="place-card no-origin" data-destination-id="{{ destination.id }}"
+                    data-destination-x="{{ destination.point.x }}"
+                    data-destination-y="{{ destination.point.y }}">
                     <img class="place-card-photo"
                         {% if destination.image %}
                             src="{{ destination.wide_image.url }}"
@@ -75,7 +77,7 @@
                         {% endif %}
                         width="400" height="200"
                         alt="{{ destination.name }}" />
-                    <h2>{{ destination.name }}</h2>
+                    <h2 class="place-card-name">{{ destination.name }}</h2>
                     <div class="place-card-travel-logistics">
                         <span class="place-card-travel-logistics-duration">N</span> min from <span class="place-card-travel-logistics-origin">origin</span>
                     </div>

--- a/src/app/scripts/cac/control/cac-control-directions-form.js
+++ b/src/app/scripts/cac/control/cac-control-directions-form.js
@@ -32,8 +32,6 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
     };
     var options = {};
 
-    var typeaheadTo = null;
-    var typeaheadFrom = null;
     var typeaheads = {};
 
 
@@ -57,20 +55,15 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
     return DirectionsFormControl;
 
     function initialize() {
-        typeaheadTo = new Typeahead(options.selectors.typeaheadTo);
-        typeaheadTo.events.on(typeaheadTo.eventNames.selected, onTypeaheadSelected);
-        typeaheadTo.events.on(typeaheadTo.eventNames.cleared, onTypeaheadCleared);
+        typeaheads.destination = new Typeahead(options.selectors.typeaheadTo);
+        typeaheads.destination.events.on(typeaheads.destination.eventNames.selected,
+                                         onTypeaheadSelected);
+        typeaheads.destination.events.on(typeaheads.destination.eventNames.cleared,
+                                         onTypeaheadCleared);
 
-        typeaheadFrom = new Typeahead(options.selectors.typeaheadFrom);
-        typeaheadFrom.events.on(typeaheadFrom.eventNames.selected, onTypeaheadSelected);
-        typeaheadFrom.events.on(typeaheadFrom.eventNames.cleared, onTypeaheadCleared);
-
-        // Also put the typeheads in an object to avoid having to make ternaries to get the right
-        // one in functions that take a 'key' argument
-        typeaheads = {
-            origin: typeaheadFrom,
-            destination: typeaheadTo
-        };
+        typeaheads.origin = new Typeahead(options.selectors.typeaheadFrom);
+        typeaheads.origin.events.on(typeaheads.origin.eventNames.selected, onTypeaheadSelected);
+        typeaheads.origin.events.on(typeaheads.origin.eventNames.cleared, onTypeaheadCleared);
 
         $(options.selectors.reverseButton).click($.proxy(reverseOriginDestination, this));
 
@@ -83,11 +76,11 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
         var destination = UserPreferences.getPreference('destination');
 
         if (origin && origin.location) {
-            typeaheadFrom.setValue(UserPreferences.getPreference('originText'));
+            typeaheads.origin.setValue(UserPreferences.getPreference('originText'));
         }
 
         if (destination && destination.location) {
-            typeaheadTo.setValue(UserPreferences.getPreference('destinationText'));
+            typeaheads.destination.setValue(UserPreferences.getPreference('destinationText'));
         }
     }
 
@@ -131,8 +124,8 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
         UserPreferences.setPreference('destinationText', originText);
 
         // update the text control
-        typeaheadFrom.setValue(destinationText);
-        typeaheadTo.setValue(originText);
+        typeaheads.origin.setValue(destinationText);
+        typeaheads.destination.setValue(originText);
 
         // Trigger reversed event, with new origin and destination, for directions controller to use
         events.trigger(eventNames.reversed, [destination, origin]);
@@ -179,8 +172,8 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
 
     // Clear both fields and any errors
     function clearAll() {
-        typeaheadFrom.setValue('');
-        typeaheadTo.setValue('');
+        typeaheads.origin.setValue('');
+        typeaheads.destination.setValue('');
         $(options.selectors.origin).removeClass(options.selectors.errorClass);
         $(options.selectors.destination).removeClass(options.selectors.errorClass);
         $(options.selectors.alert).remove();

--- a/src/app/scripts/cac/control/cac-control-directions-form.js
+++ b/src/app/scripts/cac/control/cac-control-directions-form.js
@@ -34,6 +34,7 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
 
     var typeaheadTo = null;
     var typeaheadFrom = null;
+    var typeaheads = {};
 
 
     function DirectionsFormControl(params) {
@@ -63,6 +64,13 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
         typeaheadFrom = new Typeahead(options.selectors.typeaheadFrom);
         typeaheadFrom.events.on(typeaheadFrom.eventNames.selected, onTypeaheadSelected);
         typeaheadFrom.events.on(typeaheadFrom.eventNames.cleared, onTypeaheadCleared);
+
+        // Also put the typeheads in an object to avoid having to make ternaries to get the right
+        // one in functions that take a 'key' argument
+        typeaheads = {
+            origin: typeaheadFrom,
+            destination: typeaheadTo
+        };
 
         $(options.selectors.reverseButton).click($.proxy(reverseOriginDestination, this));
 
@@ -97,8 +105,7 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
 
     // For setting origin or destination from code, e.g. directions links
     function setLocation(key, location) {
-        var typeahead = (key === 'origin') ? typeaheadFrom : typeaheadTo;
-        typeahead.setValue(location.address);
+        typeaheads[key].setValue(location.address);
         UserPreferences.setLocation(key, location);
         events.trigger(eventNames.selected, [key, location]);
     }
@@ -143,7 +150,7 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
             console.error('Unrecognized key in moveOriginDestination: ' + key);
             return;
         }
-        var typeahead = (key === 'origin') ? typeaheadFrom : typeaheadTo;
+        var typeahead = typeaheads[key];
 
         Geocoder.reverse(position.lat, position.lng).then(function (data) {
             if (data && data.address) {

--- a/src/app/scripts/cac/control/cac-control-directions-form.js
+++ b/src/app/scripts/cac/control/cac-control-directions-form.js
@@ -48,6 +48,7 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
         eventNames: eventNames,
         moveOriginDestination: moveOriginDestination,
         clearAll: clearAll,
+        setLocation: setLocation,
         setError: setError,
         setFromUserPreferences: setFromUserPreferences
     };
@@ -85,13 +86,18 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
     // Handle the form-related parts of a typeahead select, then fire an event with the new
     // location for the directions and explore controllers to use
     function onTypeaheadSelected(event, key, location) {
-
         if (!location) {
             UserPreferences.clearLocation(key);
         } else {
             UserPreferences.setLocation(key, location);
         }
 
+        events.trigger(eventNames.selected, [key, location]);
+    }
+
+    // For setting origin or destination from code, e.g. directions links
+    function setLocation(key, location, text) {
+        UserPreferences.setLocation(key, location, text);
         events.trigger(eventNames.selected, [key, location]);
     }
 

--- a/src/app/scripts/cac/control/cac-control-directions-form.js
+++ b/src/app/scripts/cac/control/cac-control-directions-form.js
@@ -96,8 +96,10 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
     }
 
     // For setting origin or destination from code, e.g. directions links
-    function setLocation(key, location, text) {
-        UserPreferences.setLocation(key, location, text);
+    function setLocation(key, location) {
+        var typeahead = (key === 'origin') ? typeaheadFrom : typeaheadTo;
+        typeahead.setValue(location.address);
+        UserPreferences.setLocation(key, location);
         events.trigger(eventNames.selected, [key, location]);
     }
 

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -86,7 +86,6 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Te
 
     DirectionsControl.prototype = {
         clearDirections: clearDirections,
-        // setDestination: setDestination,
         setDirections: setDirections,
         setOptions: setOptions,
         setFromUserPreferences: setFromUserPreferences
@@ -363,33 +362,6 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Te
             itineraryListControl.show();
         }
     }
-
-    // TODO: restore/reimplement this functionality
-    /* Show directions to a destination when the user clicks a Places link */
-    // function setDestination(destination) {
-    //     // Set origin
-    //     var origin = UserPreferences.getPreference('origin');
-    //     var originText = UserPreferences.getPreference('originText');
-    //     directions.origin = [origin.location.y, origin.location.x];
-
-    //     // Set destination
-    //     var destinationCoords = destination.point.coordinates;
-    //     var destinationText = destination.address;
-    //     directions.destination = [destinationCoords[1], destinationCoords[0]];
-
-    //     // Save destination coordinates in expected format (to match typeahead results)
-    //     destination.location = {
-    //         x: destinationCoords[0],
-    //         y: destinationCoords[1]
-    //     };
-
-    //     // set in UI
-    //     typeaheadFrom.setValue(originText);
-    //     typeaheadTo.setValue(destinationText);
-
-    //     // Get directions
-    //     planTrip();
-    // }
 
     function setDirections(key, value) {
         clearItineraries();

--- a/src/app/scripts/cac/home/cac-home-templates.js
+++ b/src/app/scripts/cac/home/cac-home-templates.js
@@ -32,7 +32,7 @@ CAC.Home.Templates = (function (Handlebars) {
                         '{{/if}}',
                         'width="400" height="200"',
                         'alt="{{ this.name }}" />',
-                    '<h2>{{ this.name }}</h2>',
+                    '<h2 class="place-card-name">{{ this.name }}</h2>',
                     '<div class="place-card-travel-logistics">',
                         '<span class="place-card-travel-logistics-duration"></span> ',
                         'from <span class="place-card-travel-logistics-origin">origin</span>',

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -261,6 +261,10 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
         };
         directionsFormControl.setLocation('destination', destination);
         tabControl.setTab(tabControl.TABS.DIRECTIONS);
+        if (!UserPreferences.getPreference('origin')) {
+            directionsFormControl.setError('origin');
+            $(options.selectors.originInput).focus();
+        }
     }
 
     function onTypeaheadSelected() {

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -10,6 +10,7 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
             // destinations
             placeCard: '.place-card',
             placeCardDirectionsLink: '.place-card .place-action-go',
+            placeCardName: '.place-card-name',
             placeList: '.place-list',
             places: '.places',
 
@@ -114,10 +115,6 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
             }).open();
         });
 
-        $(options.selectors.placeList).on('click',
-                                          options.selectors.placeCardDirectionsLink,
-                                          $.proxy(clickedDestination, this));
-
         // Listen for origin/destination dragging events to forward to the DirectionsFormControl
         mapControl.events.on(mapControl.eventNames.originMoved,
                              $.proxy(moveOrigin, this));
@@ -185,6 +182,9 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
             $.proxy(tabControl.setTab(tabControl.TABS.EXPLORE), this);
         });
 
+        $(options.selectors.places).on('click', options.selectors.placeCardDirectionsLink,
+                                       $.proxy(clickedDestinationDirections, this));
+
         $(options.selectors.homeLink).on('click', function (event) {
             event.preventDefault();
             event.stopPropagation();
@@ -246,19 +246,21 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
     }
 
     /**
-     * When user clicks a destination, look it up, then redirect to its details in 'explore' tab.
+     * When user clicks the Directions link on a destination, send them to the directions tab
+     * with that destination (whether or not there's an origin set)
      */
-    function clickedDestination(event) {
-        console.error('TODO: implement clickedDestination');
+    function clickedDestinationDirections(event) {
         event.preventDefault();
-        UserPreferences.setPreference('method', 'explore');
 
-        var block = $(event.target).closest(options.selectors.placeCard);
-        var placeId = block.data('destination-id');
+        var placeCard = $(event.target).closest(options.selectors.placeCard);
+        var placeId = placeCard.data('destination-id');
         UserPreferences.setPreference('placeId', placeId);
-
-        // TODO: Enable once explore view exists
-        // tabControl.setTab(tabControl.TABS.EXPLORE);
+        var destination = {
+            address: placeCard.find(options.selectors.placeCardName).text(),
+            location: { x: placeCard.data('destination-x'), y: placeCard.data('destination-y') }
+        };
+        directionsFormControl.setLocation('destination', destination);
+        tabControl.setTab(tabControl.TABS.DIRECTIONS);
     }
 
     function onTypeaheadSelected() {


### PR DESCRIPTION
Makes the "Directions" button on the "Places we love" cards take you to the directions view with the selected place as the destination.  If there's an origin set it will generate directions.  If not you'll get the map but no directions, just as you would see if you followed a one-sided directions link.

Resolves #545.