### PR TITLE
Extend geocoder search bounds to cover southern DE

### DIFF
--- a/src/app/scripts/cac/search/cac-search-params.js
+++ b/src/app/scripts/cac/search/cac-search-params.js
@@ -4,11 +4,12 @@
 CAC.Search.SearchParams = (function () {
     'use strict';
 
-    // bounds to cover are the counties here:
+    // bounds to cover are the counties of the DVRPC region, as shown here:
     // http://pecpa.org/wp-content/uploads/Recreation-The-Circuit-map-photo-Patrick-1260x979.jpg
+    // and also extended to cover the state of Delaware fully
     var searchExtent = [
         '-76.209582',
-        '39.467695',
+        '38.441753',
         '-74.243725',
         '40.725449'
     ].join(',');


### PR DESCRIPTION
Extend bounding box for geocoder search southward to cover all of the state of Delaware.
Previously limited to the DVRPC region. Matches new OSM extent for Delaware routing coverage.
