### PR TITLE
Clean up directions form, including:

### DIFF
--- a/src/app/styles/components/_directions-form.scss
+++ b/src/app/styles/components/_directions-form.scss
@@ -8,7 +8,7 @@
     }
 
     @include respond-to('xxs') {
-        margin: ($home-section-margin - 10px) auto;
+        margin: ($home-section-margin - 20px) auto;
     }
 
     .body-map & {
@@ -50,14 +50,6 @@
         @include respond-to('xxs') {
             width: 100%;
             max-width: 100%;
-        }
-
-        @include respond-to('md-up') {
-            .directions-tab-button label {
-                position: relative;
-                background-color: $gophillygo-blue-dark;
-                cursor: pointer;
-            }
         }
     }
 
@@ -149,10 +141,6 @@
             margin-right: 60px;
         }
 
-        @include respond-to('xxs') {
-            margin-right: 30px;
-        }
-
         .body-map & {
             margin-right: 40px;
 
@@ -194,7 +182,6 @@
         align-items: center;
         justify-content: center;
         width: 50px;
-        height: 100%;
         margin-top: -5px;
         margin-left: 24px;
         padding-top: 3px;
@@ -234,6 +221,26 @@
             border: 1px solid $white;
             background-color: $gophillygo-blue;
 
+            @include respond-to('xxs-up') {
+                &.directions-from label {
+                    background-color: $gophillygo-blue;
+                }
+
+                &.directions-tab-button label {
+                    position: relative;
+                    background-color: $gophillygo-blue-dark;
+                    cursor: pointer;
+                }
+
+                &.directions-to label {
+                    padding-right: .5rem;
+                }
+
+                &.isochrone-control label {
+                    padding-right: 1rem;
+                }
+            }
+
             &:after {
                 position: absolute;
                 width: 30px;
@@ -244,18 +251,14 @@
             }
 
             &.error {
-                background-color: $gophillygo-red;
+                background-color: rgba($gophillygo-red, .5);
 
                 &:after {
                     opacity: 0;
                 }
-
-                input[type=text], input[type=search] {
-                    background-color: $gophillygo-red !important;
-                }
             }
 
-            &.directions-to {
+            &.directions-tab-button {
                 border-top-width: 0;
             }
         }
@@ -265,8 +268,8 @@
         }
 
         label {
-            flex: 0 0 4em;
-            padding-right: 1em;
+            flex: 0 0 5.5rem;
+            padding-right: 1.5rem;
             font-size: 1.4rem;
             font-weight: $font-weight-bold;
             line-height: 40px;
@@ -274,23 +277,33 @@
             cursor: text;
 
             .body-map & {
+                flex-basis: 4rem;
+                margin-right: .5rem;
+                padding-right: .5rem;
+                padding-left: .7rem;
                 font-size: 1.2rem;
                 font-weight: $font-weight-medium;
                 line-height: 30px;
                 color: rgba(255, 255, 255, .9);
+                text-align: left;
             }
         }
 
         input[type=text], input[type=search] {
             flex: 1 0 auto;
             border: 0;
+            padding-top: 0;
+            padding-bottom: 0;
             font-size: 1.4rem;
             background-color: transparent;
+            line-height: 40px;
+            border-radius: 0;
 
             .body-map & {
+                padding: 0;
                 color: $white !important;
                 font-weight: $font-weight-medium;
-                line-height: 30px;
+                line-height: 28px;
 
                 &.tt-hint {
                     color: rgba($white, .7) !important;
@@ -321,8 +334,8 @@
             color: rgba($font-color, .7);
 
             .body-map & {
-                height: 30px;
-                line-height: 30px;
+                height: 28px;
+                line-height: 28px;
                 color: rgba($white, .7) !important;
             }
         }
@@ -339,15 +352,16 @@
         }
 
         .tt-dropdown-menu {
-            width: 100%;
-            margin-left: -10px;
+            width: calc(100% + 5.5rem);
+            margin-left: -5.5rem;
             background-color: $directions-form-text-input-background-color;
             font-size: 1.4rem;
             line-height: 1.25;
+            z-index: 1000 !important;
 
             .body-map & {
-                width: $sidebar-width - 20px;
-                margin-left: -5rem;
+                width: calc(100% + 4.5rem);
+                margin-left: -4.5rem;
                 font-size: 1.3rem;
                 line-height: 2;
             }
@@ -399,11 +413,11 @@
             display: none;
             position: absolute;
             top: -16px;
-            right: -5px;
+            right: 0;
             width: 30px;
             height: 30px;
             padding: 0;
-            border: 1px solid $white;
+            border: 0;
             border-radius: 100%;
             background-color: $gophillygo-blue;
             color: $white;
@@ -432,7 +446,8 @@
      #isochrone-slider {
         @include inputrange();
         margin-right: 1rem;
-        width: 80%;
+        width: 50%;
+        background-color: $gophillygo-blue;
     }
 
     .directions-tab-button.isochrone-control {
@@ -448,8 +463,7 @@
 
         #output-directions-within {
             position: relative;
-            width: 6rem;
-            margin-right: 1rem;
+            margin: 0 2rem 0 1rem;
             color: $white;
             font-size: 1.4rem;
             font-weight: $font-weight-medium;
@@ -457,7 +471,7 @@
             text-align: right;
 
             &:after {
-                content: ' min';
+                content: ' minutes';
             }
         }
 }

--- a/src/app/styles/components/_map.scss
+++ b/src/app/styles/components/_map.scss
@@ -52,6 +52,10 @@
     .leaflet-bar {
         border-radius: 0;
 
+        @include respond-to('xxs-up') {
+            box-shadow: 0 0 4px rgba(0,0,0,0.5);
+        }
+
         a {
             width: 40px;
             height: 40px;
@@ -73,7 +77,7 @@
         background: #fff;
         border-radius: 0;
         line-height: 2;
-        box-shadow: 0 1px 5px rgba(0,0,0,0.65);
+        box-shadow: 0 0 4px rgba(0,0,0,0.5);
 
         .leaflet-control-layers-separator {
             margin: 14px -20px;

--- a/src/app/styles/utils/_breakpoints.scss
+++ b/src/app/styles/utils/_breakpoints.scss
@@ -1,6 +1,7 @@
 $breakpoints: (
     'xxs': (max-width: 480px),
-
+    'xxs-up': (min-width: 481px),
+    
     'xs': (max-width: 767px),
 
     'sm': "(min-width: 768px) and (max-width: 991px)",


### PR DESCRIPTION
- Clean up layout and styles of labels, including to/within toggle.
- Make isochrone slider narrower, so 15min steps feel better.
- Use extra space from above to make "15 min" -> "15 minutes".
- Stop red error background from occluding white borders in map view.
- Tighten up typeahead hint.
- Reposition and resize typeahead dropdown.