### PR TITLE
Add current location marker on mobile

### DIFF
--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -5,6 +5,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         id: 'map',
         selectors: {
             id: '#map',
+            isMobile: false,
             leafletMinimizer: '.leaflet-minimize',
             leafletLayerList: '.leaflet-control-layers-list',
             leafletLayerControl: '.leaflet-control-layers',
@@ -15,6 +16,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
     };
 
     var map = null;
+    var currentLocationMarker = null;
     var geocodeMarker = null;
     var directionsMarkers = {
         origin: null,
@@ -123,7 +125,11 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         tabControl = this.options.tabControl;
 
         // put zoom control on top right
-        zoomControl = new cartodb.L.Control.Zoom({ position: 'topright', zoomInText: '<i class="icon-plus"></i>', zoomOutText: '<i class="icon-minus"></i>' });
+        zoomControl = new cartodb.L.Control.Zoom({
+            position: 'topright',
+            zoomInText: '<i class="icon-plus"></i>',
+            zoomOutText: '<i class="icon-minus"></i>'
+        });
 
         initializeBasemaps();
 
@@ -135,6 +141,11 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
                                         function(event, place) {
                                             events.trigger(eventNames.destinationPopupClick, place);
                                         });
+
+        if (this.options.isMobile) {
+            showCurrentLocation();
+        }
+
         mapLoaded = true;
     }
 
@@ -349,6 +360,9 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
             zoomControl.addTo(map);
             initializeOverlays();
             initializeLayerControl.apply(this, null);
+            if (currentLocationMarker) {
+                currentLocationMarker.addTo(map);
+            }
             componentsLoaded = true;
         }
     }
@@ -361,6 +375,9 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         }
         if (layerControl) {
             layerControl.removeFrom(map);
+        }
+        if (currentLocationMarker) {
+            map.removeLayer(currentLocationMarker);
         }
 
         map.removeLayer(overlays['Bike Share Locations']);
@@ -399,6 +416,34 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
             map.removeLayer(lastDisplayPointMarker);
             lastDisplayPointMarker = null;
         }
+    }
+
+    /**
+     * Track user location with map marker.
+     */
+    function showCurrentLocation() {
+        map.locate({
+            watch: true,
+            enableHighAccuracy: true,
+            maximumAge: 3000 // use cached location up to 3 seconds
+        });
+
+        map.on('locationfound', function(event) {
+            if (!currentLocationMarker) {
+                currentLocationMarker = new cartodb.L.circleMarker(event.latlng, 4);
+            } else {
+                currentLocationMarker.setLatLng(event.latlng);
+            }
+        });
+
+        map.on('locationerror', function(error) {
+            console.error('could not get user location:');
+            console.error(error);
+
+            if (currentLocationMarker) {
+                map.removeLayer(currentLocationMarker);
+            }
+        });
     }
 
 })(jQuery, Handlebars, cartodb, L, turf, _);

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -434,6 +434,10 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
             } else {
                 currentLocationMarker.setLatLng(event.latlng);
             }
+
+            if (map && componentsLoaded) {
+                currentLocationMarker.addTo(map);
+            }
         });
 
         map.on('locationerror', function(error) {

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -59,7 +59,8 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
         });
 
         mapControl = new MapControl({
-            tabControl: tabControl
+            tabControl: tabControl,
+            isMobile: $(window).width() < MD_UP_BREAKPOINT
         });
 
         modeOptionsControl = new ModeOptions();


### PR DESCRIPTION
Use breakpoint for mobile detection, as HTML5 does not support detecting if GPS geolocation is supported.
Use Leaflet `locate` to watch user location.

Closes #848.

### Demo

![image](https://user-images.githubusercontent.com/960264/28788912-d8a32dc0-75f0-11e7-9a4a-b2df2154e013.png)


### Notes

Since HTML5 feature support detection does not allow for finding out if GPS is present or not, instead use screen width for mobile device detection.


## Testing Instructions

 * Rebuild JS in app VM with `cd /opt/app/src && npm run gulp-development`
 * Resize browser to width < 992 px
 * Visit home page at http://localhost:8024/, location marker should *not* show
 * Go to map page for directions or explore page; location marker should now show
 * Should be able to navigate back and forth between home and map pages with expected behavior
