### PR TITLE
Upgrade Django #896

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -23,13 +23,13 @@ cac_python_dependencies:
     - { name: 'base58', version: '0.2.5' }
     - { name: 'boto', version: '2.48.0' }
     - { name: 'django', version: '1.9.13' }
-    - { name: 'django-ckeditor', version: '5.3.0' }
-    - { name: 'django-extensions', version: '1.9.1' }
+    - { name: 'django-ckeditor', version: '5.3.1' }
+    - { name: 'django-extensions', version: '1.9.7' }
     - { name: 'django-storages', version: '1.6.5' }
     - { name: 'gunicorn', version: '19.7.1' }
     - { name: 'pillow', version: '4.3.0' }
     - { name: 'psycopg2', version: '2.7.3' }
-    - { name: 'pytz', version: '2017.2' }
+    - { name: 'pytz', version: '2017.3' }
     - { name: 'pyyaml', version: '3.12' }
     - { name: 'troposphere', version: '0.7.2'}
     # Note: django-wpadmin is installed manually to work around the fact that ansible-pip

--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -22,7 +22,7 @@ app_cron_event_feed: "cd {{ root_app_dir }} && python manage.py load_events >> {
 cac_python_dependencies:
     - { name: 'base58', version: '0.2.5' }
     - { name: 'boto', version: '2.48.0' }
-    - { name: 'django', version: '1.10.8' }
+    - { name: 'django', version: '1.11.7' }
     - { name: 'django-ckeditor', version: '5.3.1' }
     - { name: 'django-extensions', version: '1.9.7' }
     - { name: 'django-storages', version: '1.6.5' }

--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -22,7 +22,7 @@ app_cron_event_feed: "cd {{ root_app_dir }} && python manage.py load_events >> {
 cac_python_dependencies:
     - { name: 'base58', version: '0.2.5' }
     - { name: 'boto', version: '2.48.0' }
-    - { name: 'django', version: '1.9.13' }
+    - { name: 'django', version: '1.10.8' }
     - { name: 'django-ckeditor', version: '5.3.1' }
     - { name: 'django-extensions', version: '1.9.7' }
     - { name: 'django-storages', version: '1.6.5' }

--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -22,7 +22,7 @@ app_cron_event_feed: "cd {{ root_app_dir }} && python manage.py load_events >> {
 cac_python_dependencies:
     - { name: 'base58', version: '0.2.5' }
     - { name: 'boto', version: '2.48.0' }
-    - { name: 'django', version: '1.8.18' }
+    - { name: 'django', version: '1.9.13' }
     - { name: 'django-ckeditor', version: '5.3.0' }
     - { name: 'django-extensions', version: '1.9.1' }
     - { name: 'django-storages', version: '1.6.5' }

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -16,7 +16,9 @@
   # Putting 'editable: false' in the entry in cac_python_dependencies should make it install
   # non-editable, but it's getting ignored
 - name: Install django-wpadmin manually to work around ansible bug
-  command: pip install --upgrade 'git+https://github.com/azavea/django-wpadmin@v1.9#egg=django-wpadmin'
+  command: pip install --upgrade 'git+https://github.com/flibbertigibbet/django-wpadmin@feature/django-1-11#egg=django-wpadmin'
+  # TODO: change to release install
+  #command: pip install --upgrade 'git+https://github.com/azavea/django-wpadmin@v1.9#egg=django-wpadmin'
 
 # TODO: peg this to a version, rather than a commit, when released
 # ansible pip module installs this in /tmp/src for some reason, so we use the

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -16,9 +16,7 @@
   # Putting 'editable: false' in the entry in cac_python_dependencies should make it install
   # non-editable, but it's getting ignored
 - name: Install django-wpadmin manually to work around ansible bug
-  command: pip install --upgrade 'git+https://github.com/flibbertigibbet/django-wpadmin@feature/django-1-9#egg=django-wpadmin'
-  # FIXME: remove
-  #command: pip install 'git+https://github.com/azavea/django-wpadmin@v1.8.13#egg=django-wpadmin'
+  command: pip install --upgrade 'git+https://github.com/azavea/django-wpadmin@v1.9#egg=django-wpadmin'
 
 # TODO: peg this to a version, rather than a commit, when released
 # ansible pip module installs this in /tmp/src for some reason, so we use the

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -16,7 +16,9 @@
   # Putting 'editable: false' in the entry in cac_python_dependencies should make it install
   # non-editable, but it's getting ignored
 - name: Install django-wpadmin manually to work around ansible bug
-  command: pip install 'git+https://github.com/azavea/django-wpadmin@v1.8.13#egg=django-wpadmin'
+  command: pip install 'git+https://github.com/flibbertigibbet/django-wpadmin@feature/django-1-9#egg=django-wpadmin'
+  # FIXME: remove
+  #command: pip install 'git+https://github.com/azavea/django-wpadmin@v1.8.13#egg=django-wpadmin'
 
 # TODO: peg this to a version, rather than a commit, when released
 # ansible pip module installs this in /tmp/src for some reason, so we use the

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -16,7 +16,7 @@
   # Putting 'editable: false' in the entry in cac_python_dependencies should make it install
   # non-editable, but it's getting ignored
 - name: Install django-wpadmin manually to work around ansible bug
-  command: pip install 'git+https://github.com/flibbertigibbet/django-wpadmin@feature/django-1-9#egg=django-wpadmin'
+  command: pip install --upgrade 'git+https://github.com/flibbertigibbet/django-wpadmin@feature/django-1-9#egg=django-wpadmin'
   # FIXME: remove
   #command: pip install 'git+https://github.com/azavea/django-wpadmin@v1.8.13#egg=django-wpadmin'
 

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -16,10 +16,9 @@
   # Putting 'editable: false' in the entry in cac_python_dependencies should make it install
   # non-editable, but it's getting ignored
 - name: Install django-wpadmin manually to work around ansible bug
-  command: pip install --upgrade 'git+https://github.com/flibbertigibbet/django-wpadmin@feature/django-1-11#egg=django-wpadmin'
-  # TODO: change to release install
-  #command: pip install --upgrade 'git+https://github.com/azavea/django-wpadmin@v1.9#egg=django-wpadmin'
+  command: pip install --upgrade 'git+https://github.com/azavea/django-wpadmin@v1.11#egg=django-wpadmin'
 
+# TODO: #914 replace major kirby
 # TODO: peg this to a version, rather than a commit, when released
 # ansible pip module installs this in /tmp/src for some reason, so we use the
 # command instead

--- a/python/cac_tripplanner/cac_tripplanner/settings.py
+++ b/python/cac_tripplanner/cac_tripplanner/settings.py
@@ -7,6 +7,7 @@ https://docs.djangoproject.com/en/1.7/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.7/ref/settings/
 """
+import django
 
 from boto.utils import get_instance_metadata
 from django.core.exceptions import ImproperlyConfigured
@@ -223,12 +224,20 @@ LOGGING = {
 }
 
 # TEMPLATE CONFIGURATION
-# See https://docs.djangoproject.com/en/1.8/ref/settings/#templates
+# See https://docs.djangoproject.com/en/1.11/ref/settings/#templates
+
+# set renderer
+# https://docs.djangoproject.com/en/1.11/ref/forms/renderers/#django.forms.renderers.TemplatesSetting
+FORM_RENDERER = 'django.forms.renderers.TemplatesSetting'
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [
             os.path.normpath(os.path.join(BASE_DIR, 'templates')),
+            'django/forms/templates',
+            'templates',
+            os.path.normpath(os.path.join(django.__path__[0] + '/forms/templates'))
         ],
         'APP_DIRS': True,
         'OPTIONS': {

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -98,7 +98,7 @@ var buildTurfHelpers = function() {
 };
 
 var buildTurfPointOnLine = function() {
-    return browserify(turfRoot + 'point-on-line', {
+    return browserify(turfRoot + 'nearest-point-on-line', {
             standalone: 'turf.pointOnLine',
             exclude: [turfRoot + 'helpers']
         })

--- a/src/package.json
+++ b/src/package.json
@@ -4,13 +4,13 @@
     "node": ">=0.12.0"
   },
   "dependencies": {
-    "@turf/point-on-line": "~5.0.3"
+    "@turf/nearest-point-on-line": "~5.0.4"
   },
   "devDependencies": {
     "aliasify": "^2.0.0",
-    "apache-server-configs": "~2.14.0",
+    "apache-server-configs": "~2.15.0",
     "bower": "~1.8.2",
-    "browserify": "~14.4.0",
+    "browserify": "~14.5.0",
     "chai": "~4.1.2",
     "connect": "~3.6.5",
     "connect-livereload": "~0.6.0",
@@ -18,14 +18,14 @@
     "gulp": "~3.9.1",
     "gulp-add-src": "~0.2.0",
     "gulp-autoprefixer": "~4.0.0",
-    "gulp-cache": "~0.4.5",
+    "gulp-cache": "~1.0.1",
     "gulp-concat": "~2.6.1",
     "gulp-csso": "~3.0.0",
     "gulp-debug": "~3.1.0",
     "gulp-filter": "~5.0.1",
     "gulp-flatten": "~0.3.1",
     "gulp-if": "~2.0.2",
-    "gulp-imagemin": "~3.4.0",
+    "gulp-imagemin": "~4.0.0",
     "gulp-jshint": "~2.0.4",
     "gulp-jshint-xml-file-reporter": "~0.5.1",
     "gulp-load-plugins": "~1.5.0",
@@ -54,7 +54,7 @@
     "merge-stream": "~1.0.0",
     "mocha": "~4.0.1",
     "opn": "~5.1.0",
-    "phantomjs-prebuilt": "^2.1.15",
+    "phantomjs-prebuilt": "^2.1.16",
     "pump": "~1.0.2",
     "requirejs": "~2.3.5",
     "serve-index": "~1.9.1",


### PR DESCRIPTION
## Overview

Update from Django 1.8 to Django 1.11 (latest stable).

No changes required to this project apart from updating the version of the third-party [django-wpadmin](https://github.com/azavea/django-wpadmin) project we'd forked previously to bump the supported version number to 1.8.

Changes to `django-wpadmin` for 1.9 support came from an unmerged PR upstream. The only changes for 1.10 and 1.11 support were to remove a template tag import that is no longer necessary, and to slightly widen a drop-down in the CSS to preserve the horizontal layout of the 'actions' bar.

Also updates a few npm packages, and fixes an issue with a package having been renamed (#915).

### Notes

Styling changed slightly; the admin header bar is easier to read.

Old admin site:
![old_wpadmin_styling](https://user-images.githubusercontent.com/960264/33091026-ec901b5a-cec3-11e7-91f6-43b8b7395091.png)

New admin site:
![new_wpadmin_styling](https://user-images.githubusercontent.com/960264/33091032-f09fc826-cec3-11e7-999f-1237c7241f65.png)


## Testing Instructions

 * `vagrant provision app`
 * Site continue to function as normal; in particular, the admin site


## Checklist
- [x] No gulp lint warnings
- [x] No python lint warnings
- [x] Python tests pass

Closes #896 
Fixes #915
Closes #897