### PR TITLE
Feature/sml/swipe-itineraries

### DIFF
--- a/src/app/scripts/cac/control/cac-control-itinerary-list.js
+++ b/src/app/scripts/cac/control/cac-control-itinerary-list.js
@@ -17,7 +17,23 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates) {
             alert: '.alert',
             container: '.directions-list',
             hiddenClass: 'hidden',
+            itineraryList: '.routes-list',
             itineraryItem: '.route-summary'
+        },
+        // Settings for 'slick' carousel for swiping itineraries on mobile
+        slick: {
+            arrows: false,
+            dots: true,
+            infinite: false,
+            mobileFirst: true,
+            variableWidth: true,
+            responsive : [
+                {
+                    // Breakpoint must match 'xxs' in _breakpoints.scss
+                    breakpoint: 480,
+                    settings: 'unslick'
+                }
+            ]
         }
     };
     var options = {};
@@ -59,6 +75,9 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates) {
         // Show the directions div and populate with itineraries
         var html = MapTemplates.itineraryList(itineraries);
         $container.html(html);
+
+        enableCarousel(itineraries);
+
         $(options.selectors.itineraryItem).on('click', onItineraryClicked);
         $(options.selectors.itineraryItem).hover(onItineraryHover);
     }
@@ -75,6 +94,22 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates) {
         $container.one('click', options.selectors.alert, function() {
             $(options.selectors.alert).remove();
         });
+    }
+
+    /**
+     * Enable 'slick' carousel for swiping itineraries on mobile
+     * @param {[object]} itineraries An open trip planner itinerary object, as returned from the plan endpoint
+     */
+    function enableCarousel(itineraries) {
+        if (itineraries.length < 2) {
+            return;
+        }
+
+        $(options.selectors.itineraryList)
+            .slick(options.slick)
+            .on('afterChange', function(event, slick, currentSlide) {
+                $(options.selectors.itineraryItem).eq(currentSlide).triggerHandler('mouseenter');
+            });
     }
 
     function getItineraryById(id) {

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -214,7 +214,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
     // Template for itinerary summaries
     function itineraryList(itineraries) {
         var source = [
-        '<h1>Choose a route</h1><div class="routes-list"></div>',
+        '<h1>Choose a route</h1><div class="routes-list">',
         '{{#each itineraries}}',
             '<div class="route-summary" data-itinerary="{{this.id}}">',
             '<div class="route-summary-details">',
@@ -232,7 +232,8 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                     '</div>',
                 '</div>',
             '</div>',
-        '</div>{{/each}}'].join('');
+        '</div>{{/each}}',
+        '</div>'].join('');
 
         var template = Handlebars.compile(source);
         var html = template({itineraries: itineraries});

--- a/src/app/styles/components/_directions-form.scss
+++ b/src/app/styles/components/_directions-form.scss
@@ -408,7 +408,6 @@
                 display: block;
             }
         }
-
     }
 
     .directions-to {

--- a/src/app/styles/components/_directions-form.scss
+++ b/src/app/styles/components/_directions-form.scss
@@ -184,9 +184,9 @@
     .btn-options {
         display: flex;
         align-items: center;
+        align-self: stretch;
         justify-content: center;
         width: 50px;
-        height: 100%;
         margin-top: -5px;
         margin-left: 24px;
         padding-top: 3px;
@@ -194,7 +194,7 @@
         cursor: pointer;
 
         i.icon-sliders {
-            font-size: 1.8rem;
+            font-size: 2rem;
         }
 
         @include respond-to('xxs') {

--- a/src/app/styles/components/_directions-results.scss
+++ b/src/app/styles/components/_directions-results.scss
@@ -17,7 +17,8 @@
         width: 100%;
         height: $route-summary-height;
         overflow: hidden;
-        z-index: 100;
+        z-index: 1000;
+        box-shadow: 0 0 16px rgba(128, 128, 128, 0.7);
     }
 
     h1 {
@@ -37,6 +38,7 @@
         flex-flow: row nowrap;
         align-items: stretch;
         justify-content: flex-start;
+        width: 100vw;
         height: $route-summary-height;
         margin-bottom: 20px;
         padding: 6px 10px 4px 16px;

--- a/src/app/styles/components/_slick-dots.scss
+++ b/src/app/styles/components/_slick-dots.scss
@@ -1,0 +1,18 @@
+.slick-dots {
+    bottom: 0;
+    
+    li {
+        width: 18px;
+        height: 18px;
+        margin: 0;
+    }
+
+    li button {
+        width: 18px;
+        height: 18px;
+    }
+
+    li button:before {
+        font-size: 20px;
+    }
+}

--- a/src/app/styles/main.scss
+++ b/src/app/styles/main.scss
@@ -1,6 +1,7 @@
 // Vendors
 @import
-'vendors/inputrange';
+'vendors/inputrange',
+'vendors/slick-theme';
 
 // Utils
 @import
@@ -34,7 +35,8 @@
 'components/directions-step-by-step',
 'components/sidebar-banner',
 'components/modal',
-'components/spinner';
+'components/spinner',
+'components/slick-dots';
 
 
 // Layouts

--- a/src/app/styles/utils/_breakpoints.scss
+++ b/src/app/styles/utils/_breakpoints.scss
@@ -1,4 +1,5 @@
 $breakpoints: (
+    // 'xxs' must match defaults.slick.responsive.breakpoint in cac-control-itinerary-list.js
     'xxs': (max-width: 480px),
 
     'xs': (max-width: 767px),

--- a/src/app/styles/vendors/_slick-theme.scss
+++ b/src/app/styles/vendors/_slick-theme.scss
@@ -1,0 +1,194 @@
+@charset "UTF-8";
+
+// Default Variables
+
+// Slick icon entity codes outputs the following
+// "\2190" outputs ascii character "←"
+// "\2192" outputs ascii character "→"
+// "\2022" outputs ascii character "•"
+
+$slick-font-path: "./fonts/" !default;
+$slick-font-family: "slick" !default;
+$slick-loader-path: "./" !default;
+$slick-arrow-color: white !default;
+$slick-dot-color: black !default;
+$slick-dot-color-active: $slick-dot-color !default;
+$slick-prev-character: "\2190" !default;
+$slick-next-character: "\2192" !default;
+$slick-dot-character: "\2022" !default;
+$slick-dot-size: 6px !default;
+$slick-opacity-default: 0.75 !default;
+$slick-opacity-on-hover: 1 !default;
+$slick-opacity-not-active: 0.25 !default;
+
+@function slick-image-url($url) {
+    @if function-exists(image-url) {
+        @return image-url($url);
+    }
+    @else {
+        @return url($slick-loader-path + $url);
+    }
+}
+
+@function slick-font-url($url) {
+    @if function-exists(font-url) {
+        @return font-url($url);
+    }
+    @else {
+        @return url($slick-font-path + $url);
+    }
+}
+
+/* Slider */
+
+// .slick-list {
+//     .slick-loading & {
+//         background: #fff slick-image-url("ajax-loader.gif") center center no-repeat;
+//     }
+// }
+//
+/* Icons */
+// @if $slick-font-family == "slick" {
+//     @font-face {
+//         font-family: "slick";
+//         src: slick-font-url("slick.eot");
+//         src: slick-font-url("slick.eot?#iefix") format("embedded-opentype"), slick-font-url("slick.woff") format("woff"), slick-font-url("slick.ttf") format("truetype"), slick-font-url("slick.svg#slick") format("svg");
+//         font-weight: normal;
+//         font-style: normal;
+//     }
+// }
+
+/* Arrows */
+
+.slick-prev,
+.slick-next {
+    position: absolute;
+    display: block;
+    height: 20px;
+    width: 20px;
+    line-height: 0px;
+    font-size: 0px;
+    cursor: pointer;
+    background: transparent;
+    color: transparent;
+    top: 50%;
+    -webkit-transform: translate(0, -50%);
+    -ms-transform: translate(0, -50%);
+    transform: translate(0, -50%);
+    padding: 0;
+    border: none;
+    outline: none;
+    &:hover, &:focus {
+        outline: none;
+        background: transparent;
+        color: transparent;
+        &:before {
+            opacity: $slick-opacity-on-hover;
+        }
+    }
+    &.slick-disabled:before {
+        opacity: $slick-opacity-not-active;
+    }
+    &:before {
+        font-family: $slick-font-family;
+        font-size: 20px;
+        line-height: 1;
+        color: $slick-arrow-color;
+        opacity: $slick-opacity-default;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+    }
+}
+
+.slick-prev {
+    left: -25px;
+    [dir="rtl"] & {
+        left: auto;
+        right: -25px;
+    }
+    &:before {
+        content: $slick-prev-character;
+        [dir="rtl"] & {
+            content: $slick-next-character;
+        }
+    }
+}
+
+.slick-next {
+    right: -25px;
+    [dir="rtl"] & {
+        left: -25px;
+        right: auto;
+    }
+    &:before {
+        content: $slick-next-character;
+        [dir="rtl"] & {
+            content: $slick-prev-character;
+        }
+    }
+}
+
+/* Dots */
+
+.slick-dotted.slick-slider {
+    margin-bottom: 30px;
+}
+
+.slick-dots {
+    position: absolute;
+    bottom: -25px;
+    list-style: none;
+    display: block;
+    text-align: center;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    li {
+        position: relative;
+        display: inline-block;
+        height: 20px;
+        width: 20px;
+        margin: 0 5px;
+        padding: 0;
+        cursor: pointer;
+        button {
+            border: 0;
+            background: transparent;
+            display: block;
+            height: 20px;
+            width: 20px;
+            outline: none;
+            line-height: 0px;
+            font-size: 0px;
+            color: transparent;
+            padding: 5px;
+            cursor: pointer;
+            &:hover, &:focus {
+                outline: none;
+                &:before {
+                    opacity: $slick-opacity-on-hover;
+                }
+            }
+            &:before {
+                position: absolute;
+                top: 0;
+                left: 0;
+                content: $slick-dot-character;
+                width: 20px;
+                height: 20px;
+                font-family: $slick-font-family;
+                font-size: $slick-dot-size;
+                line-height: 20px;
+                text-align: center;
+                color: $slick-dot-color;
+                opacity: $slick-opacity-not-active;
+                -webkit-font-smoothing: antialiased;
+                -moz-osx-font-smoothing: grayscale;
+            }
+        }
+        &.slick-active button:before {
+            color: $slick-dot-color-active;
+            opacity: $slick-opacity-default;
+        }
+    }
+}


### PR DESCRIPTION
Use the [slick carousel library](http://kenwheeler.github.io/slick/) to make itineraries swipeable on mobile.

Things to note:
- It's still not obvious you need to tap the itinerary to open step-by-step. I'll address this in a follow-up PR. And it should be less of a concern once we do [on-map route cards](https://marvelapp.com/30a0g54/screen/16895433).
- The progress indicator dots overlay the content while swiping. Minor and cosmetic, but I'll plan to revisit the layout in a follow up sweep to fix this.
- Swiping on desktop tends to trigger the click event. Annoying, but will only happen when the viewport is < 480px wide (hopefully never).


