### PR TITLE
Disable anchor tags in article teaser

### DIFF
--- a/python/cac_tripplanner/cac_tripplanner/settings.py
+++ b/python/cac_tripplanner/cac_tripplanner/settings.py
@@ -282,6 +282,24 @@ CKEDITOR_CONFIGS = {
              'embed',
              'embedsemantic',
              'autogrow']),
+    },
+    'teaser': {
+        'toolbar': [
+            ["Styles",
+             "Format",
+             "Bold",
+             "Italic",
+             "Underline",
+             "Strike",
+             "SpellChecker",
+             "Undo",
+             "Redo"],
+            [],
+            [],
+            ["SpecialChar"],
+            []
+        ],
+        'extraPlugins': '',
     }
 }
 

--- a/python/cac_tripplanner/cms/models.py
+++ b/python/cac_tripplanner/cms/models.py
@@ -80,7 +80,7 @@ class Article(models.Model):
     title = models.CharField(max_length=80)
     slug = models.SlugField()
     author = models.ForeignKey(User)
-    teaser = RichTextField()  # above the fold
+    teaser = RichTextField(config_name='teaser')  # above the fold
     content = RichTextField(null=True, blank=True)  # below the fold
     publish_date = models.DateTimeField(blank=True, null=True)
     created = models.DateTimeField(auto_now_add=True)


### PR DESCRIPTION
Create a separate ckeditor config for the WYSIWIG rich content editor
used for the teaser on articles, to disable anchor tags in the teaser.

Anchor tags in article teasers break the layout, as the teaser is wrapped in an anchor tag.
To prevent #929 resurfacing.

Article `ckeditor` field in admin for teaser:
![cac_teaser_ckeditor](https://user-images.githubusercontent.com/960264/33621359-74e8cdb8-d9b8-11e7-998f-d163d93e09f5.png)

For content (which allows anchor tags):
![cac_content_ckeditor](https://user-images.githubusercontent.com/960264/33621369-7c13f2fc-d9b8-11e7-8a36-1b25f2448b5a.png)
