### PR TITLE
Use just street address on place cards

### DIFF
--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -394,6 +394,11 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
         var date = UserPreferences.getPreference('dateTime');
         date = date ? moment.unix(date) : moment(); // default to now
 
+        // prefer to label with just the street address, and fall back to full address
+        var origin = UserPreferences.getPreference('origin');
+        var originLabel = origin.attributes && origin.attributes.StAddr ? origin.attributes.StAddr :
+            UserPreferences.getPreference('originText');
+
         var $placeCards = $(options.selectors.placeCard);
         $placeCards.each(function() {
             var $card = $(this);
@@ -402,10 +407,6 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
             var xCoord = $card.attr(options.selectors.placeAttrX);
             var yCoord = $card.attr(options.selectors.placeAttrY);
             var placeCoords = [yCoord, xCoord];
-
-            // origin text has not been updated on URL, so fromText not set on itineraries
-            // get it from user preferences instead
-            var originLabel = UserPreferences.getPreference('originText');
 
             // get travel time to destination and update place card
             Routing.planTrip(exploreLatLng, placeCoords, date, otpOptions)

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -395,9 +395,11 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
         date = date ? moment.unix(date) : moment(); // default to now
 
         // prefer to label with just the street address, and fall back to full address
+        // for featured places, use the label in the 'name' attribute instead of the address
         var origin = UserPreferences.getPreference('origin');
-        var originLabel = origin.attributes && origin.attributes.StAddr ? origin.attributes.StAddr :
-            UserPreferences.getPreference('originText');
+        var originLabel = origin.name ? origin.name :
+            (origin.attributes && origin.attributes.StAddr ? origin.attributes.StAddr :
+            UserPreferences.getPreference('originText'));
 
         var $placeCards = $(options.selectors.placeCard);
         $placeCards.each(function() {


### PR DESCRIPTION
## Overview

When adding travel times from origin to place cards on home page, show just the street address.
Closes #872.

### Demo

![image](https://user-images.githubusercontent.com/960264/29032713-7668a66a-7b60-11e7-942f-a8fdc713a754.png)


## Testing Instructions

 * Set an origin address on the home page form and wait for the place card travel times to populate
 * The "x min from y" text on the place cards should only show the origin street address

