### PR TITLE
Do not use marker title to determine type

### DIFF
--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -264,7 +264,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
             var latlng = new cartodb.L.LatLng(position.lat, position.lng);
             marker.setLatLng(latlng, {draggable: true});
 
-            var trigger = (marker.options.title === 'origin') ?
+            var trigger = (marker.options.isOrigin) ?
                             eventNames.originMoved : eventNames.destinationMoved;
 
             events.trigger(trigger, position);
@@ -294,6 +294,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                 var originOptions = {
                     icon: originIcon,
                     draggable: true,
+                    isOrigin: true,
                     title: 'Drag to change origin',
                     zIndexOffset: 1001
                 };
@@ -314,6 +315,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                 var destOptions = {
                     icon: destIcon,
                     draggable: true,
+                    isOrigin: false,
                     title: 'Drag to change destination',
                     zIndexOffset: 1000
                 };


### PR DESCRIPTION
Fixes #815. Add property to marker to determine via event inspection whether dragged marker
is the origin or the destination.