### PR TITLE
Guard in data migrations

### DIFF
--- a/python/cac_tripplanner/destinations/migrations/0024_default_destination_categories.py
+++ b/python/cac_tripplanner/destinations/migrations/0024_default_destination_categories.py
@@ -76,13 +76,16 @@ def add_sample_categories(apps, schema_editor):
 
     # set the new categories on the default destinations that were added in migration 0012
     for dest in get_sample_destinations():
-        destination = Destination.objects.get(name=dest['name'])
-        if not destination:
+        try:
+            destination = Destination.objects.get(name=dest['name'])
+        except Destination.DoesNotExist:
             continue
         for add_category in dest['categories']:
-            category = DestinationCategory.objects.get(name=add_category)
-            if category:
-                destination.categories.add(category)
+            try:
+                category = DestinationCategory.objects.get(name=add_category)
+            except DestinationCategory.DoesNotExist:
+                continue
+            destination.categories.add(category)
 
 
 def delete_sample_categories(apps, schema_editor):

--- a/python/cac_tripplanner/destinations/migrations/0028_default_activities.py
+++ b/python/cac_tripplanner/destinations/migrations/0028_default_activities.py
@@ -73,13 +73,16 @@ def add_sample_activities(apps, schema_editor):
 
     # set the new activities on the default destinations that were added in migration 0012
     for dest in get_sample_destinations():
-        destination = Destination.objects.get(name=dest['name'])
-        if not destination:
+        try:
+            destination = Destination.objects.get(name=dest['name'])
+        except Destination.DoesNotExist:
             continue
         for add_activity in dest['activities']:
-            activity = Activity.objects.get(name=add_activity)
-            if activity:
+            try:
+                activity = Activity.objects.get(name=add_activity)
                 destination.activities.add(activity)
+            except Activity.DoesNotExist:
+                continue
 
 
 def delete_sample_activities(apps, schema_editor):

--- a/python/cac_tripplanner/destinations/migrations/0030_default_watershed_alliance.py
+++ b/python/cac_tripplanner/destinations/migrations/0030_default_watershed_alliance.py
@@ -26,8 +26,9 @@ def set_watershed_alliance(apps, schema_editor):
 
     # set the watershed alliance flag on the default destinations that were added in migration 0012
     for dest in get_watershed_alliance_locations():
-        destination = Destination.objects.get(name=dest)
-        if not destination:
+        try:
+            destination = Destination.objects.get(name=dest)
+        except Destination.DoesNotExist:
             continue
         destination.watershed_alliance = True
         destination.save()


### PR DESCRIPTION
## Overview

Properly handle objects not existing in data migrations.


## Testing Instructions

 * `vagrant ssh`
 * `cd /opt/app/python/cac_tripplanner`
 * `./manage.py shell_plus`
 * Change the `name` property on one of the default destinations in the shell:
 * `d = Destination.objects.first()`
 * `d.name = 'Something Else'`
 * `d.save()`
 * Revert migrations: `./manage.py migrate destinations 0023`
 * Redo migrations: `./manage.py migrate`
 * Migrations should succeed


Fixes #931.

