### PR TITLE
Pluralize mode miles

### DIFF
--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -171,11 +171,13 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
     function getFormattedDistance(distanceMeters) {
         // less than ~0.2 miles
         if (distanceMeters < 322) {
-            return Math.round(distanceMeters * 3.28084).toString() + ' feet';
+            var feet = Math.round(distanceMeters * 3.28084);
+            return feet > 1 ? feet.toString() + ' feet' : feet.toString() + ' foot';
         }
 
         // return miles
-        return (Math.round(((distanceMeters / 1000) * 0.621371) * 10) / 10).toString() + ' miles';
+        var miles = (Math.round(((distanceMeters / 1000) * 0.621371) * 10) / 10);
+        return miles > 1 ? miles.toString() + ' miles' : miles.toString() + ' mile';
     }
 
     /**


### PR DESCRIPTION
## Overview

Check for distances less than one mile or foot in per-mode summary text.
Use singular for those distances.


### Demo

![image](https://user-images.githubusercontent.com/960264/31588033-17ee9a32-b1ba-11e7-8852-1238f166375a.png)


### Notes

Also made modification for feet vs foot, although we shouldn't be displaying any distances that short.

## Testing Instructions

 * Plan a trip with a single mode distance of one mile or less
 * Trip detail text should display `mile` instead of `miles`
 * Screenshot above is of [this local trip plan url](http://localhost:8024/?origin=39.9615655%2C-75.154192&originText=990%20Spring%20Garden%20St%2C%20Philadelphia%2C%20Pennsylvania%2C%2019123&mode=WALK&maxWalk=482802&wheelchair=false&bikeTriangle=any&arriveBy=false&dateTime=&destination=39.9505412%2C-75.1489535&destinationText=N%205th%20St%20%26%20Market%20St%2C%20Philadelphia%2C%20Pennsylvania%2C%2019106)


## Checklist
- [x] No gulp lint warnings


Fixes #885.
