### PR TITLE
Do not use service worker to cache admin pages

### DIFF
--- a/python/cac_tripplanner/templates/service-worker.js
+++ b/python/cac_tripplanner/templates/service-worker.js
@@ -27,14 +27,10 @@ self.addEventListener('fetch', function(event) {
             return response;
         } else {
             return fetch(event.request).then(function (response) {
-                // Cache fetched request if it is on this domain,
-                // does not involve a routing request (has an origin),
-                // and does not require authentication credentials (cookies are not passed).
+                // Only cache static and media assets on this domain
                 var url = event.request.url;
                 if (url.startsWith(location.origin) &&
-                    !url.includes('origin=') &&
-                    !url.includes('/admin') &&
-                    event.request.method === 'GET') {
+                    (url.includes('/static') || url.includes('/media'))) {
 
                     var responseClone = response.clone();
                     caches.open(CACHE_NAME).then(function (cache) {

--- a/python/cac_tripplanner/templates/service-worker.js
+++ b/python/cac_tripplanner/templates/service-worker.js
@@ -1,7 +1,7 @@
 // Service Worker to support functioning as a PWA
 // https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
 
-var CACHE_NAME = 'cac_tripplanner_v1';
+var CACHE_NAME = 'cac_tripplanner_v2';
 
 var cacheFiles = {{ cache_files | safe }};
 
@@ -28,7 +28,7 @@ self.addEventListener('fetch', function(event) {
         } else {
             return fetch(event.request).then(function (response) {
                 // cache fetched request if it is on this domain
-                if (request.url.startsWith(location.href)) {
+                if (!location.href.includes('/admin') && request.url.startsWith(location.href)) {
                     var responseClone = response.clone();
                     caches.open(CACHE_NAME).then(function (cache) {
                         cache.put(event.request, responseClone);

--- a/python/cac_tripplanner/templates/service-worker.js
+++ b/python/cac_tripplanner/templates/service-worker.js
@@ -27,9 +27,15 @@ self.addEventListener('fetch', function(event) {
             return response;
         } else {
             return fetch(event.request).then(function (response) {
-                // cache fetched request if it is on this domain and does not require authentication
-                if (!event.request.url.includes('/admin') &&
-                        event.request.url.startsWith(location.origin)) {
+                // Cache fetched request if it is on this domain,
+                // does not involve a routing request (has an origin),
+                // and does not require authentication credentials (cookies are not passed).
+                var url = event.request.url;
+                if (url.startsWith(location.origin) &&
+                    !url.includes('origin=') &&
+                    !url.includes('/admin') &&
+                    event.request.method === 'GET') {
+
                     var responseClone = response.clone();
                     caches.open(CACHE_NAME).then(function (cache) {
                         cache.put(event.request, responseClone);
@@ -38,6 +44,7 @@ self.addEventListener('fetch', function(event) {
                 return response;
             }).catch(function (error) {
                 console.error(error);
+                console.error(event);
                 return fetch(event.request);
             });
         }

--- a/python/cac_tripplanner/templates/service-worker.js
+++ b/python/cac_tripplanner/templates/service-worker.js
@@ -27,15 +27,17 @@ self.addEventListener('fetch', function(event) {
             return response;
         } else {
             return fetch(event.request).then(function (response) {
-                // cache fetched request if it is on this domain
-                if (!location.href.includes('/admin') && request.url.startsWith(location.href)) {
+                // cache fetched request if it is on this domain and does not require authentication
+                if (!event.request.url.includes('/admin') &&
+                        event.request.url.startsWith(location.origin)) {
                     var responseClone = response.clone();
                     caches.open(CACHE_NAME).then(function (cache) {
                         cache.put(event.request, responseClone);
                     });
                 }
                 return response;
-            }).catch(function () {
+            }).catch(function (error) {
+                console.error(error);
                 return fetch(event.request);
             });
         }


### PR DESCRIPTION
## Overview

Service worker requests will not include credentials unless specifically requested in the fetch.
See `credentials` parameter discussion [here](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers).

However, including credentials for all fetch requests will cause some requests to fail, such as for third-party fonts. Instead exclude `admin` page requests (to the Django CMS app) from the cache, which require the CSRF token for form posts.

## Notes

Posting the failed request as a curl command copied from Chrome results in a 403 error regarding the CSRF token missing, although the posted form contains the expected CSRF hidden field with its value set. This led to finding that service worker `fetch` requests do not include cookies by default.

## Testing
 * can first reproduce issue on current `develop` branch by attempting to save anything in admin panel
 * in Chrome network tab, the admin form page loaded before failed save should show `(from ServiceWorker)` under `size` column
 * testing fix: now pull this branch
 * restart app: `vagrant ssh app -c "sudo service restart cac-tripplanner-app"`
 * clear browser cache under Application tab (remove service worker)
 * visit app home page to load new service worker and let it cache things
 * saving changes in admin panel should work
 * page requests to admin panel should no longer cache the page HTML via service worker


Fixes #887.
