### PR TITLE
Update places on origin/destination reversed

### DIFF
--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -50,6 +50,8 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
                                         onTypeaheadSelected);
         directionsFormControl.events.on(directionsFormControl.eventNames.cleared,
                                         onTypeaheadCleared);
+        directionsFormControl.events.on(directionsFormControl.eventNames.reversed,
+                                        reverseOriginDestination);
         directionsFormControl.events.on(directionsFormControl.eventNames.geocodeError,
                                         onGeocodeError);
 
@@ -252,6 +254,12 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
             }
             getNearbyPlaces();
         }
+    }
+
+    // The reverse button doesn't trigger typeahead-selected events, but for our purposes it's the
+    // same as selecting a new origin.
+    function reverseOriginDestination(event, newOrigin) {
+        onTypeaheadSelected(event, 'origin', newOrigin);
     }
 
     /**


### PR DESCRIPTION
A small bugfix: The Explore tab wasn't listening for the `reverse` event from the directions form, which wasn't having any effect on the isochrone because it loads origin from preferences when you switch to it, but the nearby places were going stale. This makes Explore listen for the `reverse` event and treat it like a typeahead-selected, which causes the nearby places to be updated.