### PR TITLE
Feature/kak/fix waypoints dragend#830

### DIFF
--- a/src/app/scripts/cac/pages/cac-pages-directions.js
+++ b/src/app/scripts/cac/pages/cac-pages-directions.js
@@ -98,12 +98,12 @@ CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings) {
             crossDomain: true,
             data: otpParams,
             processData: false
-        }).then(function(data) {
+        }).done(function(data) {
             var itineraries = data.plan.itineraries;
             var itinerary = new Itinerary(itineraries[itineraryIndex], itineraryIndex);
             setMapItinerary(itinerary);
             directionsListControl.setItinerary(itinerary);
-        }, function (error) {
+        }).fail(function (error) {
             console.error(error);
         });
 

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -161,7 +161,11 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
         // explicitly set the index property so it will populate on the geoJSON properties
         // when point array used to create FeatureCollection
         return _.map(waypoints.split(';'), function(point, index) {
-            return turf.point(point.split(',').reverse(), {index: index});
+            var points = _.map(point.split(',').reverse(), function(pt) {
+                // turf.point expects numeric input
+                return parseFloat(pt);
+            });
+            return turf.point(points, {index: index});
         });
     }
 

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -29,7 +29,7 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
             crossDomain: true,
             data: urlParams,
             processData: false
-        }).then(function(data) {
+        }).done(function(data) {
             if (data.plan) {
                 // Ensure unique itineraries.
                 // Due to issue: https://github.com/opentripplanner/OpenTripPlanner/issues/1894
@@ -64,7 +64,7 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
             } else {
                 deferred.reject(data.error);
             }
-        }, function (error) {
+        }).fail(function (error) {
             deferred.reject(error);
         });
         return deferred.promise();
@@ -96,7 +96,7 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
             crossDomain: true,
             data: urlParams,
             processData: false
-        }).then(function(data) {
+        }).done(function(data) {
             if (data.plan) {
                 var otpItinerary = data.plan.itineraries[0];
 
@@ -108,7 +108,7 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
             } else {
                 deferred.reject(data.error);
             }
-        }, function (error) {
+        }).fail(function (error) {
             deferred.reject(error);
         });
         return deferred.promise();

--- a/src/package.json
+++ b/src/package.json
@@ -4,7 +4,7 @@
     "node": ">=0.12.0"
   },
   "dependencies": {
-    "@turf/point-on-line": "~3.5.3"
+    "@turf/point-on-line": "~3.14.2"
   },
   "devDependencies": {
     "aliasify": "^2.0.0",


### PR DESCRIPTION
## Overview

Fixes #830.

After fresh npm install, draggable routes would not update after waypoint release or page (re-)load.


### Notes

Also fixes issue with promise chaining behavior with ajax having changed, which swallowed the console error from turf.

Despite having version pinned for installed `@turf/point-on-line` npm package, it has relative dependencies that are not pinned, which resulted in the latest `@turf/helpers` being installed with the production build. Latest `helpers` broke usage by no longer casting strings for you when building a point. Pinning the relative dependencies would require modifying the gulp build process, since the install path would change. Since turf is about to come out with a new major version release (4.x), perhaps this is not worth the effort.


## Testing Instructions

 * Clear and re-install npm packages
 * Drag a route
 * Should update map and side panel on waypoint release
 * Should show trip with waypoint(s) on map and in sidepanel on page (re-)load


## Checklist
- [x] No gulp lint warnings
- [x] No python lint warnings
- [x] Python tests pass


Connects #830
