### PR TITLE
Feature/sml/ui tweaks

### DIFF
--- a/python/cac_tripplanner/cms/forms.py
+++ b/python/cac_tripplanner/cms/forms.py
@@ -23,4 +23,4 @@ class ArticleForm(ModelForm):
 
     def clean_narrow_image(self):
         """Custom validator for narrow image field"""
-        return validate_image(self.cleaned_data.get('narrow_image', False), 400, 600)
+        return validate_image(self.cleaned_data.get('narrow_image', False), 310, 218)

--- a/python/cac_tripplanner/cms/models.py
+++ b/python/cac_tripplanner/cms/models.py
@@ -89,7 +89,7 @@ class Article(models.Model):
     wide_image = models.ImageField(upload_to=generate_filename, null=True,
                                    help_text='The wide image. Will be displayed at 1440x400.')
     narrow_image = models.ImageField(upload_to=generate_filename, null=True,
-                                     help_text='The narrow image. Will be displayed at 400x600.')
+                                     help_text='The narrow image. Will be displayed at 310x218.')
 
     @property
     def published(self):

--- a/python/cac_tripplanner/templates/partials/article-card.html
+++ b/python/cac_tripplanner/templates/partials/article-card.html
@@ -1,6 +1,6 @@
 <div class="preview-card">
     <a href="{% url 'learn-detail' slug=article.slug %}" class="preview-card-link">
-        <img class="preview-photo" src="{{ article.narrow_image.url }}" width="308" height="204"
+        <img class="preview-photo" src="{{ article.narrow_image.url }}" width="310"
              alt="{{ article.title }}" />
         <div class="preview-details">
             <div class="category-heading">

--- a/python/cac_tripplanner/templates/partials/destination-card.html
+++ b/python/cac_tripplanner/templates/partials/destination-card.html
@@ -1,6 +1,6 @@
 <div class="preview-card">
     <a href="{% url 'place-detail' pk=destination.pk %}" class="preview-card-link">
-        <img class="preview-photo" src="{{ destination.wide_image.url }}" width="308" height="204" alt="{{ destination.name }}" />
+        <img class="preview-photo" src="{{ destination.wide_image.url }}" width="310" alt="{{ destination.name }}" />
         <div class="preview-details">
             <h2>{{ destination.name }}</h2>
             <p class="lede">{{ destination.description|striptags|truncatewords:20 }}</p>

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -288,11 +288,10 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                 var originOptions = {
                     icon: originIcon,
                     draggable: true,
-                    title: 'origin',
+                    title: 'Drag to change origin',
                     zIndexOffset: 1001
                 };
-                directionsMarkers.origin = new cartodb.L.marker(origin, originOptions)
-                                                        .bindPopup('<p>Origin</p>');
+                directionsMarkers.origin = new cartodb.L.marker(origin, originOptions);
                 directionsMarkers.origin.addTo(map);
                 directionsMarkers.origin.on('dragend', markerDrag);
             }
@@ -309,11 +308,10 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                 var destOptions = {
                     icon: destIcon,
                     draggable: true,
-                    title: 'destination',
+                    title: 'Drag to change destination',
                     zIndexOffset: 1000
                 };
-                directionsMarkers.destination = new cartodb.L.marker(destination, destOptions)
-                                                             .bindPopup('<p>Destination</p>');
+                directionsMarkers.destination = new cartodb.L.marker(destination, destOptions);
                 directionsMarkers.destination.addTo(map);
                 directionsMarkers.destination.on('dragend', markerDrag);
             }

--- a/src/app/scripts/cac/map/cac-map-isochrone.js
+++ b/src/app/scripts/cac/map/cac-map-isochrone.js
@@ -229,7 +229,7 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _, Settin
                 var popupContent = template({geojson: geojson});
                 var markerId = geojson.properties.id;
                 var marker = new cartodb.L.marker(latLng, {icon: destinationIcon})
-                        .bindPopup(popupContent);
+                        .bindPopup(popupContent, {className: 'poi-popup'});
                 destinationMarkers[markerId] = {
                     marker: marker,
                     destination: destinations[geojson.properties.id]

--- a/src/app/scripts/cac/map/cac-map-isochrone.js
+++ b/src/app/scripts/cac/map/cac-map-isochrone.js
@@ -3,7 +3,8 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _, Settin
 
     var defaults = {
         selectors: {
-            destinationPopup: '.destination-directions-link'
+            destinationPopup: '.destination-directions-link',
+            poiPopupClassName: 'poi-popup'
         }
     };
 
@@ -229,7 +230,7 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _, Settin
                 var popupContent = template({geojson: geojson});
                 var markerId = geojson.properties.id;
                 var marker = new cartodb.L.marker(latLng, {icon: destinationIcon})
-                        .bindPopup(popupContent, {className: 'poi-popup'});
+                        .bindPopup(popupContent, {className: options.selectors.poiPopupClassName});
                 destinationMarkers[markerId] = {
                     marker: marker,
                     destination: destinations[geojson.properties.id]

--- a/src/app/scripts/cac/map/cac-map-itinerary.js
+++ b/src/app/scripts/cac/map/cac-map-itinerary.js
@@ -1,6 +1,12 @@
 CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
     'use strict';
 
+    var defaults = {
+        selectors: {
+            routeTooltipClassName: 'route-tooltip'
+        }
+    };
+
     var map = null;
     var itineraries = {};
 
@@ -13,6 +19,8 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
     var itineraryHoverListener = null;
     var liveUpdatingItinerary = false; // true when live update request sent but not completed
     var waypointsLayer = null;
+
+    var options = null;
 
     var waypointRadius = 6;
     var waypointFillColor = 'white';
@@ -32,10 +40,11 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
         popupAnchor: [60, 40]
     } );
 
-    function ItineraryControl(options) {
+    function ItineraryControl(opts) {
         this.events = events;
         this.eventNames = eventNames;
-        map = options.map;
+        options = $.extend({}, defaults, opts);
+        map = opts.map;
     }
 
     ItineraryControl.prototype.plotItinerary = plotItinerary;
@@ -121,7 +130,8 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
                 lastItineraryHoverMarker = new cartodb.L.Marker(e.latlng, {
                         draggable: true,
                         icon: waypointIcon
-                    }).bindPopup('Drag to change route', {closeButton: false, className: 'route-tooltip'}
+                    }).bindPopup('Drag to change route',
+                                 {closeButton: false, className: options.selectors.routeTooltipClassName}
                     ).on('dragstart', function(e) {
                         dragging = true;
                         var pt = e.target.getLatLng();
@@ -196,7 +206,8 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
                         redrawWaypointDrag(event, geojson.properties.index, false);
                     });
 
-            marker.bindPopup('Drag to change. Click to remove.', {closeButton: false, className: 'route-tooltip'})
+            marker.bindPopup('Drag to change. Click to remove.',
+                             {closeButton: false, className: options.selectors.routeTooltipClassName})
                     .on('mouseover', function () {
                         clearTimeout(popupTimeout);
                         return dragging || this.openPopup();

--- a/src/app/scripts/cac/map/cac-map-itinerary.js
+++ b/src/app/scripts/cac/map/cac-map-itinerary.js
@@ -121,7 +121,7 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
                 lastItineraryHoverMarker = new cartodb.L.Marker(e.latlng, {
                         draggable: true,
                         icon: waypointIcon
-                    }).bindPopup('Drag to change route', {closeButton: false}
+                    }).bindPopup('Drag to change route', {closeButton: false, className: 'route-tooltip'}
                     ).on('dragstart', function(e) {
                         dragging = true;
                         var pt = e.target.getLatLng();
@@ -196,7 +196,7 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
                         redrawWaypointDrag(event, geojson.properties.index, false);
                     });
 
-            marker.bindPopup('Drag to change. Click to remove.', {closeButton: false})
+            marker.bindPopup('Drag to change. Click to remove.', {closeButton: false, className: 'route-tooltip'})
                     .on('mouseover', function () {
                         clearTimeout(popupTimeout);
                         return dragging || this.openPopup();

--- a/src/app/scripts/cac/map/cac-map-overlays.js
+++ b/src/app/scripts/cac/map/cac-map-overlays.js
@@ -1,13 +1,19 @@
 CAC.Map.OverlaysControl = (function ($, cartodb, L, Utils) {
     'use strict';
 
-    var defaults = {};
+    var defaults = {
+        selectors: {
+            bikeSharePopupClassName: 'bikeshare-popup',
+            eventPopupClassName: 'event-popup'
+        }
+    };
 
+    var options = null;
     var bikeShareFeatureGroup = null;
     var eventsFeatureGroup = null;
 
-    function OverlaysControl(options) {
-        this.options = $.extend({}, defaults, options);
+    function OverlaysControl(opts) {
+        options = $.extend({}, defaults, opts);
     }
 
     OverlaysControl.prototype.bikeShareOverlay = bikeShareOverlay;
@@ -79,7 +85,8 @@ CAC.Map.OverlaysControl = (function ($, cartodb, L, Utils) {
         });
         var latLng = cartodb.L.latLng(share.geometry.coordinates[1], share.geometry.coordinates[0]);
         var marker = new cartodb.L.marker(latLng, { icon: icon });
-        marker.bindPopup(CAC.Map.Templates.bikeSharePopup(share), {className: 'bikeshare-popup'});
+        marker.bindPopup(CAC.Map.Templates.bikeSharePopup(share),
+                         {className: options.selectors.bikeSharePopupClassName});
         return marker;
     }
 
@@ -91,7 +98,8 @@ CAC.Map.OverlaysControl = (function ($, cartodb, L, Utils) {
             prefix: 'fa'
         });
         var marker = new cartodb.L.marker(latLng, { icon: icon });
-        marker.bindPopup(CAC.Map.Templates.eventPopup(event), {className: 'event-popup'});
+        marker.bindPopup(CAC.Map.Templates.eventPopup(event),
+                         {className: options.selectors.eventPopupClassName});
         return marker;
     }
 

--- a/src/app/scripts/cac/map/cac-map-overlays.js
+++ b/src/app/scripts/cac/map/cac-map-overlays.js
@@ -79,7 +79,7 @@ CAC.Map.OverlaysControl = (function ($, cartodb, L, Utils) {
         });
         var latLng = cartodb.L.latLng(share.geometry.coordinates[1], share.geometry.coordinates[0]);
         var marker = new cartodb.L.marker(latLng, { icon: icon });
-        marker.bindPopup(CAC.Map.Templates.bikeSharePopup(share), {});
+        marker.bindPopup(CAC.Map.Templates.bikeSharePopup(share), {className: 'bikeshare-popup'});
         return marker;
     }
 
@@ -91,7 +91,7 @@ CAC.Map.OverlaysControl = (function ($, cartodb, L, Utils) {
             prefix: 'fa'
         });
         var marker = new cartodb.L.marker(latLng, { icon: icon });
-        marker.bindPopup(CAC.Map.Templates.eventPopup(event), {});
+        marker.bindPopup(CAC.Map.Templates.eventPopup(event), {className: 'event-popup'});
         return marker;
     }
 

--- a/src/app/styles/components/_directions-results.scss
+++ b/src/app/styles/components/_directions-results.scss
@@ -1,5 +1,6 @@
 .directions-results {
     @include sidebar-main;
+    position: relative;
 
     .body-home &,
     .body-map-explore &,
@@ -12,13 +13,22 @@
     }
 
     @include respond-to('xxs') {
-        flex: 0 0 $route-summary-height;
+        flex: 0 1 auto;
         order: 10;
         width: 100%;
-        height: $route-summary-height;
+        height: auto;
+        max-height: $route-summary-height;
         overflow: hidden;
         z-index: 1000;
         box-shadow: 0 0 16px rgba(128, 128, 128, 0.7);
+
+        .routes-list {
+            height: $route-summary-height;
+
+            &:empty {
+                display: none;
+            }
+        }
     }
 
     h1 {

--- a/src/app/styles/components/_map-marker-popup.scss
+++ b/src/app/styles/components/_map-marker-popup.scss
@@ -1,4 +1,30 @@
-.leaflet-popup {
+.route-tooltip {
+    // width: auto;
+    // top: 40px;
+    // left: 50px;
+    // padding: .5em;
+    // background-color: $white;
+
+    .leaflet-popup-tip-container {
+        display: none;
+    }
+
+    .leaflet-popup-content-wrapper {
+        border-radius: 0;
+    }
+
+    .leaflet-popup-content {
+        margin: 2px 4px;
+    }
+}
+
+.poi-popup,
+.bikeshare-popup,
+.event-popup {
+
+    .leaflet-popup-content-wrapper {
+        border-radius: 0;
+    }
 
     .leaflet-popup-close-button {
         top: 8px !important;

--- a/src/app/styles/components/_map.scss
+++ b/src/app/styles/components/_map.scss
@@ -121,16 +121,4 @@
             border: 0;
         }
     }
-
-    .leaflet-popup-tip-container {
-        display: none;
-    }
-
-    .leaflet-popup-content-wrapper {
-        border-radius: 0;
-    }
-
-    .leaflet-popup-content {
-        margin: 2px 4px;
-    }
 }

--- a/src/app/styles/components/_place-list.scss
+++ b/src/app/styles/components/_place-list.scss
@@ -1,5 +1,6 @@
 .places {
     @include sidebar-main;
+    position: relative;
 
     @include respond-to('xxs') {
         width: 100%;

--- a/src/app/styles/components/_place-list.scss
+++ b/src/app/styles/components/_place-list.scss
@@ -23,6 +23,7 @@
         width: 100%;
         max-width: $home-main-max-width;
         height: auto;
+        min-height: 100px;
         margin: 0 auto $home-section-margin;
         padding: 0 $home-section-padding 10px;
         background-color: $home-section-bg-color;

--- a/src/app/styles/components/_spinner.scss
+++ b/src/app/styles/components/_spinner.scss
@@ -1,5 +1,10 @@
 .sk-spinner {
     display: flex;
+    position: absolute;
+    flex-flow: row nowrap;
+    justify-content: center;
+    width: 100%;
+
     &.hidden {
         display: none;
     }


### PR DESCRIPTION
Couple of QA fixes…
- Fixed and normalized map marker popup styling, which had regressed
- Hide itineraries list on mobile while loading. This gets rid of an ugly Chrome Android state that would be pretty common. Map view with keyboard open shows a big blank area.

![bs_realdroid_mobile_samsung galaxy s7-6 0-1440x2560](https://cloud.githubusercontent.com/assets/128699/22437881/cb0643a6-e6f7-11e6-9a2b-ddc6b1df7a91.jpg)
