### PR TITLE
Feature/kak/display travel times with minutes#836

### DIFF
--- a/src/app/scripts/cac/pages/cac-pages-directions.js
+++ b/src/app/scripts/cac/pages/cac-pages-directions.js
@@ -1,4 +1,4 @@
-CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings) {
+CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings, Utils) {
     'use strict';
 
     var center = [39.95, -75.1667];
@@ -24,11 +24,7 @@ CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings) {
 
     Directions.prototype.initialize = function () {
 
-        moment.updateLocale('en', {
-            relativeTime : {
-                mm: '%d min',
-            }
-        });
+        Utils.initializeMoment();
 
         // Note: date/time does not get passed and so always defaults to departing now
 
@@ -162,4 +158,4 @@ CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings) {
 
     return Directions;
 
-})(jQuery, _, CAC.Control.DirectionsList, CAC.Routing.Itinerary, CAC.Settings);
+})(jQuery, _, CAC.Control.DirectionsList, CAC.Routing.Itinerary, CAC.Settings, CAC.Utils);

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -87,6 +87,11 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
             }
         });
 
+        // Do not round to hour or day. Default is to round at 45 min/22 hours
+        // https://momentjs.com/docs/#/customization/relative-time-threshold/
+        moment.relativeTimeThreshold('m', 60);
+        moment.relativeTimeThreshold('h', 24);
+
         showHideNeedWheelsBanner();
 
         _setupEvents();

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -1,5 +1,5 @@
 CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchParams, TabControl,
-                            UserPreferences, UrlRouter) {
+                            UserPreferences, UrlRouter, Utils) {
     'use strict';
 
     // this needs to match the value in styles/utils/_breakpoints.scss
@@ -81,19 +81,9 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
             urlRouter: urlRouter
         });
 
-        moment.updateLocale('en', {
-            relativeTime : {
-                mm: '%d min',
-            }
-        });
 
-        // Do not round to hour or day. Default is to round at 45 min/22 hours
-        // https://momentjs.com/docs/#/customization/relative-time-threshold/
-        moment.relativeTimeThreshold('m', 60);
-        moment.relativeTimeThreshold('h', 24);
-
+        Utils.initializeMoment();
         showHideNeedWheelsBanner();
-
         _setupEvents();
     };
 
@@ -511,4 +501,4 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
     }
 
 })(jQuery, CAC.Control.ModeOptions, CAC.Map.Control, CAC.Control.TripOptions, CAC.Search.SearchParams,
-    CAC.Control.Tab, CAC.User.Preferences, CAC.UrlRouting.UrlRouter);
+    CAC.Control.Tab, CAC.User.Preferences, CAC.UrlRouting.UrlRouter, CAC.Utils);

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -187,9 +187,8 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
         var hours = duration.hours();
         var minutes = duration.minutes();
         if (hours > 0 && minutes > 0 && duration.days() < 1) {
-            var hoursDuration = moment.duration(hours, 'hours');
             var minutesDuration = moment.duration(minutes, 'minutes');
-            return hoursDuration.humanize() + ', ' + minutesDuration.humanize();
+            return hours + ' h ' + minutesDuration.humanize();
         }
 
         return duration.humanize();

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -179,8 +179,20 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
      * @param {object} duration Duration in seconds, as on OTP itinerary or leg
      * @return {string} duration of itinerary/leg, formatted with units (hrs, min, s)
      */
-    function getFormattedDuration(duration) {
-        return moment.duration(duration, 'seconds').humanize();
+    function getFormattedDuration(seconds) {
+        var duration = moment.duration(seconds, 'seconds');
+
+        // For durations less than a day and greater than an hour, format to display both
+        // hours and minutes.
+        var hours = duration.hours();
+        var minutes = duration.minutes();
+        if (hours > 0 && minutes > 0 && duration.days() < 1) {
+            var hoursDuration = moment.duration(hours, 'hours');
+            var minutesDuration = moment.duration(minutes, 'minutes');
+            return hoursDuration.humanize() + ', ' + minutesDuration.humanize();
+        }
+
+        return duration.humanize();
     }
 
     /**

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -184,11 +184,8 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
 
         // For durations less than a day and greater than an hour, format to display both
         // hours and minutes.
-        var hours = duration.hours();
-        var minutes = duration.minutes();
-        if (hours > 0 && minutes > 0 && duration.days() < 1) {
-            var minutesDuration = moment.duration(minutes, 'minutes');
-            return hours + ' h ' + minutesDuration.humanize();
+        if (duration.hours() > 0 && duration.minutes() > 0 && duration.days() < 1) {
+            return duration.hours() + 'h ' + duration.minutes() + 'm';
         }
 
         return duration.humanize();

--- a/src/app/scripts/cac/utils.js
+++ b/src/app/scripts/cac/utils.js
@@ -281,9 +281,16 @@ CAC.Utils = (function (_, moment) {
      * Customize moment library. Should be called once, on app initialization.
      */
     function initializeMoment() {
+        // Override time duration formatting strings
+        // https://momentjs.com/docs/#/customization/relative-time/
         moment.updateLocale('en', {
             relativeTime : {
+                s: '%d sec',
+                ss: '%d sec',
+                m: '%d min',
                 mm: '%d min',
+                h:  '1 hour',
+                hh: '%d hours'
             }
         });
 

--- a/src/app/scripts/cac/utils.js
+++ b/src/app/scripts/cac/utils.js
@@ -1,4 +1,4 @@
-CAC.Utils = (function (_) {
+CAC.Utils = (function (_, moment) {
     'use strict';
 
     var directions = {
@@ -110,7 +110,8 @@ CAC.Utils = (function (_) {
         getUrlParams: getUrlParams,
         encodeUrlParams: encodeUrlParams,
         getModeColor: getModeColor,
-        modeStringHelper: modeStringHelper
+        modeStringHelper: modeStringHelper,
+        initializeMoment: initializeMoment
     };
 
     return Object.freeze(module);
@@ -276,4 +277,20 @@ CAC.Utils = (function (_) {
         return modeStr;
     }
 
-})(_);
+    /**
+     * Customize moment library. Should be called once, on app initialization.
+     */
+    function initializeMoment() {
+        moment.updateLocale('en', {
+            relativeTime : {
+                mm: '%d min',
+            }
+        });
+
+        // Do not round to hour or day. Default is to round at 45 min/22 hours
+        // https://momentjs.com/docs/#/customization/relative-time-threshold/
+        moment.relativeTimeThreshold('m', 60);
+        moment.relativeTimeThreshold('h', 24);
+    }
+
+})(_, moment);


### PR DESCRIPTION
## Overview

Display travel durations greater than an hour with minutes. Default moment `humanize` behavior is to round to the largest unit.

### Demo

![image](https://user-images.githubusercontent.com/960264/28793898-8737c6a0-7602-11e7-846f-16606f0d984a.png)


### Notes

Related feature request is at moment/moment#348.

Can cause text wrap in the trip summary:
![image](https://user-images.githubusercontent.com/960264/28793550-4c6e5ea4-7601-11e7-8f8d-65eaed98b7b2.png)



## Testing Instructions

 * `cd /opt/app/src && npm run gulp-development`
 * Set origin on home page at http://localhost:8024
 * Wait for the place cards to populate the travel times
 * Travel times over an hour should also display minutes
 * Minutes should no longer round up to hours over 45 minutes
 * Check times on map page itinerary list and detail as well


Closes #836 
