### PR TITLE
Use setValue in geolocate

### DIFF
--- a/src/app/scripts/cac/search/cac-typeahead.js
+++ b/src/app/scripts/cac/search/cac-typeahead.js
@@ -49,6 +49,7 @@ CAC.Search.Typeahead = (function (_, $, Geocoder, SearchParams, Utils) {
         this.$element = null;
 
         var createTypeahead = _.bind(function() {
+            var thisTypeahead = this;
             var $element = $(selector).typeahead(this.options, {
                 name: 'featured',
                 displayKey: 'name',
@@ -89,7 +90,7 @@ CAC.Search.Typeahead = (function (_, $, Geocoder, SearchParams, Utils) {
                                 var fullAddress = data.address.Match_addr;
                                 /*jshint camelcase: true */
 
-                                $element.typeahead('val', fullAddress).change();
+                                thisTypeahead.setValue(fullAddress);
                                 events.trigger(eventNames.selected, [typeaheadKey, location]);
                             }
                         });


### PR DESCRIPTION
The typeaheads have a function that gets called on `blur` and resets the
value if there's a mismatch between what the field says and the last
selected value. The geolocation callback was setting the field's value
but not using the special `setValue` method that keeps the internal
lastSelectedValue in sync.

This produced no symptoms until PR #787, which caused a blur event to
happen when it wasn't before, which resulted in the value set by the
geolocation being compared to the blank original value, triggering the
reset.

This makes the geolocation callback use `setValue`.

Note: I don't know if there might be a more proper way to get at the typahead object inside the geolocation callback.  It's so many levels deep that assigning it to a variable in the `createTypeahead`scope seemed simpler than whatever would be required to make it available as `this` in the scope where we need it.