### PR TITLE
Feature/sml/route colors and misc

### DIFF
--- a/python/cac_tripplanner/templates/partials/modals.html
+++ b/python/cac_tripplanner/templates/partials/modals.html
@@ -106,9 +106,6 @@
             <p>Here's a link to these directions:</p>
             <p><a id="modalDirectionsLink" href=""></a></p>
         </div>
-        <footer class="modal-footer">
-            <button name="close-modal" class="btn-close-modal">Close</button>
-        </footer>
     </div>
 
 </div>

--- a/src/app/scripts/cac/utils.js
+++ b/src/app/scripts/cac/utils.js
@@ -92,12 +92,12 @@ CAC.Utils = (function (_) {
         WALK: brandColors.BLUE,
         BICYCLE: brandColors.PURPLE,
         BUS: brandColors.YELLOW,
-        TRAM: brandColors.ORANGE,
-        SUBWAY: brandColors.ORANGE,
-        TRAIN: brandColors.ORANGE,
-        RAIL: brandColors.ORANGE,
+        TRAM: brandColors.YELLOW,
+        SUBWAY: brandColors.YELLOW,
+        TRAIN: brandColors.YELLOW,
+        RAIL: brandColors.YELLOW,
         CAR: '#111111',
-        FERRY: brandColors.BLUE
+        FERRY: brandColors.YELLOW
     };
 
     var module = {

--- a/src/app/styles/components/_directions-results.scss
+++ b/src/app/styles/components/_directions-results.scss
@@ -79,8 +79,7 @@
             }
 
             .route-modes {
-                .icon-walk,
-                .icon-ferry {
+                .icon-walk {
                     color: $gophillygo-blue;
                 }
 
@@ -88,14 +87,12 @@
                     color: $gophillygo-purple;
                 }
 
-                .icon-bus {
-                    color: $gophillygo-yellow;
-                }
-
+                .icon-bus,
                 .icon-subway,
                 .icon-train,
-                .icon-tram {
-                    color: $gophillygo-orange;
+                .icon-tram,
+                .icon-ferry {
+                    color: $gophillygo-yellow;
                 }
 
                 .icon-car {

--- a/src/app/styles/components/_directions-step-by-step.scss
+++ b/src/app/styles/components/_directions-step-by-step.scss
@@ -52,6 +52,7 @@
         justify-content: space-between;
 
         @include respond-to('xxs') {
+            align-items: stretch;
             width: 100%;
             background-color: $gophillygo-blue;
             color: $white;
@@ -60,6 +61,7 @@
 
         button {
             flex: 0 0 40px;
+            padding: 0;
             border: 0;
             border-radius: 0;
             background: none;

--- a/src/app/styles/components/_modal.scss
+++ b/src/app/styles/components/_modal.scss
@@ -176,7 +176,7 @@
 }
 
 .modal-list {
-    flex: 1 0 200px;
+    flex: 1 0 210px;
     list-style: none;
     margin: 0;
     padding: 0;
@@ -192,6 +192,10 @@
         padding-left: 50px;
         line-height: 7rem;
         cursor: pointer;
+
+        .modal-share & {
+            height: 5rem;
+        }
 
         &:hover {
             background-color: #eee;


### PR DESCRIPTION
Remove close button from share modal. Was getting in the way of all the share options, and not necessary, with click-outside working.

Fix some padding and size issues for the directions "back" and "share" buttons.

Changed walk color to GoPhlGo blue and made all transit modes GoPhlGo yellow. Rationale:
- On-brand colors aren’t necessary, but good to use if we can.
- SEPTA's primary lines don’t use yellow AFAICT, so in theory our yellow transit paths won’t imply a certain line.
- Purple (bike) is a SEPTA color for Norristown HSL, but that’s not in the downtown area and has a very specific footprint, so hopefully won’t be confusing.
- Blue (walk) is the MFL, but that has a very specific route, while walking can happen *anywhere*. Further, blue is our main UI color, so hopefully the semantic gravity [TM] of matching the UI will outweigh that of the MFL line. They’re also quite different blues.