### PR TITLE
Feature/kak/detail per mode summaries#852

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions-list.js
+++ b/src/app/scripts/cac/control/cac-control-directions-list.js
@@ -129,7 +129,11 @@ CAC.Control.DirectionsList = (function (_, $, ShareModal, MapTemplates) {
                 text: itinerary.toText,
                 time: itinerary.endTime
             },
-            legs: itinerary.legs
+            legs: itinerary.legs,
+            formattedDistance: itinerary.formattedDistance,
+            formattedDuration: itinerary.formattedDuration,
+            showSummaryModes: itinerary.showSummaryModes,
+            modeSummaries: itinerary.modeSummaries
         };
 
         return MapTemplates.itinerary(templateData);

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -315,6 +315,23 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                         '<div class="directions-time">at {{datetime data.end.time}}</div>',
                     '</div>',
                 '</div>',
+                // per-mode summary
+                '{{#if data.showSummaryModes}}',
+                '<div class="directions-mode-summary">',
+                    '<div class="mode-summary-header">',
+                        '<div>Travel time</div>',
+                        '<div>Distance</div>',
+                    '</div>',
+                    '{{#each data.modeSummaries}}<div class="mode-summary-item">',
+                        '<div class="{{modeClass @key}}"></div>',
+                        '<div>{{this.formattedDuration}}</div>',
+                        '<div>{{this.formattedDistance}}</div>',
+                    '</div>{{/each}}',
+                    '<div class="mode-summary-footer">',
+                        '<div>{{data.formattedDuration}}</div>',
+                        '<div>{{data.formattedDistance}}</div>',
+                    '</div>',
+                '</div>{{/if}}',
             '</div>'
         ].join('');
         var template = Handlebars.compile(source);

--- a/src/app/styles/components/_directions-step-by-step.scss
+++ b/src/app/styles/components/_directions-step-by-step.scss
@@ -130,6 +130,31 @@
             }
         }
     }
+
+    .directions-mode-summary {
+
+        display: flex;
+        font-weight: $font-weight-medium;
+        overflow: hidden;
+
+        padding: 13px 0 13px 43px;
+        border-top: 1px solid #ddd;
+        background: $v-lt-gray;
+
+        font-family: gpg;
+
+        .mode-summary-header {
+            font-weight: $font-weight-bold;
+        }
+
+        .mode-summary-item {
+            font-weight: $font-weight-medium;
+        }
+
+        .mode-summary-footer {
+            font-weight: $font-weight-bold;
+        }
+    }
 }
 
 .directions-instruction {


### PR DESCRIPTION
## Overview

Add per-mode trip summary block to bottom of directions list (detail view).


### Demo

![image](https://user-images.githubusercontent.com/960264/27806986-e49ff536-600b-11e7-92cd-6b90378c3ee2.png)


### Notes

Will need styling work; flex display showing in columns content that should be in rows.

Note that due to transit wait times, totals may be greater that the sum of the per-mode results. Also, very short distances by a mode are hidden from the summaries.

## Testing Instructions

 * Trip detail summary information should match that on itinerary list summary
 * Should only display if more than one mode in summary


Closes #852
