### PR TITLE
Feature/kak/change bikeshare feed source#891

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -9,6 +9,9 @@ virtualenv_version: 15.1.0
 
 otp_router: "default"
 
+otp_version: "1.2.0"
+otp_jar_sha1: "a7f659a63a54e894457bab6fc162fb0f47586057"
+
 # used by nginx and gunicorn to set timeouts; OTP defaults to 30s
 otp_session_timeout_s: 30
 

--- a/deployment/ansible/group_vars/development_template
+++ b/deployment/ansible/group_vars/development_template
@@ -24,6 +24,3 @@ use_s3_storage: false
 default_admin_username: 'admin'
 default_admin_password: 'admin'
 default_admin_email: 'systems+cac@azavea.com'
-
-# for bike share directions
-bcycle_api_key: ''

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
-bikeshare_update_interval_s: 500
-bikeshare_update_network_name: 'Indego'
-bikeshare_update_url: 'https://publicapi.bcycle.com/api/1.0/ListProgramKiosks/3'
+bikeshare_update_interval_s: 120
+bikeshare_update_url: 'https://gbfs.bcycle.com/bcycle_indego/'

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
@@ -44,13 +44,6 @@
 
 - name: Copy Router Configuration to Graph Directory
   template: src=router-config.json.j2 dest={{ otp_data_dir }}/{{ otp_router }}/router-config.json
-  when: not(
-          (bcycle_api_key is undefined)
-          or
-          (bcycle_api_key is none)
-          or
-          (bcycle_api_key | trim == '')
-        )
 
 - name: Move Graph to Graph Directory (test/develop)
   command: mv {{ otp_data_dir }}/Graph.obj {{ otp_data_dir }}/{{ otp_router }}

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/templates/router-config.json.j2
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/templates/router-config.json.j2
@@ -3,10 +3,8 @@
         {
             type: "bike-rental",
             frequencySec: {{ bikeshare_update_interval_s}},
-            network: "{{ bikeshare_update_network_name }}",
-            sourceType: "b-cycle",
-            url: "{{ bikeshare_update_url }}",
-            apiKey: "{{ bcycle_api_key }}"
+            sourceType: "gbfs",
+            url: "{{ bikeshare_update_url }}"
         }
     ]
 }

--- a/python/cac_tripplanner/cac_tripplanner/settings.py
+++ b/python/cac_tripplanner/cac_tripplanner/settings.py
@@ -14,7 +14,6 @@ from django.core.exceptions import ImproperlyConfigured
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 import yaml
-import logging.config
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 try:


### PR DESCRIPTION
## Overview

Fix bike share routing by switching the feed source. The official BCycle feed we had been using now returns 500 errors.

Also bumps the OpenTripPlanner version in use (not necessary for the bike feed change).


### Demo

Bike share routing working again:
![image](https://user-images.githubusercontent.com/960264/30763409-0ace4dc4-9fb4-11e7-979e-e3a3b0d28231.png)


### Notes

New source is listed in the new General Bike Share Feed Specification, and wasn't available when this feature was first implemented. OpenTripPlanner GBFS-related documentation is at the bottom of [this page](http://docs.opentripplanner.org/en/latest/Configuration/). The new source doesn't require an API key (as the old source did).

## Testing Instructions

 * Delete `bcycle_api_key` from the `group_vars` files
 * Destroy and recreate `otp` vagrant machine
 * Bike share directions with transit turned off should route to use Indigo bikes where available en route

Fixes #891.
Closes #892.
