### PR TITLE
Fix isochrone requests in production

### DIFF
--- a/src/app/scripts/cac/map/cac-map-isochrone.js
+++ b/src/app/scripts/cac/map/cac-map-isochrone.js
@@ -105,9 +105,9 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _, Settin
         $.ajax({
             type: 'GET',
             data: payload,
-            cache: false,
-            url: isochroneUrl,
-            contentType: 'application/json'
+            dataType: 'json',
+            crossDomain: true,
+            url: isochroneUrl
         }).done(deferred.resolve).fail(deferred.reject);
         return deferred.promise();
     }


### PR DESCRIPTION
Current staging configuration.
Fixes #777. In particular, needed to remove content type (set data type instead),
and also CloudFront says it requires caching support.