### PR TITLE
Fix iOS 9 home page layout bug

### DIFF
--- a/src/app/styles/components/_directions-form.scss
+++ b/src/app/styles/components/_directions-form.scss
@@ -11,6 +11,11 @@
         margin: ($home-section-margin - 20px) auto;
     }
 
+    .body-home & {
+        height: $directions-form-home-height;
+        min-height: $directions-form-home-height;
+    }
+
     .body-map & {
         max-width: $sidebar-width;
         margin: 0;
@@ -18,6 +23,7 @@
         @include respond-to('xxs') {
             width: 100%;
             max-width: 100%;
+            height: auto;
         }
     }
 }
@@ -40,6 +46,10 @@
         padding: 0 10px;
     }
 
+    .body-home & {
+        height: $directions-form-home-height;
+    }
+
     .body-map & {
         width: $sidebar-width;
         max-width: $sidebar-width;
@@ -50,6 +60,7 @@
         @include respond-to('xxs') {
             width: 100%;
             max-width: 100%;
+            height: auto;
         }
     }
 

--- a/src/app/styles/pages/_home.scss
+++ b/src/app/styles/pages/_home.scss
@@ -10,6 +10,7 @@
     justify-content: space-between;
     width: 100%;
     height: 100%;
-    overflow: auto;
+    overflow-x: hidden;
+    overflow-y: auto;
     -webkit-overflow-scrolling: touch;
 }

--- a/src/app/styles/utils/_variables.scss
+++ b/src/app/styles/utils/_variables.scss
@@ -9,6 +9,7 @@ $modal-panel-drop-shadow: 0 0 100px rgba(0, 0, 0, .3);
 
 $sidebar-width: 340px;
 $footer-sidebar-height: 60px;
+$directions-form-home-height: 180px;
 $directions-form-sidebar-height: 140px;
 
 $sidebar-banner-height: 50px;


### PR DESCRIPTION
In the Home view on iOS 9 Mobile Safari, the places list overlays the directions form. Pretty nasty. This fixes it.


![simulator screen shot jan 31 2017 11 58 03 am](https://cloud.githubusercontent.com/assets/128699/22475312/8bf3c8b8-e7ac-11e6-8a00-9f0896bf5227.png)
