### PR TITLE
Feature/disable mobile explore

### DIFF
--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -42,7 +42,9 @@
                     tabindex="4" type="button" name="reverse"><i class="icon-reverse"></i></button>
             </div>
             <div class="isochrone-control directions-text-input hidden">
-                <label for="isochrone-slider">time</label>
+                <label for="isochrone-slider">within</label>
+                <output id="output-directions-within" name="output-directions-within"
+                    for="isochrone-slider" value="15"></output>
                 <input type="range" id="isochrone-slider" name="isochrone-slider" value="15"
                     tabindex="5" min="15" max="60" step="15">
             </div>

--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -33,7 +33,7 @@
                 <button class="btn-geolocate" title="Detect current location" type="button"
                     tabindex="3" name="geolocate"><i class="icon-geolocate"></i></button>
             </div>
-            <div class="directions-to directions-text-input">
+            <div class="directions-to directions-tab-button directions-text-input">
                 <label for="input-directions-to">to</label>
                 <input type="search" id="input-directions-to" name="input-directions-to" value=""
                     placeholder="Enter a destination — or choose one below"
@@ -41,7 +41,7 @@
                 <button class="btn-reverse" title="Swap starting point and destination"
                     tabindex="4" type="button" name="reverse"><i class="icon-reverse"></i></button>
             </div>
-            <div class="isochrone-control directions-text-input hidden">
+            <div class="isochrone-control directions-tab-button directions-text-input hidden">
                 <label for="isochrone-slider">within</label>
                 <output id="output-directions-within" name="output-directions-within"
                     for="isochrone-slider" value="15"></output>

--- a/python/cac_tripplanner/templates/partials/header.html
+++ b/python/cac_tripplanner/templates/partials/header.html
@@ -10,7 +10,8 @@
     </div>
     <nav class="primary-nav tab-control">
         <a class="nav-item {% if not tab or tab == 'home'%} on {% endif %}" href="/" data-tab-id="HOME">Home</a>
-        <a class="nav-item {% if tab == 'explore'%} on {% endif %}" data-tab-id="EXPLORE">Explore</a>
+        <a id="explore-header-link" class="nav-item {% if tab == 'explore'%} on {% endif %}"
+            data-tab-id="EXPLORE">Explore</a>
         <a class="nav-item {% if tab == 'info'%} on {% endif %}" href="{% url 'learn-list' %}">Learn</a>
     </nav>
 </header>

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -68,9 +68,6 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
         // update isochrone on slider move
         $(options.selectors.isochroneSlider).change(setOptions);
 
-        // initialize slider text value
-        $(options.selectors.isochroneOutput).val($(options.selectors.isochroneSlider).val());
-
         showPlacesContent();
     }
 
@@ -316,7 +313,10 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
 
     function setFromUserPreferences() {
         // set explore time preference
-        $(options.selectors.isochroneSlider).val(UserPreferences.getPreference('exploreMinutes'));
+        var exploreMinutes = UserPreferences.getPreference('exploreMinutes');
+        $(options.selectors.isochroneSlider).val(exploreMinutes);
+        $(options.selectors.isochroneOutput).val(exploreMinutes);
+
 
         var exploreOrigin = UserPreferences.getPreference('origin');
 

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -17,6 +17,7 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
             hiddenClass: 'hidden',
             isochroneSliderContainer: '.isochrone-control',
             isochroneSlider: '#isochrone-slider',
+            isochroneOutput: '#output-directions-within',
             placesContent: '.places-content',
             spinner: '.places > .sk-spinner',
             placeCard: 'li.place-card',
@@ -103,6 +104,8 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
 
     // trigger re-query when trip options are changed
     function setOptions() {
+        // set text output to match slider
+        $(options.selectors.isochroneOutput).val($(options.selectors.isochroneSlider).val());
         if (exploreLatLng) {
             clickedExplore();
         }

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -67,6 +67,10 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
 
         // update isochrone on slider move
         $(options.selectors.isochroneSlider).change(setOptions);
+
+        // initialize slider text value
+        $(options.selectors.isochroneOutput).val($(options.selectors.isochroneSlider).val());
+
         showPlacesContent();
     }
 

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -156,9 +156,11 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
         });
 
         // toggle from home or directions to explore, or explore to directions, using 'to' label
-        $(options.selectors.tabToToggleLink).on('click', function (event) {
-            event.preventDefault();
-            event.stopPropagation();
+        $(options.selectors.tabToToggleLink).on('click', function () {
+
+            if (!$(options.selectors.map).is(':visible')) {
+                return; // only allow explore mode on desktop
+            }
 
             if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
                 tabControl.setTab(tabControl.TABS.DIRECTIONS);

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -19,6 +19,7 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
             homeLink: '.home-link',
             tabControl: '.tab-control',
             tabControlLink: '.nav-item',
+            tabToToggleLink: '.directions-tab-button label',
 
             mapViewButton: 'a.map-view-btn',
 
@@ -151,6 +152,18 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
                 event.stopPropagation();
 
                 tabControl.setTab(tabId);
+            }
+        });
+
+        // toggle from home or directions to explore, or explore to directions, using 'to' label
+        $(options.selectors.tabToToggleLink).on('click', function (event) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
+                tabControl.setTab(tabControl.TABS.DIRECTIONS);
+            } else {
+                tabControl.setTab(tabControl.TABS.EXPLORE);
             }
         });
 

--- a/src/app/styles/components/_app-header.scss
+++ b/src/app/styles/components/_app-header.scss
@@ -129,6 +129,12 @@
         display: none;
     }
 
+    #explore-header-link {
+        @include respond-to('xs') {
+            display: none;
+        }
+    }
+
     .nav-item {
         @include delinkify;
         margin-right: 25px;

--- a/src/app/styles/components/_directions-form.scss
+++ b/src/app/styles/components/_directions-form.scss
@@ -419,17 +419,13 @@
      #isochrone-slider {
         @include inputrange();
         margin-right: 1rem;
-        width: 70%;
+        width: 80%;
     }
 
-    &.directions-destination-mode-within {
-
-        .directions-destination.isochrone-control {
-            display: flex;
-        }
-
-        .directions-destination.directions-text-input {
-            display: none;
+    .directions-tab-button.isochrone-control {
+            &:after {
+                background: $gophillygo-blue;
+            }
         }
 
         .directions-to label {
@@ -451,9 +447,8 @@
                 content: ' min';
             }
         }
-    }
 
-    @include respond-to('sm-up') {
+    @include respond-to('md-up') {
         .directions-tab-button label {
             position: relative;
             background-color: $gophillygo-blue-dark;

--- a/src/app/styles/components/_directions-form.scss
+++ b/src/app/styles/components/_directions-form.scss
@@ -53,12 +53,6 @@
         }
     }
 
-    #isochrone-slider {
-        @include inputrange();
-        margin-right: 1rem;
-        width: 75%;
-    }
-
     .isochrone-control {
         display: flex;
 
@@ -411,4 +405,69 @@
         }
 
     }
+
+    .directions-to {
+         &.isochrone-control {
+             display: none;
+         }
+
+         &.directions-text-input {
+             display: flex;
+         }
+     }
+
+     #isochrone-slider {
+        @include inputrange();
+        margin-right: 1rem;
+        width: 70%;
+    }
+
+    @include respond-to('xxs-up') {
+        .directions-to label {
+            position: relative;
+            background-color: $gophillygo-blue-dark;
+            cursor: pointer;
+
+            // Caret if we go with menu instead of toggle
+            // &:after {
+            //     position: absolute;
+            //     right: 5px;
+            //     color: inherit;
+            //     font-size: 1.1rem;
+            //     content: '▾';
+            // }
+        }
+
+        &.directions-destination-mode-within {
+
+            .directions-destination.isochrone-control {
+                display: flex;
+            }
+
+            .directions-destination.directions-text-input {
+                display: none;
+            }
+
+            .directions-to label {
+                padding-right: 1em;
+                margin-right: .2em;
+            }
+
+            #output-directions-within {
+                position: relative;
+                width: 6rem;
+                margin-right: 1rem;
+                color: $white;
+                font-size: 1.4rem;
+                font-weight: $font-weight-medium;
+                line-height: 30px;
+                text-align: right;
+
+                &:after {
+                    content: ' min';
+                }
+            }
+        }
+    }
 }
+

--- a/src/app/styles/components/_directions-form.scss
+++ b/src/app/styles/components/_directions-form.scss
@@ -422,51 +422,42 @@
         width: 70%;
     }
 
-    @include respond-to('xxs-up') {
+    &.directions-destination-mode-within {
+
+        .directions-destination.isochrone-control {
+            display: flex;
+        }
+
+        .directions-destination.directions-text-input {
+            display: none;
+        }
+
         .directions-to label {
+            padding-right: 1em;
+            margin-right: .2em;
+        }
+
+        #output-directions-within {
+            position: relative;
+            width: 6rem;
+            margin-right: 1rem;
+            color: $white;
+            font-size: 1.4rem;
+            font-weight: $font-weight-medium;
+            line-height: 30px;
+            text-align: right;
+
+            &:after {
+                content: ' min';
+            }
+        }
+    }
+
+    @include respond-to('sm-up') {
+        .directions-tab-button label {
             position: relative;
             background-color: $gophillygo-blue-dark;
             cursor: pointer;
-
-            // Caret if we go with menu instead of toggle
-            // &:after {
-            //     position: absolute;
-            //     right: 5px;
-            //     color: inherit;
-            //     font-size: 1.1rem;
-            //     content: '▾';
-            // }
-        }
-
-        &.directions-destination-mode-within {
-
-            .directions-destination.isochrone-control {
-                display: flex;
-            }
-
-            .directions-destination.directions-text-input {
-                display: none;
-            }
-
-            .directions-to label {
-                padding-right: 1em;
-                margin-right: .2em;
-            }
-
-            #output-directions-within {
-                position: relative;
-                width: 6rem;
-                margin-right: 1rem;
-                color: $white;
-                font-size: 1.4rem;
-                font-weight: $font-weight-medium;
-                line-height: 30px;
-                text-align: right;
-
-                &:after {
-                    content: ' min';
-                }
-            }
         }
     }
 }

--- a/src/app/styles/utils/_breakpoints.scss
+++ b/src/app/styles/utils/_breakpoints.scss
@@ -1,6 +1,5 @@
 $breakpoints: (
     'xxs': (max-width: 480px),
-    'xxs-up': (min-width: 481px),
 
     'xs': (max-width: 767px),
 

--- a/src/app/styles/utils/_breakpoints.scss
+++ b/src/app/styles/utils/_breakpoints.scss
@@ -1,5 +1,6 @@
 $breakpoints: (
     'xxs': (max-width: 480px),
+    'xxs-up': (min-width: 481px),
 
     'xs': (max-width: 767px),
 


### PR DESCRIPTION
Hide explore tab header button on mobile, effectively disabling explore mode for mobile devices.

Implement toggling modes with label for `to` field.

Closes #742. Also adds text label with the number of minutes for the explore mode slider, as was in #641.

See #641 for source for most of the styling. Also got some input from @lederer on behavior (decided to hide explore tab link on mobile).