### PR TITLE
Style 'no results in travelshed' message

### DIFF
--- a/src/app/scripts/cac/home/cac-home-templates.js
+++ b/src/app/scripts/cac/home/cac-home-templates.js
@@ -53,7 +53,7 @@ CAC.Home.Templates = (function (Handlebars) {
             '{{/unless}}',
             '{{#if alternateMessage}}',
             '<header class="places-header">',
-                '<h2>{{alternateMessage}}</h2>',
+                '<h2 class="no-places">{{alternateMessage}}</h2>',
                 '<a href="#" class="map-view-btn">Map View</a>',
             '</header>',
             '{{/if}}',

--- a/src/app/styles/components/_place-list.scss
+++ b/src/app/styles/components/_place-list.scss
@@ -72,6 +72,14 @@
         }
     }
 
+    .no-places {
+        margin: 1em;
+        color: $gray;
+        font-size: 1.6rem;
+        line-height: 1.7;
+        text-align: center;
+    }
+
     a.map-view-btn {
         @include delinkify($gophillygo-blue);
         display: block;


### PR DESCRIPTION
## Overview

This PR styles the new "No featured destinations…" message in the sidebar.


### Demo

#### Before

![image](https://user-images.githubusercontent.com/128699/31738556-0ce753ca-b419-11e7-8efe-5504e78a41ba.png)

#### After

![image](https://user-images.githubusercontent.com/128699/31738351-5c4e458c-b418-11e7-8e42-b76471f09286.png)


## Testing Instructions

- `vagrant ssh app`
- `cd /opt/app/src && npm run gulp-development`
- Go to explore mode with 'map view' button on home page or toggle on bottom of directions view
- Choose an origin and travelshed with no results. ([here's one](http://localhost:8024/?origin=39.9615655%2C-75.154192&originText=990%20Spring%20Garden%20St%2C%20Philadelphia%2C%20Pennsylvania%2C%2019123&mode=WALK&maxWalk=482802&wheelchair=false&bikeTriangle=any&arriveBy=false&dateTime=&placeId=&exploreMinutes=15))
- Sidebar message should look like screenshot above

Connects #898 
