### PR TITLE
Set z-index for origin and destination markers

### DIFF
--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -278,7 +278,12 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
             if (directionsMarkers.origin) {
                 directionsMarkers.origin.setLatLng(origin);
             } else {
-                var originOptions = {icon: originIcon, draggable: true, title: 'origin' };
+                var originOptions = {
+                    icon: originIcon,
+                    draggable: true,
+                    title: 'origin',
+                    zIndexOffset: 1001
+                };
                 directionsMarkers.origin = new cartodb.L.marker(origin, originOptions)
                                                         .bindPopup('<p>Origin</p>');
                 directionsMarkers.origin.addTo(map);
@@ -294,7 +299,12 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
             if (directionsMarkers.destination) {
                 directionsMarkers.destination.setLatLng(destination);
             } else {
-                var destOptions = {icon: destIcon, draggable: true, title: 'destination' };
+                var destOptions = {
+                    icon: destIcon,
+                    draggable: true,
+                    title: 'destination',
+                    zIndexOffset: 1000
+                };
                 directionsMarkers.destination = new cartodb.L.marker(destination, destOptions)
                                                              .bindPopup('<p>Destination</p>');
                 directionsMarkers.destination.addTo(map);


### PR DESCRIPTION
Always display origin and destination on top of other markers. Fixes issue where origin marker not visible
in explore mode when origin is a featured destination.
Fixes #736.

In explore mode, setting origin to the name of a featured destination (available in autocomplete by name) should result in green origin marker visible on map, and not obscured by the orange destination marker for the selected place.