### PR TITLE
Hide options bar when no options are overridden

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions-list.js
+++ b/src/app/scripts/cac/control/cac-control-directions-list.js
@@ -28,7 +28,8 @@ CAC.Control.DirectionsList = (function (_, $, ShareModal, MapTemplates) {
             googlePlusShareButton: '.modal-list-google',
             shareModalButton: '.share-directions',
             stepByStepClass: 'body-step-by-step',
-            sidebarBannerClass: 'body-has-sidebar-banner'
+            sidebarBannerClass: 'body-has-sidebar-banner',
+            activeSidebarBanner: '.sidebar-banner:not(.hidden)'
         }
     };
     var options = {};
@@ -55,7 +56,6 @@ CAC.Control.DirectionsList = (function (_, $, ShareModal, MapTemplates) {
         setItinerary: setItinerary,
         show: show,
         hide: hide,
-        toggle: toggle
     };
 
     return DirectionsListControl;
@@ -142,14 +142,11 @@ CAC.Control.DirectionsList = (function (_, $, ShareModal, MapTemplates) {
 
     function hide() {
         $(options.selectors.mapContainer).removeClass(options.selectors.stepByStepClass);
-        $(options.selectors.mapContainer).addClass(options.selectors.sidebarBannerClass);
-    }
-
-    function toggle() {
-        if ($(options.selectors.mapContainer).hasClass(options.selectors.sidebarBannerClass)) {
-            show();
-        } else {
-            hide();
+        // The spacing of the sidebar depends on the body div having a class indicating the
+        // presence of a banner in the sidebar. Most of the pieces are a few layers up in Home,
+        // so this uses a selector to figure out if there is an active sidebar and set the class.
+        if ($(options.selectors.mapContainer).find(options.selectors.activeSidebarBanner).length > 0) {
+            $(options.selectors.mapContainer).addClass(options.selectors.sidebarBannerClass);
         }
     }
 

--- a/src/app/scripts/cac/control/cac-control-tab.js
+++ b/src/app/scripts/cac/control/cac-control-tab.js
@@ -20,8 +20,8 @@ CAC.Control.Tab = (function ($) {
     var defaults = {
         classes: {
             HOME: 'body-home',
-            DIRECTIONS: 'body-map body-map-directions body-has-sidebar-banner',
-            EXPLORE: 'body-map body-map-explore body-has-sidebar-banner',
+            DIRECTIONS: 'body-map body-map-directions',
+            EXPLORE: 'body-map body-map-explore',
             LEARN: 'body-learn'
         },
         selectors: {

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -133,7 +133,7 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
         // listen to sidebar banner close button
         $(options.selectors.sidebarBannerCloseButton).on('click', function(e) {
             e.stopPropagation();
-            $(options.selectors.needWheelsBanner).addClass(options.selectors.hiddenClass);
+            hideNeedWheelsBanner();
         });
 
         // listen to sidebar banner click
@@ -144,7 +144,7 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
             }).open();
 
             // dismiss 'need wheels?' banner
-            $(options.selectors.needWheelsBanner).addClass(options.selectors.hiddenClass);
+            hideNeedWheelsBanner();
         });
 
         $(options.selectors.tabControl).on('click', options.selectors.tabControlLink, function (event) {
@@ -452,7 +452,7 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
 
     /**
      * The 'need wheels?' sidebar banner should only display when trip options have
-     * never been seen and currently in bicycle mode. Check on initial load and mdoe toggle.
+     * never been seen and currently in bicycle mode. Check on initial load and mode toggle.
      */
     function showHideNeedWheelsBanner() {
         if (UserPreferences.showNeedWheelsPrompt()) {
@@ -461,10 +461,14 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
             $(options.selectors.sidebarTripOptionsBanner).addClass(options.selectors.hiddenClass);
             $(options.selectors.mapContainer).addClass(options.selectors.sidebarBannerClass);
         } else {
-            $(options.selectors.needWheelsBanner).addClass(options.selectors.hiddenClass);
-            // show trip options instead
-            updateTripOptionsBanner();
+            hideNeedWheelsBanner();
         }
+    }
+
+    function hideNeedWheelsBanner() {
+        $(options.selectors.needWheelsBanner).addClass(options.selectors.hiddenClass);
+        // show trip options instead, if applicable
+        updateTripOptionsBanner();
     }
 
     /**

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -23,10 +23,12 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
 
             mapViewButton: 'a.map-view-btn',
 
-            needWheelsBanner: '.sidebar-banner.indego-banner',
+            mapContainer: '.body-map',
             sidebarBanner: '.sidebar-banner',
             sidebarBannerCloseButton: 'button.btn-dismiss-sidebar-banner',
+            needWheelsBanner: '.sidebar-banner.indego-banner',
             sidebarTripOptionsBanner: '.sidebar-banner.trip-options-banner',
+            sidebarBannerClass: 'body-has-sidebar-banner',
             hiddenClass: 'hidden',
 
             originInput: '#input-directions-from'
@@ -393,6 +395,8 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
             '</div>'
         ].join('');
 
+        var isDefault = true;
+
         var mode = UserPreferences.getPreference('mode');
         var bikeMode = mode.indexOf('BICYCLE') >= 0;
         var indego = bikeMode && mode.indexOf('BICYCLE_RENT') >= 0;
@@ -406,11 +410,14 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
             } else {
                 modeText = 'Bike';
             }
+            isDefault = UserPreferences.isDefault('bikeShare') && isDefault;
 
             var rideType = UserPreferences.getPreference('bikeTriangle');
+            isDefault = UserPreferences.isDefault('bikeTriangle') && isDefault;
             rideTypeOrAccessibility = rideType.charAt(0).toUpperCase() + rideType.slice(1) + ' ride';
         } else {
             var wheelchair = UserPreferences.getPreference('wheelchair');
+            isDefault = UserPreferences.isDefault('wheelchair') && isDefault;
             if (wheelchair) {
                 rideTypeOrAccessibility = 'Wheelchair';
             }
@@ -421,6 +428,15 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
         }
 
         var timingText = TripOptions.prototype.getTimingText() || 'Depart now';
+        isDefault = TripOptions.prototype.getTimingText() === null && isDefault;
+
+        var $banner = $(options.selectors.sidebarTripOptionsBanner);
+
+        if (isDefault) {
+            $banner.addClass(options.selectors.hiddenClass);
+            $(options.selectors.mapContainer).removeClass(options.selectors.sidebarBannerClass);
+            return;
+        }
 
         var template = Handlebars.compile(source);
         var html = template({
@@ -429,8 +445,8 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
             timingText: timingText
         });
 
-        var $banner = $(options.selectors.sidebarTripOptionsBanner);
         $banner.html(html);
+        $(options.selectors.mapContainer).addClass(options.selectors.sidebarBannerClass);
         $banner.removeClass(options.selectors.hiddenClass);
     }
 
@@ -443,6 +459,7 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
             $(options.selectors.needWheelsBanner).removeClass(options.selectors.hiddenClass);
             // hide trip options banner
             $(options.selectors.sidebarTripOptionsBanner).addClass(options.selectors.hiddenClass);
+            $(options.selectors.mapContainer).addClass(options.selectors.sidebarBannerClass);
         } else {
             $(options.selectors.needWheelsBanner).addClass(options.selectors.hiddenClass);
             // show trip options instead

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -107,7 +107,7 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
         // set bike share preference separate from mode
         if (params.mode) {
             var bikeShare = params.mode.indexOf('_RENT') >= 0;
-            UserPreferences.setPreference('bikeShare', bikeShare);
+            UserPreferences.setPreference('bikeShare', bikeShare, true);
         }
         events.trigger(eventNames.changed);
     }
@@ -138,10 +138,10 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
                 if (field === 'origin' || field === 'destination') {
                     var coords = _.map(params[field].split(','), parseFloat);
                     if (isNaN(coords[0])) {
-                        UserPreferences.setPreference(field, undefined);
+                        UserPreferences.setPreference(field, undefined, true);
                     } else {
                         var location = makeLocation(coords, params[field + 'Text']);
-                        UserPreferences.setPreference(field, location);
+                        UserPreferences.setPreference(field, location, true);
                     }
                 } else if (field === 'waypoints') {
                     var waypoints = _.map(params[field].split(';'), function(waypoint) {
@@ -150,15 +150,15 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
                             return coords;
                         }
                     });
-                    UserPreferences.setPreference(field, waypoints);
+                    UserPreferences.setPreference(field, waypoints, true);
                 } else if (field === 'dateTime') {
                     if (!params[field]) {
-                        UserPreferences.setPreference(field, undefined);
+                        UserPreferences.setPreference(field, undefined, true);
                     } else {
-                        UserPreferences.setPreference(field, parseInt(params[field]));
+                        UserPreferences.setPreference(field, parseInt(params[field]), true);
                     }
                 } else {
-                    UserPreferences.setPreference(field, params[field]);
+                    UserPreferences.setPreference(field, params[field], true);
                 }
             }
         });

--- a/src/app/scripts/cac/user/cac-user-preferences.js
+++ b/src/app/scripts/cac/user/cac-user-preferences.js
@@ -87,7 +87,11 @@ CAC.User.Preferences = (function(Storages, _) {
      * @param {String} preference Name of setting to store
      * @param {Object} val Setting value to store
      */
-    function setPreference(preference, val) {
+    function setPreference(preference, val, ignoreDefault) {
+        if (ignoreDefault && _.has(defaults, preference) && defaults[preference] === val) {
+            delete options[preference];
+            return;
+        }
         storage.set(preference, JSON.stringify(val));
     }
 


### PR DESCRIPTION
Makes the options bar stop showing up when none of the options have been changed.

Since the definition of "changed" includes "set by the user to a default value", any page loaded from URL was showing up as non-default, since all the options get written into the URL then saved to UserPreferences on load.  I dealt with that by adding an option to `UserPreferences.setPreference` to ignore default values (i.e. only save a preference if it differs from the default value) and made the URL routing controller use that option in its calls.

There was also an issue whereby the directions list was always setting the `body-has-sidebar-banner` on close, which messed up the sidebar height if there was not in fact a sidebar banner active.  I dealt with that by having it check the DOM for non-hidden sidebar banners.  Connecting it directly to the code that controls the banners, which is in CAC.Pages.Home, would in principle be better but is tricky since they're a few layers apart in the controller hierarchy.

Defaults:
![image](https://cloud.githubusercontent.com/assets/6598836/22265622/cbfaeb92-e24a-11e6-892a-7bbc2934e2e2.png) 

Not default:
![image](https://cloud.githubusercontent.com/assets/6598836/22265651/ecd9740a-e24a-11e6-962f-ca7d802f8c81.png)


Resolves #748.