### PR TITLE
Change breakpoint for to/within toggle

### DIFF
--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -3,7 +3,7 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
     'use strict';
 
     // this needs to match the value in styles/utils/_breakpoints.scss
-    var MD_UP_BREAKPOINT = 992;
+    var XXS_BREAKPOINT = 480;
 
     var defaults = {
         selectors: {
@@ -60,7 +60,7 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
 
         mapControl = new MapControl({
             tabControl: tabControl,
-            isMobile: $(window).width() < MD_UP_BREAKPOINT
+            isMobile: $(window).width() < XXS_BREAKPOINT
         });
 
         modeOptionsControl = new ModeOptions();
@@ -168,7 +168,7 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
 
             // only allow explore mode on desktop and only respond to label in map view
             if (tabControl.isTabShowing(tabControl.TABS.HOME) ||
-                $(window).width() < MD_UP_BREAKPOINT) {
+                $(window).width() < XXS_BREAKPOINT) {
 
                 return;
             }

--- a/src/app/styles/utils/_breakpoints.scss
+++ b/src/app/styles/utils/_breakpoints.scss
@@ -3,6 +3,7 @@ $breakpoints: (
 
     // 'xxs' must match defaults.slick.responsive.breakpoint in cac-control-itinerary-list.js
     'xxs': (max-width: 480px),
+    // NB: if xxs breakpoint changes, must also update cac-pages-home.js XXS_BREAKPOINT
     'xxs-up': (min-width: 481px),
 
     'xs': (max-width: 767px),
@@ -12,7 +13,6 @@ $breakpoints: (
     'sm-down': (max-width: 991px),
 
     'md': "(min-width: 992px) and (max-width: 1200px)",
-    // NB: if md-up breakpoint changes, must also update cac-pages-home.js MD_UP_BREAKPOINT
     'md-up': (min-width: 992px),
     'md-down': (max-width: 1200px),
 


### PR DESCRIPTION
Closes #874.

Use narrower breakpoint for detecting mobile for the to/within and current location display.

## Testing Instructions

 * Browser view widths above 480 should respond to clicks on to/within toggle button
 * Narrower widths should not, but should show current location
