### PR TITLE
Guard against map control not loaded yet

### DIFF
--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -331,16 +331,25 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
     }
 
     function onPlaceClicked(event) {
+        if (!mapControl || !mapControl.isochroneControl) {
+            return;
+        }
         var placeId = $(event.target).closest(options.selectors.placeCard).data('destination-id');
         mapControl.isochroneControl.highlightDestination(placeId, { panTo: true });
     }
 
     function onPlaceHovered(event) {
+        if (!mapControl || !mapControl.isochroneControl) {
+            return;
+        }
         var placeId = $(event.target).closest(options.selectors.placeCard).data('destination-id');
         mapControl.isochroneControl.highlightDestination(placeId);
     }
 
     function onPlaceBlurred() {
+        if (!mapControl || !mapControl.isochroneControl) {
+            return;
+        }
         mapControl.isochroneControl.highlightDestination(null);
     }
 


### PR DESCRIPTION
Fixes #792.

Guard against map control still loading when first navigating to directions view on mobile (where map may not have loaded yet).

In hover activity handlers, so fine to just do nothing.