### PR TITLE
Resize map on itinerary selection

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -237,6 +237,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Te
         currentItinerary.highlight(true);
         directionsListControl.hide();
         itineraryListControl.show();
+        mapControl.fitToBounds(currentItinerary.geojson.getBounds());
     }
 
     /**
@@ -259,6 +260,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Te
             directionsListControl.setItinerary(itinerary);
             itineraryListControl.hide();
             directionsListControl.show();
+            mapControl.fitToBounds(itinerary.geojson.getBounds());
         }
     }
 

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -84,6 +84,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
     }
 
     MapControl.prototype.isLoaded = isLoaded;
+    MapControl.prototype.fitToBounds = fitToBounds;
     MapControl.prototype.loadMap = loadMap;
     MapControl.prototype.setGeocodeMarker = setGeocodeMarker;
     MapControl.prototype.setDirectionsMarkers = setDirectionsMarkers;
@@ -207,6 +208,11 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                 $(selectors.leafletLayerList).hide();
             }
         });
+    }
+
+    function fitToBounds(bounds) {
+        map.invalidateSize();
+        map.fitBounds(bounds);
     }
 
     function setGeocodeMarker(latLng) {


### PR DESCRIPTION
Closes #802.

Invalidate map size so that when itinerary step list slides up or down, fitting again to itinerary
bounds will accomodate.