### PR TITLE
Show destination marker when no origin

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -100,7 +100,9 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Te
             directionsFormControl.setError('origin');
             directionsFormControl.setError('destination');
 
-            updateUrl();  // Still update the URL if they request one-sided directions
+            // Still update the URL and show marker if they request one-sided directions
+            updateUrl();
+            mapControl.setDirectionsMarkers(directions.origin, directions.destination, true);
             return;
         }
 
@@ -400,7 +402,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Te
             directions.destination = [destination.location.y, destination.location.x ];
         }
 
-        if (origin && destination && tabControl.isTabShowing(tabControl.TABS.DIRECTIONS)) {
+        if (tabControl.isTabShowing(tabControl.TABS.DIRECTIONS) && (origin || destination)) {
             planTrip();
         }
     }

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -256,7 +256,6 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
      * @param {Boolean} [zoomToFit] Zoom the view to the marker(s)
      */
     function setDirectionsMarkers(originCoords, destinationCoords, zoomToFit) {
-
         // helper for when origin/destination dragged to new place
         function markerDrag(event) {
             var marker = event.target;


### PR DESCRIPTION
Show and zoom to fit destination marker on map when origin is not present.
Closes #834.

### Demo

![image](https://user-images.githubusercontent.com/960264/28784167-9778dce2-75e0-11e7-93d4-2dd14503b1d9.png)


## Testing Instructions

 * Click 'directions' on a place card on the home page without setting an origin
 * Destination marker should show on map


