### PR TITLE
Make geolocate button spin while working

### DIFF
--- a/src/app/scripts/cac/search/cac-typeahead.js
+++ b/src/app/scripts/cac/search/cac-typeahead.js
@@ -32,7 +32,8 @@ CAC.Search.Typeahead = (function (_, $, Geocoder, SearchParams, Utils) {
     };
 
     var selectors = {
-        geolocate: '.icon-geolocate'
+        geolocate: '.icon-geolocate',
+        spinClass: 'spin'
     };
 
     function CACTypeahead(selector, options) {
@@ -81,6 +82,7 @@ CAC.Search.Typeahead = (function (_, $, Geocoder, SearchParams, Utils) {
             // Wire up locator button
             if ('geolocation' in navigator) {
                 $element.parent().parent().find(selectors.geolocate).on('click', function() {
+                    $(selectors.geolocate).addClass(selectors.spinClass);
                     navigator.geolocation.getCurrentPosition(function(pos) {
                         var coords = pos.coords;
                         Geocoder.reverse(coords.latitude, coords.longitude).then(function (data) {
@@ -92,12 +94,16 @@ CAC.Search.Typeahead = (function (_, $, Geocoder, SearchParams, Utils) {
 
                                 thisTypeahead.setValue(fullAddress);
                                 events.trigger(eventNames.selected, [typeaheadKey, location]);
+                                $(selectors.geolocate).removeClass(selectors.spinClass);
                             }
+                        }).catch(function (error) {
+                            console.error('reverse geocoding error:', error);
+                            $(selectors.geolocate).removeClass(selectors.spinClass);
                         });
 
                     }, function(error) {
-                        console.error('geolocation error:');
-                        console.error(error);
+                        console.error('geolocation error:', error);
+                        $(selectors.geolocate).removeClass(selectors.spinClass);
                     });
                 });
             }

--- a/src/app/styles/components/_directions-form.scss
+++ b/src/app/styles/components/_directions-form.scss
@@ -412,7 +412,7 @@
             color: $lt-gray;
             cursor: pointer;
 
-            &.spin i {
+            & i.spin {
                 display: inline-block;
                 animation: full-rotation 2s infinite linear;
             }


### PR DESCRIPTION
Adds a `spin` class to the geolocate button while it's working (and removes it when it finishes or errors). Errors get logged to the console.

Just realized I had worked on this last week but gotten sidetracked before pushing it, and once things were prioritized it wasn't on the high-priority list.  Also it doesn't display the error to the user when it fails, though that's no worse than what we have now where clicking the button either results in an address appearing or doesn't, with neither "working" nor "error" feedback.  I don't think there's an existing error setup to hook into that would make sense for this case, and I wonder whether a simple alert (which would look janky and require a click) is any more user friendly than failing silently...

Anyway, here's a thing, which we can merge, delay, or nix.

Resolves #764.