### PR TITLE
Bump OTP ansible role version

### DIFF
--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -5,7 +5,7 @@
   version: 0.2.6
 
 - src: azavea.opentripplanner
-  version: 1.0.4
+  version: 1.0.5
 
 - src: azavea.nginx
   version: 0.2.2


### PR DESCRIPTION
## Overview

Updates OTP version to 1.1.0 (from 1.0.0).
Also fixes outdated JVM package version.


### Notes

Trivial; merging for deploy.
