### PR TITLE
Feature/kak/list places no destionation#873

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -3,7 +3,7 @@ app_username: "vagrant"
 
 packer_version: "0.7.5"
 
-nodejs_version: 6.11.0
+nodejs_version: 6.11.4
 
 virtualenv_version: 15.1.0
 

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -9,9 +9,6 @@ virtualenv_version: 15.1.0
 
 otp_router: "default"
 
-otp_version: "1.2.0"
-otp_jar_sha1: "a7f659a63a54e894457bab6fc162fb0f47586057"
-
 # used by nginx and gunicorn to set timeouts; OTP defaults to 30s
 otp_session_timeout_s: 30
 

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -5,7 +5,7 @@
   version: 0.2.6
 
 - src: azavea.opentripplanner
-  version: 1.0.6
+  version: 1.0.7
 
 - src: azavea.nginx
   version: 0.2.2

--- a/python/cac_tripplanner/templates/service-worker.js
+++ b/python/cac_tripplanner/templates/service-worker.js
@@ -1,7 +1,7 @@
 // Service Worker to support functioning as a PWA
 // https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
 
-var CACHE_NAME = 'cac_tripplanner_v2';
+var CACHE_NAME = 'cac_tripplanner_v3';
 
 var cacheFiles = {{ cache_files | safe }};
 

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -201,6 +201,17 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Te
         $(options.selectors.spinner).removeClass(options.selectors.hiddenClass);
     }
 
+    // helper to call plan trip if a destination is set, or show places list if no destination
+    function planTripOrShowPlaces() {
+        if (directions.destination) {
+            showPlaces(false);
+            planTrip();
+        } else {
+            showPlaces(true);
+            exploreControl.getNearbyPlaces();
+        }
+    }
+
     /**
      * Get parameters to pass to OpenTripPlanner, based on current settings
      *
@@ -315,7 +326,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Te
     // trigger re-query when trip options update
     function setOptions() {
         if (tabControl.isTabShowing(tabControl.TABS.DIRECTIONS)) {
-            planTrip();
+            planTripOrShowPlaces();
         }
     }
 
@@ -334,7 +345,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Te
         }
 
         // update the directions for the reverse trip
-        planTrip();
+        planTripOrShowPlaces();
     }
 
     function onTypeaheadCleared(event, key) {
@@ -355,7 +366,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Te
         }
         setDirections(key, [result.location.y, result.location.x]);
         if (tabControl.isTabShowing(tabControl.TABS.DIRECTIONS)) {
-            planTrip();
+            planTripOrShowPlaces();
         }
     }
 
@@ -424,14 +435,8 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Te
         }
 
         if (tabControl.isTabShowing(tabControl.TABS.DIRECTIONS)) {
-            // get directions if have origin and destination; if just origin, get nearby places
-            if (origin && !destination) {
-                showPlaces(true);
-                exploreControl.getNearbyPlaces();
-            } else {
-                showPlaces(false);
-                planTrip();
-            }
+            // get nearby places if no destination has been set yet
+            planTripOrShowPlaces();
         } else {
             // explore tab visible
             showPlaces(true);

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -374,12 +374,12 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
         // also draw all destinations on explore map (not just those in the isochrone)
         if (tabControl.isTabShowing(tabControl.TABS.EXPLORE) && mapControl.isLoaded()) {
             if (allDestinations.length > 0) {
-                mapControl.isochroneControl.drawDestinations(allDestinations);
+                mapControl.isochroneControl.drawDestinations(allDestinations, destinations);
             } else {
                 // if destinations not cached already, go fetch them
-                getAllPlaces().then(function(destinations) {
-                    allDestinations = destinations;
-                    mapControl.isochroneControl.drawDestinations(allDestinations);
+                getAllPlaces().then(function(fullDestinationsList) {
+                    allDestinations = fullDestinationsList;
+                    mapControl.isochroneControl.drawDestinations(allDestinations, destinations);
                 }).fail(function(error) {
                     console.error('error fetching destinations to map:');
                     console.error(error);

--- a/src/app/scripts/cac/map/cac-map-isochrone.js
+++ b/src/app/scripts/cac/map/cac-map-isochrone.js
@@ -29,6 +29,7 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
     var destinationOutsideTravelshedIcon = L.AwesomeMarkers.icon({
         icon: 'default',
         prefix: 'icon',
+        // modified by styles to actually be orange, with reduced opacity
         markerColor: 'darkred',
         extraClasses: 'outside'
     });

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -68,16 +68,17 @@ CAC.Pages.Home = (function ($, ModeOptions,  MapControl, TripOptions, SearchPara
 
         directionsFormControl = new CAC.Control.DirectionsFormControl({});
 
-        directionsControl = new CAC.Control.Directions({
+        exploreControl = new CAC.Control.Explore({
             mapControl: mapControl,
             directionsFormControl: directionsFormControl,
             tabControl: tabControl,
             urlRouter: urlRouter
         });
 
-        exploreControl = new CAC.Control.Explore({
+        directionsControl = new CAC.Control.Directions({
             mapControl: mapControl,
             directionsFormControl: directionsFormControl,
+            exploreControl: exploreControl,
             tabControl: tabControl,
             urlRouter: urlRouter
         });

--- a/src/app/styles/components/_map-marker.scss
+++ b/src/app/styles/components/_map-marker.scss
@@ -2,3 +2,8 @@
     margin-top: 4px;
     font-size: 18px;
 }
+
+.awesome-marker-icon-darkred {
+    background-position: -36px 0;  // override to orange
+    opacity: .5;
+}

--- a/src/app/styles/components/_map-marker.scss
+++ b/src/app/styles/components/_map-marker.scss
@@ -5,5 +5,5 @@
 
 .awesome-marker-icon-darkred {
     background-position: -36px 0;  // override to orange
-    opacity: .5;
+    opacity: .3;
 }


### PR DESCRIPTION
## Overview

List all destinations in the sidebar in directions mode when no destination is set.
Show all destinations on map in explore mode, not just those within the travelshed.


### Demo

Directions tab, no destination:
![image](https://user-images.githubusercontent.com/960264/31835205-af5b9db0-b59e-11e7-905f-ff5a327f729a.png)

Directions tab: has destination:
![image](https://user-images.githubusercontent.com/960264/31835233-ce7a0c36-b59e-11e7-9dad-03094b0799e2.png)

Explore tab: map destinations outside isochrone showing:
![image](https://user-images.githubusercontent.com/960264/31835255-e3f09ec2-b59e-11e7-8033-4296a2960ab8.png)


### Notes

This task somewhat breaks some previous assumptions built into the styles and code about what 'explore' and 'directions' tabs mean. The destinations still load into the 'explore' tab sidebar list content, but the 'directions' tab now will switch between sidebar tab content lists, depending on whether or not a destination is set, so the destinations from the 'explore' content can be seen.

It seems to be working well, but it would be good to test clicking around a bit and making sure nothing strange happens as a side effect.


## Testing Instructions

 * `vagrant ssh app`
 * `cd /opt/ap/src && npm run gulp-development`
 * Be sure to 'clear site data' at the bottom of the Chrome 'application' tab (clear service worker cache)
 * Go to explore tab on map: all destination map markers should show, always
 * Get directions somewhere
 * Clear the destination field on the directions map page tab
 * Full list of destinations should show in sidebar
 * Clicking one should then show directions with list
 * Toggling explore/directions tabs should function as expected

## Checklist
- [x] No gulp lint warnings
- [x] No python lint warnings
- [x] Python tests pass


Closes #873 
