### PR TITLE
Enable direct linking to Explore tab

### DIFF
--- a/python/cac_tripplanner/cac_tripplanner/urls.py
+++ b/python/cac_tripplanner/cac_tripplanner/urls.py
@@ -12,6 +12,7 @@ import settings
 urlpatterns = [
     # Home view, which is also the directions and explore views
     url(r'^$', dest_views.home, name='home'),
+    url(r'^explore$', dest_views.explore, name='explore'),
 
     # Map
     url(r'^api/destinations/search$', dest_views.SearchDestinations.as_view(),

--- a/python/cac_tripplanner/destinations/views.py
+++ b/python/cac_tripplanner/destinations/views.py
@@ -55,6 +55,15 @@ def home(request):
 
     return base_view(request, 'home.html', context=context)
 
+def explore(request):
+    """
+    Enables loading the explore view via URL.
+    Explore is still a javascript-defined sub-view of Home, but this enables us to send the message
+    to the javascript that it should start on that view even though there's no origin.
+    """
+    context = {'tab': 'map-explore'}
+    return base_view(request, 'home.html', context=context)
+
 
 def directions(request):
     """

--- a/python/cac_tripplanner/templates/partials/header.html
+++ b/python/cac_tripplanner/templates/partials/header.html
@@ -11,7 +11,7 @@
     <nav class="primary-nav tab-control">
         <a class="nav-item {% if not tab or tab == 'home'%} on {% endif %}" href="/" data-tab-id="HOME">Home</a>
         <a id="explore-header-link" class="nav-item {% if tab == 'explore'%} on {% endif %}"
-            data-tab-id="EXPLORE">Explore</a>
+            data-tab-id="EXPLORE" href="/explore">Explore</a>
         <a class="nav-item {% if tab == 'info'%} on {% endif %}" href="{% url 'learn-list' %}">Learn</a>
     </nav>
 </header>

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -35,6 +35,7 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
 
     function UrlRouter() {
         router = new Navigo('/');
+        router.on('explore', loadExplore);
         router.on('*', setPrefsFromUrl, {
             before: function (done) {
                 if (updatingUrl) {
@@ -82,6 +83,19 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
 
     function buildExploreUrlFromPrefs() {
         return '/?' + buildUrlParamsFromPrefs(EXPLORE_ENCODE);
+    }
+
+    /* Enables direct linking to the blank Explore view (i.e. from the Learn tab)
+     *
+     * Sets the 'mode' preference, which causes the javascript to initialize with the Explore view
+     * active, but clears the URL because the URL-manipulation done by Directions and Explore
+     * assume/require that they be at /
+     */
+    function loadExplore() {
+        UserPreferences.setPreference('method', 'explore');
+        router.pause();
+        router.navigate('/', true);
+        router.resume();
     }
 
     /* Read URL parameters into user preferences


### PR DESCRIPTION
Adds a route to both the back-end and the front-end's URL router to
enable directly linking to the Explore tab. Since the Learn tab is an
independent view, it needs the tab headers to be actual href links.
This enables a `/explore` URL which
- on the back-end, sets the tab context to 'map-explore'
- on the front-end, gets intercepted by the URL router which sets the
'mode' preference to 'explore' then clears the URL (to avoid confusing
later URL manipulation)

Resolves #758.