### PR TITLE
Fix Django logging configuration

### DIFF
--- a/python/cac_tripplanner/cac_tripplanner/settings.py
+++ b/python/cac_tripplanner/cac_tripplanner/settings.py
@@ -14,6 +14,7 @@ from django.core.exceptions import ImproperlyConfigured
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 import yaml
+import logging.config
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 try:
@@ -163,6 +164,32 @@ STATICFILES_DIRS = ()
 
 MEDIA_ROOT = '/media/cac/'
 MEDIA_URL = '/media/'
+
+# LOGGING CONFIGURATION
+LOGGING_CONFIG = None
+logging.config.dictConfig({
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'datefmt': '%Y-%m-%d %H:%M:%S %z',
+            'format': ('[%(asctime)s] [%(process)d] [%(levelname)s]'
+                       ' %(message)s'),
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': 'INFO',
+        }
+    }
+})
 
 # TEMPLATE CONFIGURATION
 # See https://docs.djangoproject.com/en/1.8/ref/settings/#templates


### PR DESCRIPTION
Reset `LOGGING_CONFIG` and then explicitly override the logging configuration so that all logs flow to `stdout`. The lack of a logging configuration was causing exception tracebacks to be swallowed when debug mode is disabled.

See: https://docs.djangoproject.com/en/1.7/topics/logging/#disabling-logging-configuration

---

**Testing**

After switching to this branch, restart the application server:

```bash
$ sudo restart cac-tripplanner-app
```

Then, trigger an exception and inspect the contents of `$ sudo cat /var/log/upstart/cac-tripplanner-app.log`:

```bash
$ sudo cat /var/log/upstart/cac-tripplanner-app.log
...
 File "/usr/local/lib/python2.7/dist-packages/django/template/base.py", line 919, in render_node
    return node.render(context)
  File "/usr/local/lib/python2.7/dist-packages/django/template/loader_tags.py", line 65, in render
    result = block.nodelist.render(context)
  File "/usr/local/lib/python2.7/dist-packages/django/template/base.py", line 905, in render
    bit = self.render_node(node, context)
  File "/usr/local/lib/python2.7/dist-packages/django/template/base.py", line 919, in render_node
    return node.render(context)
  File "/usr/local/lib/python2.7/dist-packages/django/template/defaulttags.py", line 162, in render
    len_values = len(values)
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/query.py", line 144, in __len__
    self._fetch_all()
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/query.py", line 965, in _fetch_all
    self._result_cache = list(self.iterator())
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/query.py", line 238, in iterator
    results = compiler.execute_sql()
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/sql/compiler.py", line 840, in execute_sql
    cursor.execute(sql, params)
  File "/usr/local/lib/python2.7/dist-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python2.7/dist-packages/django/db/utils.py", line 98, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/usr/local/lib/python2.7/dist-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
ProgrammingError: column destinations_destination.priority does not exist
LINE 1: ...e_image", "destinations_destination"."published", "destinati...
```