### PR TITLE
Fix mode picker layout

### DIFF
--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -83,7 +83,7 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
 
         moment.updateLocale('en', {
             relativeTime : {
-                mm: "%d min",
+                mm: '%d min',
             }
         });
 

--- a/src/app/styles/components/_directions-form.scss
+++ b/src/app/styles/components/_directions-form.scss
@@ -74,10 +74,11 @@
 
     .mode-picker {
         display: flex;
-        flex: 0 0 60px;
+        flex: none;
         flex-flow: row nowrap;
         align-items: center;
-        justify-content: center;
+        justify-content: flex-start;
+        height: 60px;
         margin-bottom: 10px;
         color: $mode-picker-text-color;
         font-size: 1.4rem;
@@ -85,76 +86,56 @@
         line-height: 3rem;
         text-transform: uppercase;
 
-        @include respond-to('xxs') {
-            justify-content: flex-end;
-            margin-right: 5px;
+        .body-home & {
+            @include respond-to('xxs') {
+                font-size: 1.3rem;
+            }
+
+            @include respond-to('xxxs') {
+                .mode-label {
+                    display: none;
+                }
+            }
         }
-
-        @include respond-to('xxxs') {
-            // Labels wrap nastily on iPhone SE
-            flex-basis: 55px;
-            justify-content: center;
-            padding-top: 3px;
-            padding-left: 60px;
-
-            .mode-option {
-                padding-right: 0;
-                padding-left: 6px;
-            }
-
-            .mode-toggle .walk {
-                margin-right: 24px;
-            }
-
-            .mode-label {
-                display: none;
-            }
-        };
 
         .body-map & {
             flex-basis: 55px;
-            justify-content: flex-end;
+            justify-content: space-around;
             margin-right: -10px;
-            padding-top: 3px;
             padding-left: 60px;
 
             .mode-label {
                 display: none;
             }
+        }
+
+        .mode-label {
+            margin-left: .16em;
         }
 
         i {
             font-size: 2.2rem;
+
+            .body-home & {
+                @include respond-to('xxxs') {
+                    font-size: 2.5rem;
+                }
+            }
 
             .body-map & {
                 font-size: 2.5rem;
             }
 
             &::before {
-                margin-right: .3em;
-                margin-left: 0;
                 line-height: 3rem;
-            }
-
-            &.icon-walk::before {
-                margin-right: .2em;
-
-                .body-map & {
-                    margin-right: 0;
-                }
             }
 
             &.icon-bike::before {
                 vertical-align: middle;
-
-                .body-map & {
-                    margin-right: 0;
-                }
             }
 
             &.icon-transit-on,
             &.icon-transit-off {
-
                 &::before {
                     width: 1.5em;
                     vertical-align: middle;
@@ -168,41 +149,54 @@
         flex-flow: row nowrap;
         align-items: center;
         justify-content: space-between;
-        margin-right: 80px;
+        margin-right: 60px;
+        margin-left: auto;
 
-        @include respond-to('xs') {
-            margin-right: 60px;
+        .body-home & {
+            @include respond-to('xxs') {
+                margin-right: 32px;
+            }
         }
 
         .body-map & {
-            margin-right: 50px;
-
-            @include respond-to('xxs') {
-                margin-right: 70px;
-            }
+            margin-right: 10px;
         }
 
         .mode-option.on {
             border-bottom-color: $mode-picker-text-color;
         }
 
-        .walk {
+        .mode-option:first-of-type {
             margin-right: 20px;
-        }
 
-        .bike {
+            .body-map & {
+                margin-right: 12px;
+            }
+
+            .body-home & {
+                @include respond-to('xxxs') {
+                    margin-right: 12px;
+                }
+            }
         }
     }
 
     .mode-option {
-        padding-right: .25em;
         border-top: 2px solid transparent;
         border-bottom: 2px solid transparent;
         cursor: pointer;
         opacity: .5;
 
         .body-map & {
-            padding-right: 0;
+            padding-right: 2px;
+            padding-left: 2px;
+        }
+
+        .body-home & {
+            @include respond-to('xxxs') {
+                padding-right: 2px;
+                padding-left: 2px;
+            }
         }
 
         &.on {
@@ -210,24 +204,28 @@
         }
     }
 
+    .mode-option.transit {
+        margin-right: auto;
+
+        .body-map & {
+            margin-right: 0;
+            margin-left: auto;
+        }
+    }
+
     .btn-options {
         display: flex;
+        flex: none;
         align-items: center;
         align-self: stretch;
         justify-content: center;
         width: 50px;
-        margin-top: -5px;
-        margin-left: 24px;
-        padding-top: 3px;
+        margin-left: auto;
         background-color: $gophillygo-blue-dark;
         cursor: pointer;
 
         i.icon-sliders {
             font-size: 2rem;
-        }
-
-        @include respond-to('xxs') {
-            margin-left: 40px;
         }
 
         i::before {


### PR DESCRIPTION
## Overview

Fix mode picker layout across browsers and devices, after a recent commit (probably https://github.com/azavea/cac-tripplanner/pull/859/commits/c06adc2bff28a272ee5b4e9e900d25e0c632c75f) mangled it on <320px screens.


### Demo

Current production at 320px:
![image](https://user-images.githubusercontent.com/128699/28628730-76996f1e-71f3-11e7-9928-97c82b163a7d.png)

This PR at 320px:
![image](https://user-images.githubusercontent.com/128699/28628757-8792403e-71f3-11e7-857a-520209841723.png)


### Notes

I ended up refactoring the SASS a fair amount. Could still be better, but it's an improvement. Looks fine at various widths across FF, IE, Edge, Chrome, Mobile Safari, Chrome Android.
