### PR TITLE
Remove dynamic link from static details page

### DIFF
--- a/python/cac_tripplanner/templates/partials/destination-detail.html
+++ b/python/cac_tripplanner/templates/partials/destination-detail.html
@@ -9,10 +9,5 @@
         <p class="info-article-p-link-inline">
             <a href="{{ destination.website_url }}" target="_blank">Visit website</a>
         </p>
-        <div class="info-article-p-actions">
-            <a class="place-action-go"
-                data-destination-id="{{ destination.id }}"
-                href="#">Get directions</a>
-        </div>
     </section>
 </article>


### PR DESCRIPTION
See #768.

Remove dynamic "get directions" link added in #760 from static place detail page, as the necessary JS is not present to either reference an origin (any origin set on the home page is lost on navigation to place details) or to reference the directions controller.

Postpone #768 to another phase.