### PR TITLE
Highlight marker when mouse is over place card

### DIFF
--- a/src/app/scripts/cac/map/cac-map-isochrone.js
+++ b/src/app/scripts/cac/map/cac-map-isochrone.js
@@ -27,7 +27,7 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
     var highlightIcon = L.AwesomeMarkers.icon({
         icon: 'default',
         prefix: 'icon',
-        markerColor: 'orange'
+        markerColor: 'blue',
     });
 
 
@@ -250,7 +250,7 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
             panTo: false
         };
         var options = $.extend({}, defaults, opts);
-        if (!destinationId) {
+        if (!destinationId || !destinationMarkers[destinationId]) {
             // revert to original marker if set
             if (lastHighlightedMarker) {
                 lastHighlightedMarker.setIcon(destinationIcon);

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -182,6 +182,12 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
             $.proxy(tabControl.setTab(tabControl.TABS.EXPLORE), this);
         });
 
+        $(options.selectors.places).on({
+            click: onPlaceClicked,
+            mouseenter: onPlaceHovered,
+            mouseleave: onPlaceBlurred
+        }, options.selectors.placeCard);
+
         $(options.selectors.places).on('click', options.selectors.placeCardDirectionsLink,
                                        $.proxy(clickedDestinationDirections, this));
 
@@ -242,28 +248,6 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
         if (tabId === tabControl.TABS.HOME) {
             UserPreferences.setPreference('method', undefined);
             clearUserSettings();
-        }
-    }
-
-    /**
-     * When user clicks the Directions link on a destination, send them to the directions tab
-     * with that destination (whether or not there's an origin set)
-     */
-    function clickedDestinationDirections(event) {
-        event.preventDefault();
-
-        var placeCard = $(event.target).closest(options.selectors.placeCard);
-        var placeId = placeCard.data('destination-id');
-        UserPreferences.setPreference('placeId', placeId);
-        var destination = {
-            address: placeCard.find(options.selectors.placeCardName).text(),
-            location: { x: placeCard.data('destination-x'), y: placeCard.data('destination-y') }
-        };
-        directionsFormControl.setLocation('destination', destination);
-        tabControl.setTab(tabControl.TABS.DIRECTIONS);
-        if (!UserPreferences.getPreference('origin')) {
-            directionsFormControl.setError('origin');
-            $(options.selectors.originInput).focus();
         }
     }
 
@@ -342,6 +326,42 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
         modeOptionsControl.setMode(UserPreferences.getPreference('mode'));
         // requery for place list once origin field cleared
         exploreControl.getNearbyPlaces();
+    }
+
+    function onPlaceClicked(event) {
+        var placeId = $(event.target).closest(options.selectors.placeCard).data('destination-id');
+        mapControl.isochroneControl.highlightDestination(placeId, { panTo: true });
+    }
+
+    function onPlaceHovered(event) {
+        var placeId = $(event.target).closest(options.selectors.placeCard).data('destination-id');
+        mapControl.isochroneControl.highlightDestination(placeId);
+    }
+
+    function onPlaceBlurred() {
+        mapControl.isochroneControl.highlightDestination(null);
+    }
+
+    /**
+     * When user clicks the Directions link on a destination, send them to the directions tab
+     * with that destination (whether or not there's an origin set)
+     */
+    function clickedDestinationDirections(event) {
+        event.preventDefault();
+
+        var placeCard = $(event.target).closest(options.selectors.placeCard);
+        var placeId = placeCard.data('destination-id');
+        UserPreferences.setPreference('placeId', placeId);
+        var destination = {
+            address: placeCard.find(options.selectors.placeCardName).text(),
+            location: { x: placeCard.data('destination-x'), y: placeCard.data('destination-y') }
+        };
+        directionsFormControl.setLocation('destination', destination);
+        tabControl.setTab(tabControl.TABS.DIRECTIONS);
+        if (!UserPreferences.getPreference('origin')) {
+            directionsFormControl.setError('origin');
+            $(options.selectors.originInput).focus();
+        }
     }
 
     /**


### PR DESCRIPTION
Restores pre-redesign functionality of highlighting the marker on the map corresponding to a featured location when you hover over the card for that location in the sidebar, and highlighting plus centering the map on a location if you click on its card.

Styling needed for what color the markers should change to and for what the cards themselves should do when hovered. Pre-redesign, they get ever-so-slightly lighter, due to [this style](https://github.com/azavea/cac-tripplanner/blob/develop/src/app/styles/components/_blocks.scss#L24).

@lederer: how would you like to do the styling?  You could add a commit to this branch, or describe what to do, or we could merge this as-is and you could get it in a separate styling PR, ...

![marker hover](https://cloud.githubusercontent.com/assets/6598836/21722307/05acc928-d3fa-11e6-9160-ff60b0226409.png)

Current production:
![hover marker old](https://cloud.githubusercontent.com/assets/6598836/21722317/0c84743a-d3fa-11e6-9c3d-0c324a089d8d.png)

With styling, resolves #728.