### PR TITLE
Add arrows to to/within toggle

### DIFF
--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -184,7 +184,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                         // .back and .getdirections are used to select these elements for the click event
                         '<div class="col-sm-6"><a class="back btn btn-primary btn-block hidden-xs">Back</a></div>',
                         '<div class="col-sm-6"><a class="getdirections btn btn-primary btn-block">',
-                            'Get Directions</a></div>',
+                            'Get directions</a></div>',
                     '</div>',
                 '</div>',
             '</div>'

--- a/src/app/styles/components/_directions-form.scss
+++ b/src/app/styles/components/_directions-form.scss
@@ -260,16 +260,23 @@
 
                 &.directions-tab-button label {
                     position: relative;
+                    padding-right: 2rem;
                     background-color: $gophillygo-blue-dark;
                     cursor: pointer;
-                }
 
-                &.directions-to label {
-                    padding-right: .5rem;
-                }
-
-                &.isochrone-control label {
-                    padding-right: 1rem;
+                    &:after {
+                        position: absolute;
+                        right: 4px;
+                        width: 20px;
+                        margin: 0;
+                        padding: 0;
+                        color: inherit;
+                        font-family: gpg;
+                        font-size: .7em;
+                        line-height: 30px;
+                        text-align: right;
+                        content: '\e813';
+                    }
                 }
             }
 


### PR DESCRIPTION
## Overview

This PR adds an up/down arrows icon to the To/Within toggle button in desktop map view, to make the toggle functionality more discoverable.

Also made an unrelated trivial copy adjustment to the infowindow.


### Demo

![image](https://user-images.githubusercontent.com/128699/29323434-e483ee76-81ae-11e7-9c33-ed1daf9814ab.png)

![image](https://user-images.githubusercontent.com/128699/29323422-dd7e3280-81ae-11e7-99eb-571aac27d895.png)


## Testing Instructions

 * Go to map view at **desktop** viewport width
 * Ensure up/down arrows are visible in both states of To/Within toggle
 * Go to map view at **mobile** viewport width
 * Ensure up/down arrows are **not** visible in "To" label

Connects #862 
