### PR TITLE
Clear focus to hide mobile keyboard on directions

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions-form.js
+++ b/src/app/scripts/cac/control/cac-control-directions-form.js
@@ -46,6 +46,7 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
         events: events,
         eventNames: eventNames,
         moveOriginDestination: moveOriginDestination,
+        clearFocus: clearFocus,
         clearAll: clearAll,
         setLocation: setLocation,
         setError: setError,
@@ -148,8 +149,7 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
         Geocoder.reverse(position.lat, position.lng).then(function (data) {
             if (data && data.address) {
                 // prevent typeahead dropdown from opening by removing focus
-                $(options.selectors.typeaheadFrom).blur();
-                $(options.selectors.typeaheadTo).blur();
+                clearFocus();
 
                 var location = Utils.convertReverseGeocodeToLocation(data);
                 UserPreferences.setPreference(key, location);
@@ -168,6 +168,11 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
                 events.trigger(eventNames.geocodeError, key);
             }
         });
+    }
+
+    function clearFocus() {
+        $(options.selectors.typeaheadFrom).blur();
+        $(options.selectors.typeaheadTo).blur();
     }
 
     // Clear both fields and any errors

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -104,6 +104,8 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Te
             return;
         }
 
+        directionsFormControl.clearFocus();
+
         // show spinner while loading
         showSpinner();
 


### PR DESCRIPTION
Resolves #757. The mobile keyboard was staying up because selecting
a destination triggers directions but was leaving the destination input
field focused. This makes `planTrip` blur the inputs.

**To Test**
By adding my machine to `ALLOWED_HOSTS` in `settings.py` I can get my development instance to load on my phone.  It can't connect to the OTP server, but loading the front-end is sufficient to reproduce this--fill in an origin and destination and observe that the keyboard stays up without this change, gets dismissed with.