### PR TITLE
Filter destinations in the map sidebar

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -2,8 +2,7 @@
  *  View control for the directions form
  *
  */
-CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Templates, Typeahead,
-                                    UserPreferences, Utils) {
+CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferences, Utils) {
 
     'use strict';
 
@@ -449,5 +448,4 @@ CAC.Control.Directions = (function (_, $, moment, Control, Geocoder, Routing, Te
         }
     }
 
-})(_, jQuery, moment, CAC.Control, CAC.Search.Geocoder,
-    CAC.Routing.Plans, CAC.Home.Templates, CAC.Search.Typeahead, CAC.User.Preferences, CAC.Utils);
+})(_, jQuery, moment, CAC.Control, CAC.Routing.Plans, CAC.User.Preferences, CAC.Utils);

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -473,7 +473,8 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Routing, Use
         return dfd.promise();
     }
 
-    function _getNearbyPlaces(filter) {
+    function _getNearbyPlaces() {
+        var filter = UserPreferences.getPreference('destinationFilter');
         showSpinner();
         var $placeCards = $(options.selectors.placeCard);
         // hide existing times to places now showing (if any)

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -375,7 +375,9 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Routing, Use
             }
         }
 
-        var newPlaces = HomeTemplates.destinations(destinations, text);
+        var newPlaces = HomeTemplates.destinations(destinations,
+                                                   text,
+                                                   tabControl.isTabShowing(tabControl.TABS.HOME));
         $(options.selectors.placesContent).html(newPlaces);
         // send event that places content changed
         events.trigger(eventNames.destinationsLoaded);
@@ -401,6 +403,8 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Routing, Use
 
         // now places list has been updated, go fetch the travel time
         // from the new origin to each place
+
+        // TODO: cache travel times for last origin/routing params set?
         getTimesToPlaces();
     }
 
@@ -418,7 +422,7 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Routing, Use
      * Filter destinations by category client-side.
      */
     function filterPlaces(allPlaces, filter) {
-        if (filter === 'All') {
+        if (!filter || filter === 'All') {
             return allPlaces;
         }
 

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -2,8 +2,8 @@
  *  View control for the sidebar explore tab
  *
  */
-CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Routing, Typeahead,
-                                 UserPreferences, Utils) {
+CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Routing, UserPreferences,
+                                 Utils) {
 
     'use strict';
 
@@ -539,5 +539,5 @@ CAC.Control.Explore = (function (_, $, Geocoder, MapTemplates, HomeTemplates, Ro
         });
     }
 
-})(_, jQuery, CAC.Search.Geocoder, CAC.Map.Templates, CAC.Home.Templates, CAC.Routing.Plans,
-    CAC.Search.Typeahead, CAC.User.Preferences, CAC.Utils);
+})(_, jQuery, CAC.Map.Templates, CAC.Home.Templates, CAC.Routing.Plans, CAC.User.Preferences,
+   CAC.Utils);

--- a/src/app/scripts/cac/control/cac-control-filter-options.js
+++ b/src/app/scripts/cac/control/cac-control-filter-options.js
@@ -56,7 +56,7 @@ CAC.Control.FilterOptions = (function ($) {
         // filter drop-down button event handler
         $(options.selectors.filterToggle).on('change', function(e) {
             e.preventDefault();
-            if (!e.target.selectedOptions || ! e.target.selectedOptions.length) {
+            if (!e.target.selectedOptions || !e.target.selectedOptions.length) {
                 return;
             }
 

--- a/src/app/scripts/cac/control/cac-control-filter-options.js
+++ b/src/app/scripts/cac/control/cac-control-filter-options.js
@@ -30,24 +30,44 @@ CAC.Control.FilterOptions = (function ($) {
         events: events,
         eventNames: eventNames,
         getFilter: getFilter,
-        setFilter: setFilter
+        setFilter: setFilter,
+        destroy: destroy
     };
 
     return FilterOptionsControl;
 
-    function initialize() {
-        // update classes on filter toggle buttons
-        $(options.selectors.filterToggle).on('click', options.selectors.filterOption, function(e) {
-            e.preventDefault();
-
-            $(this).addClass(options.selectors.onClass)
+    // helper to set the 'on' class for the selected option, and unset it for the others
+    function toggleOn(selector) {
+        $(selector).addClass(options.selectors.onClass)
                 .removeClass(options.selectors.offClass)
                 .siblings(options.selectors.filterOption)
                     .removeClass(options.selectors.onClass)
                     .addClass(options.selectors.offClass);
+    }
 
+    function initialize() {
+        // filter toggle button row event handler
+        $(options.selectors.filterToggle).on('click', options.selectors.filterOption, function(e) {
+            e.preventDefault();
+            toggleOn(this);
             events.trigger(eventNames.toggle, getFilter());
         });
+
+        // filter drop-down button event handler
+        $(options.selectors.filterToggle).on('change', function(e) {
+            e.preventDefault();
+            if (!e.target.selectedOptions || ! e.target.selectedOptions.length) {
+                return;
+            }
+
+            toggleOn(e.target.selectedOptions[0]);
+            events.trigger(eventNames.toggle, getFilter());
+        });
+    }
+
+    function destroy() {
+        // clear handlers
+        $(options.selectors.filterToggle).off();
     }
 
     /**
@@ -82,6 +102,9 @@ CAC.Control.FilterOptions = (function ($) {
         $filters.addClass(options.selectors.offClass);
 
         var $thisFilter = $(options.selectors.filterPicker).find('[data-filter="' + filter + '"]');
+
+        // change display if in drop-down
+        $(options.selectors.filterToggle).val(filter).change();
 
         // shouldn't happen, but guard against missing or bad filter being set
         if ($thisFilter.length !== 1) {

--- a/src/app/scripts/cac/home/cac-home-templates.js
+++ b/src/app/scripts/cac/home/cac-home-templates.js
@@ -1,14 +1,72 @@
 CAC.Home.Templates = (function (Handlebars) {
     'use strict';
 
+    // precompiled HTML snippets
+    var filterButtonBarTemplate = '';
+
     var module = {
-        destinations: destinations
+        destinations: destinations,
+        getFilterButtonBar: getFilterButtonBar
     };
+
+    setupFilterTemplates();
 
     return module;
 
+    function getFilterButtonBar() {
+        return filterButtonBarTemplate;
+    }
+
     /**
-     * Take list of destination objects and return templated HTML snippet for sidebar.
+     * Dynamically select which filter control to use (button bar or dropdown).
+     *
+     * @return {String} name of a registered Handlebars partial
+     */
+    function filterPartial() {
+        // TODO: implement
+        return 'filterButtonBar';
+    }
+
+    // Initialize by registering the two compiled partials for the filter bar,
+    // which be chosen dynamically when building the destinations list.
+    function setupFilterTemplates() {
+        var filterButtonBar = [
+            '<div class="filter-picker">',
+                '<div class="filter-toggle">',
+                    '<div class="all filter-option on" title="All" data-filter="All">',
+                        '<span class="filter-label">All</span>',
+                    '</div>',
+                    '<div class="events filter-option" title ="Events" ',
+                        'data-filter="Events">',
+                        '<span class="filter-label">Events</span>',
+                    '</div>',
+                    '<div class="nature filter-option" title="Nature" ',
+                        'data-filter="Nature">',
+                        '<span class="filter-label">Nature</span>',
+                    '</div>',
+                    '<div class="exercise filter-option" title="Exercise"',
+                        'data-filter="Exercise">',
+                        '<span class="filter-label">Exercise</span>',
+                    '</div>',
+                    '<div class="relax filter-option" title="Relax" data-filter="Relax">',
+                        '<span class="filter-label">Relax</span>',
+                    '</div>',
+                    '<div class="educational filter-option" title ="Educational"',
+                        'data-filter="Educational">',
+                        '<span class="filter-label">Educational</span>',
+                    '</div>',
+                    '<input type="hidden" name="destination-filter" value="All">',
+                '</div>',
+            '</div>'].join('');
+
+        filterButtonBarTemplate = Handlebars.compile(filterButtonBar);
+        Handlebars.registerPartial('filterButtonBar', filterButtonBarTemplate);
+        Handlebars.registerHelper('filterPartial', filterPartial);
+    }
+
+    /**
+     * Take list of destination objects and return templated HTML snippet for places list.
+     * Note this template HTML is also part of the Django template `home.html`.
      *
      * @param useDestinations {Array} Collection of JSON destinations from /api/destinations/search
      * @param alternateMessage {String} Text to display if there are no destinations
@@ -20,33 +78,7 @@ CAC.Home.Templates = (function (Handlebars) {
                 '<div class="places-header-content">',
                     '<h1>Places we love</h1>',
                     '<a href="#" class="map-view-btn">Map View</a>',
-                    '<div class="filter-picker">',
-                        '<div class="filter-toggle">',
-                            '<div class="all filter-option on" title="All" data-filter="All">',
-                                '<span class="filter-label">All</span>',
-                            '</div>',
-                            '<div class="events filter-option" title ="Events" ',
-                                'data-filter="Events">',
-                                '<span class="filter-label">Events</span>',
-                            '</div>',
-                            '<div class="nature filter-option" title="Nature" ',
-                                'data-filter="Nature">',
-                                '<span class="filter-label">Nature</span>',
-                            '</div>',
-                            '<div class="exercise filter-option" title="Exercise"',
-                                'data-filter="Exercise">',
-                                '<span class="filter-label">Exercise</span>',
-                            '</div>',
-                            '<div class="relax filter-option" title="Relax" data-filter="Relax">',
-                                '<span class="filter-label">Relax</span>',
-                            '</div>',
-                            '<div class="educational filter-option" title ="Educational"',
-                                'data-filter="Educational">',
-                                '<span class="filter-label">Educational</span>',
-                            '</div>',
-                            '<input type="hidden" name="destination-filter" value="All">',
-                        '</div>',
-                    '</div>',
+                    '{{> (filterPartial) }}',
                 '</div>',
             '</header>',
             '{{#unless alternateMessage}}',
@@ -86,6 +118,7 @@ CAC.Home.Templates = (function (Handlebars) {
             '</div>',
             '{{/if}}',
         ].join('');
+
         var template = Handlebars.compile(source);
         var html = template({destinations: useDestinations,
                              alternateMessage:alternateMessage},

--- a/src/app/scripts/cac/home/cac-home-templates.js
+++ b/src/app/scripts/cac/home/cac-home-templates.js
@@ -17,7 +17,8 @@ CAC.Home.Templates = (function (Handlebars) {
 
     var module = {
         destinations: destinations,
-        getFilterButtonBar: getFilterButtonBar
+        getFilterButtonBar: getFilterButtonBar,
+        getFilterDropdown: getFilterDropdown
     };
 
     initialize();
@@ -29,8 +30,14 @@ CAC.Home.Templates = (function (Handlebars) {
         compileDestinationListTemplate();
     }
 
+    // returns HTML for the places header, for use on the map page
+    function getFilterDropdown() {
+        return filterDropdownTemplate({filterOptions: filterOptions});
+    }
+
+    // returns HTML for the places header, for use on the home page
     function getFilterButtonBar() {
-        return filterButtonBarTemplate;
+        return filterButtonBarTemplate({filterOptions: filterOptions});
     }
 
     /**

--- a/src/app/scripts/cac/home/cac-home-templates.js
+++ b/src/app/scripts/cac/home/cac-home-templates.js
@@ -4,6 +4,15 @@ CAC.Home.Templates = (function (Handlebars) {
     // precompiled HTML snippets
     var filterButtonBarTemplate = '';
 
+    var filterOptions = [
+        {'class': 'all', 'label': 'All', 'value': 'All'},
+        {'class': 'events', 'label': 'Events', 'value': 'Events'},
+        {'class': 'nature', 'label': 'Nature', 'value': 'Nature'},
+        {'class': 'exercise', 'label': 'Exercise', 'value': 'Exercise'},
+        {'class': 'relax', 'label': 'Relax', 'value': 'Relax'},
+        {'class': 'educational', 'label': 'Educational', 'value': 'Educational'},
+    ];
+
     var module = {
         destinations: destinations,
         getFilterButtonBar: getFilterButtonBar
@@ -20,10 +29,16 @@ CAC.Home.Templates = (function (Handlebars) {
     /**
      * Dynamically select which filter control to use (button bar or dropdown).
      *
+     * @param isHome {Boolean} true if currently on home page
      * @return {String} name of a registered Handlebars partial
      */
-    function filterPartial() {
+    function filterPartial(isHome) {
         // TODO: implement
+        if (isHome) {
+            console.log('is home');
+        } else {
+            console.log('not home');
+        }
         return 'filterButtonBar';
     }
 
@@ -33,29 +48,12 @@ CAC.Home.Templates = (function (Handlebars) {
         var filterButtonBar = [
             '<div class="filter-picker">',
                 '<div class="filter-toggle">',
-                    '<div class="all filter-option on" title="All" data-filter="All">',
-                        '<span class="filter-label">All</span>',
+                    '{{#each filterOptions}}',
+                    '<div class="{{class}} filter-option" title="{{label}}" ',
+                        'data-filter="{{value}}">',
+                        '<span class="filter-label">{{label}}</span>',
                     '</div>',
-                    '<div class="events filter-option" title ="Events" ',
-                        'data-filter="Events">',
-                        '<span class="filter-label">Events</span>',
-                    '</div>',
-                    '<div class="nature filter-option" title="Nature" ',
-                        'data-filter="Nature">',
-                        '<span class="filter-label">Nature</span>',
-                    '</div>',
-                    '<div class="exercise filter-option" title="Exercise"',
-                        'data-filter="Exercise">',
-                        '<span class="filter-label">Exercise</span>',
-                    '</div>',
-                    '<div class="relax filter-option" title="Relax" data-filter="Relax">',
-                        '<span class="filter-label">Relax</span>',
-                    '</div>',
-                    '<div class="educational filter-option" title ="Educational"',
-                        'data-filter="Educational">',
-                        '<span class="filter-label">Educational</span>',
-                    '</div>',
-                    '<input type="hidden" name="destination-filter" value="All">',
+                    '{{/each}}',
                 '</div>',
             '</div>'].join('');
 
@@ -70,15 +68,16 @@ CAC.Home.Templates = (function (Handlebars) {
      *
      * @param useDestinations {Array} Collection of JSON destinations from /api/destinations/search
      * @param alternateMessage {String} Text to display if there are no destinations
+     * @param isHome {Boolean} True if currently on home page (and not map page)
      * @return html {String} Snippets for boxes to display on home page for each destination
      */
-    function destinations(useDestinations, alternateMessage) {
+    function destinations(useDestinations, alternateMessage, isHome) {
         var source = [
             '<header class="places-header">',
                 '<div class="places-header-content">',
                     '<h1>Places we love</h1>',
                     '<a href="#" class="map-view-btn">Map View</a>',
-                    '{{> (filterPartial) }}',
+                    '{{> (filterPartial isHome) }}',
                 '</div>',
             '</header>',
             '{{#unless alternateMessage}}',
@@ -120,10 +119,11 @@ CAC.Home.Templates = (function (Handlebars) {
         ].join('');
 
         var template = Handlebars.compile(source);
-        var html = template({destinations: useDestinations,
-                             alternateMessage:alternateMessage},
-                             {data: {level: Handlebars.logger.WARN}});
-        return html;
+        return template({destinations: useDestinations,
+                         alternateMessage: alternateMessage,
+                         filterOptions: filterOptions,
+                         isHome: isHome},
+                         {data: {level: Handlebars.logger.WARN}});
     }
 
 })(Handlebars);

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -263,11 +263,17 @@ CAC.Pages.Home = (function ($, FilterOptions, ModeOptions,  MapControl, TripOpti
         }
     }
 
-    // Returning to the Home tab resets everything as though it were loaded fresh
     function onTabShown(event, tabId) {
+        // Returning to the Home tab resets everything as though it were loaded fresh
         if (tabId === tabControl.TABS.HOME) {
             UserPreferences.setPreference('method', undefined);
             clearUserSettings();
+            // TODO: change filter component back
+            console.log('use filter button bar now');
+        } else if (tabId === tabControl.TABS.DIRECTIONS || tabId === tabControl.TABS.EXPLORE) {
+            // on switching from Home to one of the two map tabs, change the filter component
+            // TODO:
+            console.log('use filter drop down now');
         }
     }
 
@@ -293,7 +299,7 @@ CAC.Pages.Home = (function ($, FilterOptions, ModeOptions,  MapControl, TripOpti
     }
 
     /**
-     * Updates destination filter when filter bar button toggled.
+     * Updates destination filter when filter selection changed.
      */
      function toggledFilter(event, filter) {
         UserPreferences.setPreference('destinationFilter', filter);

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -239,6 +239,10 @@ CAC.Pages.Home = (function ($, FilterOptions, ModeOptions,  MapControl, TripOpti
     // Destinations filter is templated with the destinations list, so must be
     // re-initialized after destinations list changes. Initialize it with this method.
     function _setupFilterControl() {
+        if (filterOptionsControl) {
+            filterOptionsControl.events.off();
+            filterOptionsControl.destroy();
+        }
         filterOptionsControl = new FilterOptions();
         filterOptionsControl.setFilter(UserPreferences.getPreference('destinationFilter'));
         filterOptionsControl.events.on(filterOptionsControl.eventNames.toggle, toggledFilter);
@@ -268,12 +272,6 @@ CAC.Pages.Home = (function ($, FilterOptions, ModeOptions,  MapControl, TripOpti
         if (tabId === tabControl.TABS.HOME) {
             UserPreferences.setPreference('method', undefined);
             clearUserSettings();
-            // TODO: change filter component back
-            console.log('use filter button bar now');
-        } else if (tabId === tabControl.TABS.DIRECTIONS || tabId === tabControl.TABS.EXPLORE) {
-            // on switching from Home to one of the two map tabs, change the filter component
-            // TODO:
-            console.log('use filter drop down now');
         }
     }
 
@@ -302,8 +300,14 @@ CAC.Pages.Home = (function ($, FilterOptions, ModeOptions,  MapControl, TripOpti
      * Updates destination filter when filter selection changed.
      */
      function toggledFilter(event, filter) {
+        // Do not trigger destination list requery unless filter actually changed.
+        // Avoids possible infinite update loop with map page select control.
+        var currentFilter = UserPreferences.getPreference('destinationFilter');
+        if (currentFilter === filter) {
+            return;
+        }
         UserPreferences.setPreference('destinationFilter', filter);
-        exploreControl.getNearbyPlaces(filter);
+        exploreControl.getNearbyPlaces();
      }
 
     /**
@@ -360,7 +364,7 @@ CAC.Pages.Home = (function ($, FilterOptions, ModeOptions,  MapControl, TripOpti
         // reset mode control
         modeOptionsControl.setMode(UserPreferences.getPreference('mode'));
         // requery for place list once origin field cleared
-        exploreControl.getNearbyPlaces(UserPreferences.getPreference('destinationFilter'));
+        exploreControl.getNearbyPlaces();
     }
 
     function onPlaceClicked(event) {

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -47,6 +47,7 @@ CAC.Pages.Home = (function ($, FilterOptions, ModeOptions,  MapControl, TripOpti
     var directionsFormControl = null;
     var directionsControl = null;
     var exploreControl = null;
+    var tripOptionsTemplate = null;
 
     function Home(params) {
         options = $.extend({}, defaults, params);
@@ -84,6 +85,17 @@ CAC.Pages.Home = (function ($, FilterOptions, ModeOptions,  MapControl, TripOpti
             urlRouter: urlRouter
         });
 
+        // Precompile trip options template. Do before `showHideNeedWheelsBanner` called.
+        var tripOptions = [
+            '<div class="banner-message">',
+            '{{modeText}}&ensp;&middot;&ensp;',
+            '{{#if rideTypeOrAccessibility}}',
+                '{{rideTypeOrAccessibility}}&ensp;&middot;&ensp;',
+            '{{/if}}',
+            '{{timingText}}',
+            '</div>'
+        ].join('');
+        tripOptionsTemplate = Handlebars.compile(tripOptions);
 
         Utils.initializeMoment();
         showHideNeedWheelsBanner();
@@ -437,16 +449,6 @@ CAC.Pages.Home = (function ($, FilterOptions, ModeOptions,  MapControl, TripOpti
      * Sets the HTML in the trip options sidebar banner, based on user preferences.
      */
     function updateTripOptionsBanner() {
-        var source = [
-            '<div class="banner-message">',
-            '{{modeText}}&ensp;&middot;&ensp;',
-            '{{#if rideTypeOrAccessibility}}',
-                '{{rideTypeOrAccessibility}}&ensp;&middot;&ensp;',
-            '{{/if}}',
-            '{{timingText}}',
-            '</div>'
-        ].join('');
-
         var isDefault = true;
 
         var mode = UserPreferences.getPreference('mode');
@@ -490,8 +492,7 @@ CAC.Pages.Home = (function ($, FilterOptions, ModeOptions,  MapControl, TripOpti
             return;
         }
 
-        var template = Handlebars.compile(source);
-        var html = template({
+        var html = tripOptionsTemplate({
             modeText: modeText,
             rideTypeOrAccessibility: rideTypeOrAccessibility,
             timingText: timingText

--- a/src/app/styles/components/_place-list.scss
+++ b/src/app/styles/components/_place-list.scss
@@ -86,8 +86,8 @@
 
             .body-map & {
                 flex-basis: 55px;
-                justify-content: space-around;
-                font-size: 1.3rem;
+                justify-content: space-between;
+                font-size: 1.6rem;
                 padding-left: 0;
                 padding-right: 0;
             }
@@ -111,19 +111,25 @@
             }
         }
 
+        select {
+            background-color: $gophillygo-blue;
+            color: $white;
+        }
+
         .filter-toggle {
             display: flex;
             flex-flow: row nowrap;
             align-items: center;
             justify-content: space-between;
-            margin-bottom: -$home-section-padding;
-            width: 100%;
 
             .body-home & {
                 @include respond-to('xxs') {
                     margin-right: 16px;
                     margin-left: 16px;
                 }
+
+                margin-bottom: -$home-section-padding;
+                width: 100%;
             }
 
             .body-map & {
@@ -183,8 +189,8 @@
         }
 
         .body-map & {
-            font-size: 1.4rem;
-            line-height: 4;
+            font-size: 1.6rem;
+            margin-left: 10px;
         }
     }
 


### PR DESCRIPTION
## Overview

Implement a dropdown destinations filter for the map sidebar. Continue to use a button bar for filtering on the homepage, and switch between the two as appropriate.

### Demo

![no_events_isochrone](https://user-images.githubusercontent.com/960264/33913251-0b953a86-df67-11e7-9242-060085270a9e.png)


### Notes

The [prototype](https://marvelapp.com/59eh08g/screen/35591677) shows the word 'Filter' at the top of the filter bar, instead of the current selection. That is not typical drop-down behavior, and gives no clear benefit; there will always be a selection, as 'All' is the default. A standard `select` element is in use here.

As visible above, destinations that do not match the filter currently have a lower opacity, as do those outside the isochrone bounds. #937 is to not display locations that do not match the filter at all.

Created #940 to separate place list header and content reloading. Adding the filter bar has changed interaction such that the header shouldn't disappear on list reload; for now, it reloads whenever the list does.


## Testing Instructions

 * `vagrant ssh app`
 * `cd /opt/app/src && npm run gulp-development`
 * Ensure service worker cache is cleared
 * Filtering on home and map pages should behave as expected
 * Navigating between home and map pages should switch between the two filter types


## Checklist
- [x] No gulp lint warnings
- [x] Gulp tests pass


Closes #933
Closes #937
