### PR TITLE
Add app manifest and service worker for a PWA

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.app/templates/nginx-default.j2
+++ b/deployment/ansible/roles/cac-tripplanner.app/templates/nginx-default.j2
@@ -31,6 +31,12 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+    # Set Cache-Control: no-cache header
+    # Does not disable browser caching;
+    # rather says to always check server to see if there is a new version.
+    # https://jakearchibald.com/2016/caching-best-practices/
+    expires -1;
+
     location / {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;

--- a/python/cac_tripplanner/cac_tripplanner/urls.py
+++ b/python/cac_tripplanner/cac_tripplanner/urls.py
@@ -14,6 +14,9 @@ urlpatterns = [
     url(r'^$', dest_views.home, name='home'),
     url(r'^explore$', dest_views.explore, name='explore'),
 
+    # App Manifest
+    url('^manifest.json$', dest_views.manifest),
+
     # Map
     url(r'^api/destinations/search$', dest_views.SearchDestinations.as_view(),
         name='api_destinations_search'),

--- a/python/cac_tripplanner/cac_tripplanner/urls.py
+++ b/python/cac_tripplanner/cac_tripplanner/urls.py
@@ -14,8 +14,9 @@ urlpatterns = [
     url(r'^$', dest_views.home, name='home'),
     url(r'^explore$', dest_views.explore, name='explore'),
 
-    # App Manifest
+    # App manifest and service worker for PWA app
     url('^manifest.json$', dest_views.manifest),
+    url('^service-worker.js$', dest_views.service_worker),
 
     # Map
     url(r'^api/destinations/search$', dest_views.SearchDestinations.as_view(),

--- a/python/cac_tripplanner/destinations/views.py
+++ b/python/cac_tripplanner/destinations/views.py
@@ -76,6 +76,14 @@ def directions(request):
     return base_view(request, 'directions.html', {})
 
 
+def manifest(request):
+    """Render the app manifest
+
+    https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/?utm_source=devtools
+    """
+    return render(request, 'manifest.json', {})
+
+
 def place_detail(request, pk):
     destination = get_object_or_404(Destination.objects.published(), pk=pk)
     more_destinations = Destination.objects.published().exclude(pk=destination.pk)[:3]

--- a/python/cac_tripplanner/destinations/views.py
+++ b/python/cac_tripplanner/destinations/views.py
@@ -77,11 +77,40 @@ def directions(request):
 
 
 def manifest(request):
-    """Render the app manifest
+    """Render the app manifest for a PWA app that can install to homescreen
 
     https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/?utm_source=devtools
     """
     return render(request, 'manifest.json', {})
+
+
+def service_worker(request):
+    """Render the service worker for a PWA app that can install to homescreen
+
+    https://developers.google.com/web/fundamentals/getting-started/primers/service-workers
+    """
+
+    # files to cache in either development or production
+    cache_files = [
+        '/',
+        '/static/styles/vendor.css',
+        '/static/styles/main.css'
+    ]
+
+    # additional files to cache in production
+    prod_cache_files = [
+        '/static/scripts/vendor.js',
+        '/static/scripts/main.js',
+        '/static/fontello/css/gpg.css'
+    ]
+
+    if not settings.DEBUG:
+        cache_files += prod_cache_files
+
+    return render(request,
+                  'service-worker.js',
+                  {'cache_files': json.dumps(cache_files)},
+                  content_type='application/javascript')
 
 
 def place_detail(request, pk):

--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0">
     <meta name="mobile-web-app-capable" content="yes">
+    <meta name="theme-color" content="#2e68a3">
 
     {% block pagetitle %}
     <title>{% block title %}GoPhillyGo | Trip Planning for Bikes, Public Transit, and Walking | Clean Air Council{% endblock %}</title>

--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -35,6 +35,8 @@
     <meta name="twitter:image" content="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}/static/images/logo_blue.png" />
     {% endblock %}
 
+    {% include "partials/ios-weblinks.html" %}
+
     {% block cssimports %}
 
     <link href="{% static 'styles/vendor.css' %}" rel="stylesheet">

--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -6,13 +6,16 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0">
     <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="theme-color" content="#2e68a3">
+    <meta name="apple-mobile-web-app-status-bar-style" content="#2e68a3">
 
     {% block pagetitle %}
     <title>{% block title %}GoPhillyGo | Trip Planning for Bikes, Public Transit, and Walking | Clean Air Council{% endblock %}</title>
 
     <meta property="og:title" content="GoPhillyGo" />
     <meta name="twitter:title" content="GoPhillyGo" />
+    <meta name="apple-mobile-web-app-title" content="GoPhillyGo">
     {% endblock %}
 
     {% block extrametatags %}

--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0">
+    <meta name="mobile-web-app-capable" content="yes">
 
     {% block pagetitle %}
     <title>{% block title %}GoPhillyGo | Trip Planning for Bikes, Public Transit, and Walking | Clean Air Council{% endblock %}</title>

--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -44,6 +44,7 @@
 	<link rel="apple-touch-icon" sizes="76x76" href="{% static 'images/apple-touch-icon-76x76.png' %}" />
 	<link rel="apple-touch-icon" sizes="152x152" href="{% static 'images/apple-touch-icon-152x152.png' %}" />
 	<link rel="icon" type="image/png" href="{% static 'images/favicon.png' %}" sizes="32x32" />
+    <link rel="manifest" href="/manifest.json">
 
     {% endblock %}
 

--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -11,8 +11,8 @@
     {% block pagetitle %}
     <title>{% block title %}GoPhillyGo | Trip Planning for Bikes, Public Transit, and Walking | Clean Air Council{% endblock %}</title>
 
-    <meta property="og:title" content="GoPhillyGo Trip Planner" />
-    <meta name="twitter:title" content="GoPhillyGo Trip Planner" />
+    <meta property="og:title" content="GoPhillyGo" />
+    <meta name="twitter:title" content="GoPhillyGo" />
     {% endblock %}
 
     {% block extrametatags %}
@@ -20,7 +20,7 @@
     <meta property="og:url"
     content="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}" />
     <meta property="og:description"
-        content="CAC Trip Planner, for planning transit, walking, and biking trips around the Delaware Valley region.  Features parks and other destinations." />
+        content="GoPhillyGo from the Clean Air Council, for planning transit, walking, and biking trips around the Delaware Valley region.  Features parks and other destinations." />
     <meta property="og:image" content="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}/static/images/logo_blue.png" />
     <meta property="og:image:width" content="332" />
     <meta property="og:image:height" content="314" />

--- a/python/cac_tripplanner/templates/manifest.json
+++ b/python/cac_tripplanner/templates/manifest.json
@@ -1,0 +1,79 @@
+{
+  "short_name": "GoPhillyGo",
+  "name": "GoPhillyGo Trip Planner",
+  "icons": [
+    {
+      "src": "/static/images/apple-touch-icon-57x57.png",
+      "type": "image/png",
+      "sizes": "57x57"
+    },
+    {
+      "src": "/static/images/apple-touch-icon-60x60.png",
+      "type": "image/png",
+      "sizes": "60x60"
+    },
+    {
+      "src": "/static/images/apple-touch-icon-57x57.png",
+      "type": "image/png",
+      "sizes": "57x57"
+    },
+    {
+      "src": "/static/images/apple-touch-icon-72x72.png",
+      "type": "image/png",
+      "sizes": "72x72"
+    },
+    {
+      "src": "/static/images/apple-touch-icon-76x76.png",
+      "type": "image/png",
+      "sizes": "76x76"
+    },
+    {
+      "src": "/static/images/apple-touch-icon-114x114.png",
+      "type": "image/png",
+      "sizes": "114x114"
+    },
+    {
+      "src": "/static/images/apple-touch-icon-120x120.png",
+      "type": "image/png",
+      "sizes": "120x120"
+    },
+    {
+      "src": "/static/images/apple-touch-icon-144x144.png",
+      "type": "image/png",
+      "sizes": "144x144"
+    },
+    {
+      "src": "/static/images/apple-touch-icon-152x152.png",
+      "type": "image/png",
+      "sizes": "152x152"
+    },
+    {
+      "src": "/static/images/logo-blue.png",
+      "type": "image/png",
+      "sizes": "50x50"
+    },
+    {
+      "src": "/static/images/logo-blue@2x.png",
+      "type": "image/png",
+      "sizes": "100x100"
+    },
+    {
+      "src": "/static/images/logo.png",
+      "type": "image/png",
+      "sizes": "180x180"
+    },
+    {
+      "src": "/static/images/logo@2x.png",
+      "type": "image/png",
+      "sizes": "360x360"
+    },
+    {
+      "src": "/static/images/favicon.png",
+      "type": "image/png",
+      "sizes": "32x32"
+    }
+
+  ],
+  "start_url": "?launcher=true",
+  "display": "standalone"
+}

--- a/python/cac_tripplanner/templates/manifest.json
+++ b/python/cac_tripplanner/templates/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "GoPhillyGo",
-  "name": "GoPhillyGo Trip Planner",
+  "name": "GoPhillyGo",
   "icons": [
     {
       "src": "/static/images/apple-touch-icon-57x57.png",

--- a/python/cac_tripplanner/templates/manifest.json
+++ b/python/cac_tripplanner/templates/manifest.json
@@ -74,6 +74,8 @@
     }
 
   ],
-  "start_url": "?launcher=true",
-  "display": "standalone"
+  "start_url": "/?launcher=true",
+  "display": "standalone",
+  "background_color": "#245280",
+  "theme_color": "#2e68a3"
 }

--- a/python/cac_tripplanner/templates/partials/ios-weblinks.html
+++ b/python/cac_tripplanner/templates/partials/ios-weblinks.html
@@ -1,0 +1,5 @@
+<script type="text/javascript" charset="utf-8">
+// Keep iOS in standalone mode when following links
+// https://gist.github.com/irae/1042167
+(function(a,b,c){if(c in b&&b[c]){var d,e=a.location,f=/^(a|html)$/i;a.addEventListener("click",function(a){d=a.target;while(!f.test(d.nodeName))d=d.parentNode;"href"in d&&(chref=d.href).replace(e.href,"").indexOf("#")&&(!/^[a-z\+\.\-]+:/i.test(chref)||chref.indexOf(e.protocol+"//"+e.host)===0)&&(a.preventDefault(),e.href=d.href)},!1)}})(document,window.navigator,"standalone");
+</script>

--- a/python/cac_tripplanner/templates/service-worker.js
+++ b/python/cac_tripplanner/templates/service-worker.js
@@ -1,0 +1,57 @@
+// Service Worker to support functioning as a PWA
+// https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
+
+var CACHE_NAME = 'cac_tripplanner_v1';
+
+var cacheFiles = {{ cache_files | safe }};
+
+/**
+ * Handle service worker registration on first load
+ */
+self.addEventListener('install', function(event) {
+    event.waitUntil(
+        caches.open(CACHE_NAME).then(function(cache) {
+            return cache.addAll(cacheFiles);
+    }));
+});
+
+/**
+ * Handle service worker requests, fetching from cache if already cached,
+ * or putting in cache if it's hosted on this domain.
+ */
+self.addEventListener('fetch', function(event) {
+    event.respondWith(caches.match(event.request).then(function(response) {
+        // caches.match() always resolves
+        // but in case of success response will have value
+        if (response !== undefined) {
+            return response;
+        } else {
+            return fetch(event.request).then(function (response) {
+                // cache fetched request if it is on this domain
+                if (request.url.startsWith(location.href)) {
+                    var responseClone = response.clone();
+                    caches.open(CACHE_NAME).then(function (cache) {
+                        cache.put(event.request, responseClone);
+                    });
+                }
+                return response;
+            }).catch(function () {
+                return fetch(event.request);
+            });
+        }
+    }));
+});
+
+self.addEventListener('activate', function(e) {
+    e.waitUntil(
+        caches.keys().then(function(keyList) {
+            return Promise.all(keyList.map(function(key) {
+            if (key !== CACHE_NAME) {
+                return caches.delete(key);
+            }
+        }));
+        })
+    );
+    return self.clients.claim();
+});
+

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -86,6 +86,7 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
         Utils.initializeMoment();
         showHideNeedWheelsBanner();
         _setupEvents();
+        setupServiceWorker();
     };
 
     return Home;
@@ -486,6 +487,24 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
         $(options.selectors.needWheelsBanner).addClass(options.selectors.hiddenClass);
         // show trip options instead, if applicable
         updateTripOptionsBanner();
+    }
+
+    /**
+     * Set up a service worker to make this a PWA app.
+     * Necessary to support 'add to homescreen' with the app manifest.json.
+     * Service worker is defined in Django template.
+     */
+    function setupServiceWorker() {
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', function() {
+                navigator.serviceWorker.register('/service-worker.js').then(function() {
+                    // success. worker scoped here to domain.
+                }, function(err) {
+                    // registration failed
+                    console.error('ServiceWorker registration failed: ', err);
+                });
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
## Overview

Adds an app manifest and service worker to support 'add to home screen', making the site behave similar to a native app. The service worker caches some assets offline. Also added a no-cache header to nginx. (It's a misnomer. It allows caching, but says to always check for a new file version before using the cached one.)


### Demo

#### Testing on BrowserStack with a Nexus 6 and Chrome:

On first page load in browser, an 'add to homescreen' modal pops up at the bottom of the screen.
![cac_nexus_browserstack](https://user-images.githubusercontent.com/960264/28737114-0fa503e4-73bb-11e7-9fb2-5039e8444f12.png)

Home screen after adding:
![cac_nexus_homescreen_browserstack](https://user-images.githubusercontent.com/960264/28737168-3efe9a38-73bb-11e7-8b26-6cf2e2eaf80d.png)

On first launch, it take a second to load, so Chrome shows a splash screen using the background color:
![cac_nexus_loading_screen](https://user-images.githubusercontent.com/960264/28737193-59dd6fa0-73bb-11e7-9fb6-a20e55d0beab.png)

After it's loaded, there's no URL bar. The app is fullscreen.
![cac_nexus6_loaded_fullscreen](https://user-images.githubusercontent.com/960264/28737210-6ff1ef14-73bb-11e7-9f79-eb70c981d031.png)

The 'add to desktop' prompt on Chrome/Windows (can override a couple of options).
![cac_add_to_desktop_prompt_chrome_win](https://user-images.githubusercontent.com/960264/28737266-b2a807bc-73bb-11e7-9401-e41b49589a13.png)

When in non-debug mode, the service worker will explicitly cache JS files as well as the home page and CSS. (Not caching JS in dev mode as there are a lot of files, and we don't need to.)
![cac_production_build_service_worker_cache](https://user-images.githubusercontent.com/960264/28737295-da98d846-73bb-11e7-92c5-b52da2b7dc51.png)

What happens when loaded without a network connection, in dev mode, as a demo of service worker caching actually functioning. The service worker's explicitly cached files are still available, and something loads. As this app won't work offline anyways, probably okay that this looks broken.
![cac_cached_pwa_no_network](https://user-images.githubusercontent.com/960264/28737383-3d7895e6-73bc-11e7-87a8-164f0498d936.png)



### Notes

Couldn't test on Mac or iOS, as BrowserStack doesn't support local domains those platforms.

Information on the manifest and service workers can be seen under the Application tab in Chrome dev tools.

Added all of the square logo assets we have to the manifest, but there are better sizes to use. There's some documentation on those [here](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/?utm_source=devtools). The lighthouse PWA audit tool (under the Chrome dev tools 'Audits' tab) complains that the app needs some icons at least 512px. Over [here](https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android) they recommend 192px for Chrome/Android.

The colors in the manifest and theme meta tags are the blue and dark blue colors in the app.

A couple quirks in the Chrome dev tools: the 'Add to homescreen' link by the manifest info doesn't do anything, at least on my platform. The non-devtools methods do work, though (described below). Another is that it seemed often necessary to close and reopen dev tools for the service worker file list to update, under Application -> Cache Storage.


## Testing Instructions

 * Picking up the nginx configuration change will require reprovisioning the app server:
   `vagrant provision app`
 * Rebuild JS assets in the app vagrant VM: `cd /opt/app/src && npm run gulp-development`
 * Visit the home page at http://localhost:8024 (be sure site cache is clear)
 * There should be no console errors
 * Refresh page to trigger the service worker to fetch; should still be no console errors
 * 'Size' under Chrome dev tools network tab should show '(from ServiceWorker)' some assets
 * Add to desktop on Chrome under 'more tools' in the upper right three grey dots menu
 * Should be a GoPhillyGo icon added to desktop that's capable of opening site in new window


Closes #865
