### PR TITLE
Fix #881 Double scrollbars

### DIFF
--- a/src/app/styles/base/_base.scss
+++ b/src/app/styles/base/_base.scss
@@ -15,8 +15,7 @@ html {
 body {
     position: relative;
     width: 100%;
-    height: 100%;
+    min-height: 100%;
     background-color: $body-color;
-    overflow-y: scroll;
     -webkit-overflow-scrolling: touch;
 }

--- a/src/app/styles/layouts/_info.scss
+++ b/src/app/styles/layouts/_info.scss
@@ -1,16 +1,20 @@
 .body-info, .body-explore, .body-about {
-    display: flex;
-    flex-flow: column nowrap;
-    align-items: stretch;
-    justify-content: flex-start;
+    display: block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
     width: 100%;
-    min-height: 100%;
+    height: 100%;
+    max-height: 100%;
     background-color: $body-color;
     overflow-x: hidden;
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
 
     .main {
-        flex: auto;
-        align-self: center;
+        display: block;
         max-width: $home-main-max-width;
         margin: 0 auto 10rem;
 


### PR DESCRIPTION
## Overview

Revisiting the layout SASS for info pages to get rid of recently introduced double scrollbars.

Appears to work across all main browsers on Windows, Mac, iOS (9 & 10), and Android (7).

@flibbertigibbet Can you double check on Linux Chrome, since that's where you first found it?

