### PR TITLE
Feature/bump package versions

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -3,7 +3,9 @@ app_username: "vagrant"
 
 packer_version: "0.7.5"
 
-nodejs_version: 4.6.0
+nodejs_version: 4.6.2
+
+virtualenv_version: 15.1.0
 
 otp_router: "default"
 

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -5,7 +5,7 @@
   version: 0.2.6
 
 - src: azavea.opentripplanner
-  version: 1.0.3
+  version: 1.0.4
 
 - src: azavea.nginx
   version: 0.2.2

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -20,7 +20,7 @@
   version: 1.1.1
 
 - src: azavea.pip
-  version: 0.1.1
+  version: 1.0.0
 
 - src: azavea.python
   version: 0.1.0

--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -27,7 +27,6 @@ cac_python_dependencies:
     - { name: 'django-extensions', version: '1.7.5' }
     - { name: 'django-storages-redux', version: '1.3.2' }
     - { name: 'gunicorn', version: '19.6.0' }
-    - { name: 'ipython', version: '5.1.0' }
     - { name: 'pillow', version: '3.4.2' }
     - { name: 'psycopg2', version: '2.6.2' }
     - { name: 'pytz', version: '2016.10' }

--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -20,18 +20,18 @@ root_media_dir: "/media/cac"
 app_cron_event_feed: "cd {{ root_app_dir }} && python manage.py load_events >> {{ app_cron_event_feed_log }} 2>&1"
 
 cac_python_dependencies:
-    - { name: 'base58', version: '0.2.3' }
-    - { name: 'boto', version: '2.41.0' }
-    - { name: 'django', version: '1.8.13' }
-    - { name: 'django-ckeditor', version: '5.0.3' }
-    - { name: 'django-extensions', version: '1.6.7' }
+    - { name: 'base58', version: '0.2.4' }
+    - { name: 'boto', version: '2.45.0' }
+    - { name: 'django', version: '1.8.17' }
+    - { name: 'django-ckeditor', version: '5.1.1' }
+    - { name: 'django-extensions', version: '1.7.5' }
     - { name: 'django-storages-redux', version: '1.3.2' }
-    - { name: 'gunicorn', version: '19.6.0'}
-    - { name: 'ipython', version: '4.2.1' }
-    - { name: 'pillow', version: '3.3.0' }
-    - { name: 'psycopg2', version: '2.6.1' }
-    - { name: 'pytz', version: '2016.4' }
-    - { name: 'pyyaml', version: '3.11' }
+    - { name: 'gunicorn', version: '19.6.0' }
+    - { name: 'ipython', version: '5.1.0' }
+    - { name: 'pillow', version: '3.4.2' }
+    - { name: 'psycopg2', version: '2.6.2' }
+    - { name: 'pytz', version: '2016.10' }
+    - { name: 'pyyaml', version: '3.12' }
     - { name: 'troposphere', version: '0.7.2'}
     # Note: django-wpadmin is installed manually to work around the fact that ansible-pip
     # ignores editable=False

--- a/python/cac_tripplanner/destinations/views.py
+++ b/python/cac_tripplanner/destinations/views.py
@@ -145,7 +145,7 @@ class SearchDestinations(View):
         results = []
         if lat and lon:
             try:
-                searchPoint = Point(float(lon), float(lat))
+                search_point = Point(float(lon), float(lat))
             except ValueError as e:
                 error = json.dumps({
                     'msg': 'Invalid latitude/longitude pair',
@@ -153,7 +153,7 @@ class SearchDestinations(View):
                 })
                 return HttpResponse(error, 'application/json')
             results = (Destination.objects.filter(published=True)
-                       .distance(searchPoint)
+                       .distance(search_point)
                        .order_by('distance'))
         elif text is not None:
             results = Destination.objects.filter(published=True, name__icontains=text)


### PR DESCRIPTION
Mostly minor version bumps, which fixed a provisioning issue with a package version no longer available (forget which one, now). Also drops `ipython` from the list of packages pip-installed on the app server, due to a current issue with `setuptools`, which is an indirect dependency of `ipython`, and resulted in a broken `pip` installation.

Used to provision current production.
