### PR TITLE
Use map page for shared directions

### DIFF
--- a/python/cac_tripplanner/cac_tripplanner/urls.py
+++ b/python/cac_tripplanner/cac_tripplanner/urls.py
@@ -19,11 +19,12 @@ urlpatterns = [
     url(r'^api/feedevents$', dest_views.FeedEvents.as_view(), name='api_feedevents'),
     url(r'^map/reachable$', dest_views.FindReachableDestinations.as_view(), name='reachable'),
 
-    url(r'^directions/', dest_views.directions, name='directions'),
+    # print directions view. TODO: update or delete
+    # url(r'^directions/', dest_views.directions, name='directions'),
 
     # Handle pre-redesign URLs by redirecting
-    url(r'^map/directions/', RedirectView.as_view(pattern_name='home', query_string=True,
-                                                  permanent=True)),
+    url(r'^(?:map/)?directions/', RedirectView.as_view(pattern_name='home', query_string=True,
+                                                       permanent=True)),
 
     # Places
     url(r'^place/(?P<pk>[\d-]+)/$', dest_views.place_detail, name='place-detail'),

--- a/src/app/scripts/cac/share/cac-share-modal.js
+++ b/src/app/scripts/cac/share/cac-share-modal.js
@@ -66,11 +66,11 @@ CAC.Share.ShareModal = (function ($, Settings, Modal) {
     }
 
     function getShortLink() {
-        // Share link to directions list page, which is relative to the current URL, has all of
+        // Share link to directions on map, which is relative to the current URL, has all of
         // the current URL's parameters and has an added parameter for the selected itinerary.
         var href = window.location.href;
         var itineraryId = $(options.selectors.itinerary).data('itineraryId');
-        var url = ['/directions/', href.slice(href.indexOf('?')), '&',
+        var url = ['/', href.slice(href.indexOf('?')), '&',
                    $.param({itineraryIndex: itineraryId}) ].join('');
         return shortenLink(url);
     }


### PR DESCRIPTION
When generating shortened permalink for directions, use map page instead of directions step-by-step page.
Closes #696.

To test, go to share modal from directions in sidebar and view generated shortened URL; should go to same map view.