### PR TITLE
Feature/load destinations always

### DIFF
--- a/python/cac_tripplanner/destinations/views.py
+++ b/python/cac_tripplanner/destinations/views.py
@@ -17,13 +17,14 @@ from cms.models import Article
 DEFAULT_CONTEXT = {
     'debug': settings.DEBUG,
     'fb_app_id': settings.FB_APP_ID,
+    'isochrone_url': settings.ISOCHRONE_URL,
     'routing_url': settings.ROUTING_URL
 }
 
 
 def base_view(request, page, context):
     """
-    Base view that sets the OTP routing_url variable and Facebook app ID
+    Base view that sets some variables for JS settings
 
     :param request: Request object
     :param page: String representation of the HTML template

--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -117,6 +117,7 @@
 jQuery(document).ready(function ($) {
     CAC.Settings.fbAppId = '{{ fb_app_id }}';
     CAC.Settings.routingUrl = '{{ routing_url }}';
+    CAC.Settings.isochroneUrl = '{{ isochrone_url }}';
     var home = new CAC.Pages.Home();
     home.initialize();
 });

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -142,14 +142,18 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
      * The fetchIsochrone call is debounced to cut down on requests.
      */
     function clickedExplore() {
-        if (!exploreLatLng || !tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
+        if (!tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
             return;
         }
         showSpinner();
         $(options.selectors.alert).remove();
         mapControl.isochroneControl.clearIsochrone();
 
-        debouncedFetchIsochrone();
+        if (!exploreLatLng) {
+            getNearbyPlaces();
+        } else {
+            debouncedFetchIsochrone();
+        }
     }
 
     /**
@@ -183,8 +187,6 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
                 if (!destinations) {
                     setError('No destinations found.');
                 }
-                // TODO: reimplement interaction between isochrone and places sidebar, if needed
-                // setDestinationSidebar(destinations);
             }, function (error) {
                 console.error(error);
                 showPlacesContent();
@@ -304,7 +306,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
         // set explore time preference
         $(options.selectors.isochroneSlider).val(UserPreferences.getPreference('exploreMinutes'));
 
-        if (exploreLatLng && tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
+        if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
             clickedExplore();
         }
     }
@@ -349,6 +351,11 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
             // now places list has been updated, go fetch the travel time
             // from the new origin to each place
             getTimesToPlaces();
+
+            // also draw on explore map
+            if (tabControl.isTabShowing(tabControl.TABS.EXPLORE) && mapControl.isLoaded()) {
+                mapControl.isochroneControl.drawDestinations(data.destinations);
+            }
         }).fail(function(error) {
             console.error('error fetching destinations:');
             console.error(error);

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -34,6 +34,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
     var urlRouter = null;
     var directionsFormControl = null;
     var exploreLatLng = null;
+    var fetchingIsochrone = false;
 
     function ExploreControl(params) {
         options = $.extend({}, defaults, params);
@@ -57,6 +58,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
 
         if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
             setFromUserPreferences();
+            clickedExplore();
             $(options.selectors.isochroneSliderContainer).removeClass(options.selectors.hiddenClass);
         } else {
             $(options.selectors.isochroneSliderContainer).addClass(options.selectors.hiddenClass);
@@ -64,17 +66,20 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
 
         // update isochrone on slider move
         $(options.selectors.isochroneSlider).change(setOptions);
+        showPlacesContent();
     }
 
     var debouncedFetchIsochrone = _.debounce(fetchIsochrone, ISOCHRONE_DEBOUNCE_MILLIS);
 
-    var getNearbyPlaces = _.throttle(_getNearbyPlaces, ISOCHRONE_DEBOUNCE_MILLIS);
+    var getNearbyPlaces = _.debounce(_getNearbyPlaces, ISOCHRONE_DEBOUNCE_MILLIS);
 
     ExploreControl.prototype = {
+        clickedExplore: clickedExplore,
         setAddress: setAddress,
         setOptions: setOptions,
         setFromUserPreferences: setFromUserPreferences,
-        getNearbyPlaces: getNearbyPlaces
+        getNearbyPlaces: getNearbyPlaces,
+        showSpinner: showSpinner
     };
 
     return ExploreControl;
@@ -83,9 +88,11 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
     // isochrone and destination markers.
     function onTabShown(event, tabId) {
         if (tabId === tabControl.TABS.EXPLORE) {
+            showSpinner();
             UserPreferences.setPreference('method', 'explore');
             setFromUserPreferences();
             $(options.selectors.isochroneSliderContainer).removeClass(options.selectors.hiddenClass);
+            clickedExplore();
         } else {
             $(options.selectors.alert).remove();
             mapControl.isochroneControl.clearIsochrone();
@@ -98,14 +105,15 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
     function setOptions() {
         if (exploreLatLng) {
             clickedExplore();
-            getNearbyPlaces();
         }
     }
 
     // Helper to hide loading spinner and show places list
     function showPlacesContent() {
-        $(options.selectors.spinner).addClass('hidden');
-        $(options.selectors.placesContent).removeClass('hidden');
+        if (!fetchingIsochrone) {
+            $(options.selectors.spinner).addClass('hidden');
+            $(options.selectors.placesContent).removeClass('hidden');
+        }
     }
 
     // Helper to hide places list and show loading spinner in its place
@@ -149,11 +157,11 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
         $(options.selectors.alert).remove();
         mapControl.isochroneControl.clearIsochrone();
 
-        if (!exploreLatLng) {
-            getNearbyPlaces();
-        } else {
+        if (exploreLatLng) {
             debouncedFetchIsochrone();
         }
+
+        getNearbyPlaces();
     }
 
     /**
@@ -161,6 +169,12 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
      * then populate side bar with featured locations found within the travelshed.
      */
     function fetchIsochrone() {
+        showSpinner();
+
+        // do not hide spinner until isochrone fetch resolves
+        // (in case of destinations being fetched simultaneously)
+        fetchingIsochrone = true;
+
         // read slider
         var exploreMinutes = $(options.selectors.isochroneSlider).val();
 
@@ -182,13 +196,12 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
 
         mapControl.isochroneControl.fetchIsochrone(exploreLatLng, date, exploreMinutes, otpOptions,
                                                    true).then(
-            function (destinations) {
+            function () {
+                fetchingIsochrone = false;
                 showPlacesContent();
-                if (!destinations) {
-                    setError('No destinations found.');
-                }
             }, function (error) {
                 console.error(error);
+                fetchingIsochrone = false;
                 showPlacesContent();
                 setError('Could not find travelshed for given origin.');
             }
@@ -250,11 +263,11 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
     function onTypeaheadSelected(event, key, location) {
         if (key === 'origin') {
             setAddress(location);
-            // selectedPlaceId = null;
             if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
                 clickedExplore();
+            } else {
+                getNearbyPlaces();
             }
-            getNearbyPlaces();
         }
     }
 
@@ -295,19 +308,15 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
     }
 
     function setFromUserPreferences() {
+        // set explore time preference
+        $(options.selectors.isochroneSlider).val(UserPreferences.getPreference('exploreMinutes'));
+
         var exploreOrigin = UserPreferences.getPreference('origin');
 
         if (exploreOrigin) {
             setAddress(exploreOrigin);
         } else {
             exploreLatLng = null;
-        }
-
-        // set explore time preference
-        $(options.selectors.isochroneSlider).val(UserPreferences.getPreference('exploreMinutes'));
-
-        if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
-            clickedExplore();
         }
     }
 
@@ -346,16 +355,17 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
             var newPlaces = HomeTemplates.destinations(data.destinations);
             $(options.selectors.placesContent).html(newPlaces);
 
+            // also draw on explore map
+            if (tabControl.isTabShowing(tabControl.TABS.EXPLORE) && mapControl.isLoaded()) {
+                mapControl.isochroneControl.drawDestinations(data.destinations);
+            }
+
             showPlacesContent();
 
             // now places list has been updated, go fetch the travel time
             // from the new origin to each place
             getTimesToPlaces();
 
-            // also draw on explore map
-            if (tabControl.isTabShowing(tabControl.TABS.EXPLORE) && mapControl.isLoaded()) {
-                mapControl.isochroneControl.drawDestinations(data.destinations);
-            }
         }).fail(function(error) {
             console.error('error fetching destinations:');
             console.error(error);

--- a/src/app/scripts/cac/map/cac-map-isochrone.js
+++ b/src/app/scripts/cac/map/cac-map-isochrone.js
@@ -1,4 +1,4 @@
-CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
+CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _, Settings) {
     'use strict';
 
     var defaults = {
@@ -101,13 +101,12 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
     }
 
     /**
-     * Fetch all the reachable destinations within our destination database,
-     * and their enclosing isochrone (travelshed).
+     * Fetch an isochrone (travelshed).
      *
-     * @return {Object} Promise resolving to JSON with 'matched' and 'isochrone' properties
+     * @return {Object} Promise resolving to JSON with isochrone
      */
-    function fetchReachable(payload) {
-        var isochroneUrl = '/map/reachable';
+    function _fetchIsochrone(payload) {
+        var isochroneUrl = Settings.isochroneUrl;
         var deferred = $.Deferred();
         $.ajax({
             type: 'GET',
@@ -142,7 +141,7 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
 
         // Set the active isochrone request and make query
         activeIsochroneRequest = { deferred: deferred, params: params, zoomToFit: zoomToFit };
-        fetchReachable(params).then(function(data) {
+        _fetchIsochrone(params).then(function(data) {
             activeIsochroneRequest = null;
             if (pendingIsochroneRequest) {
                 // These results are already out of date. Don't display them, and instead
@@ -160,10 +159,8 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
                 deferred.resolve();
                 return;
             }
-            drawIsochrone(data.isochrone, zoomToFit);
-            // also draw 'matched' list of locations
-            drawDestinations(data.matched);
-            deferred.resolve(data.matched);
+            drawIsochrone(data, zoomToFit);
+            deferred.resolve();
         }, function(error) {
             activeIsochroneRequest = null;
             pendingIsochroneRequest = null;
@@ -178,7 +175,7 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
     function fetchIsochrone(coordsOrigin, when, exploreMinutes, otpParams, zoomToFit) {
         var deferred = $.Deferred();
         // clear results of last search
-        clearDiscoverPlaces();
+        clearIsochrone();
 
         var formattedTime = when.format('hh:mma');
         var formattedDate = when.format('YYYY/MM/DD');
@@ -186,7 +183,9 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
         var params = {
             time: formattedTime,
             date: formattedDate,
-            cutoffSec: exploreMinutes * 60 // API expects seconds
+            cutoffSec: exploreMinutes * 60, // API expects seconds
+            routerId: 'default',
+            algorithm: 'accSampling'
         };
 
         // Default precision of 200m; 100m seems good for improving response times on non-transit
@@ -266,14 +265,6 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
         lastHighlightedMarker = marker;
     }
 
-    /**
-     * Remove layers for isochrone and destinations within it.
-     */
-    function clearDiscoverPlaces() {
-        clearDestinations();
-        clearIsochrone();
-    }
-
     function clearDestinations() {
         if (destinationsLayer) {
             map.removeLayer(destinationsLayer);
@@ -286,4 +277,4 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
         }
     }
 
-})(jQuery, Handlebars, cartodb, L, turf, _);
+})(jQuery, Handlebars, cartodb, L, turf, _, CAC.Settings);

--- a/src/app/scripts/cac/map/cac-map-isochrone.js
+++ b/src/app/scripts/cac/map/cac-map-isochrone.js
@@ -228,7 +228,7 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
                                      '</div>',
                                      '<a href="{{geojson.properties.website_url}}" ',
                                      'target="_blank">{{geojson.properties.website_url}}</a>',
-                                     '<a class="destination-directions-link pull-right" ',
+                                     '<a class="destination-directions-link" ',
                                      'id="{{geojson.properties.id}}">Get Directions</a>'
                                     ].join('');
                 var template = Handlebars.compile(popupTemplate);

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -234,9 +234,10 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
                 directionsControl.setFromUserPreferences();
                 tabControl.setTab(tabControl.TABS.DIRECTIONS);
             } else if (method === 'explore') {
+                exploreControl.showSpinner();
                 exploreControl.setFromUserPreferences();
                 tabControl.setTab(tabControl.TABS.EXPLORE);
-                exploreControl.getNearbyPlaces();
+                exploreControl.clickedExplore();
             }
         } else {
             tabControl.setTab(tabControl.TABS.HOME);


### PR DESCRIPTION
Closes #714 and #713.

Always load destination markers on explore tab, even when no origin set (and no isochrone shown).

Also modifies isochrone call to fetch it directly from OTP, instead of the Django endpoint that filters for destinations within isochrone, as those destinations aren't used. (Django endpoint left in, should we have use for it later.)

@lederer: Destination map marker popups still need styling attention, at least to get the `Get Directions` link to pull right, as the bootstrap class for that is no longer going to work.