### PR TITLE
Use existing graph if present and bump OTP VM memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Development Installation
 5. See the app at http://localhost:8024! See OpenTripPlanner at http://localhost:9090.
 6. Running `npm run gulp-watch` from `/opt/app/src` will automatically collect static files together when changes are detected for Django template consumption. Alternatively, `npm run gulp-development` can be run manually whenever changes are made to the static files.
 
+Note that if there is an existing build Graph.obj in `otp_data`, vagrant provisioning in development mode will not attempt to rebuild the graph, but will use the one already present.
+
 Building AMIs
 ------------------------
 1. Make a production group_vars file (similarly to how is described above with development). Make sure production is set to true, and also specify an app_username, which should be set to: ubuntu

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ end
 
 if ENV['CAC_TRIPPLANNER_MEMORY'].nil?
   # OpenTripPlanner needs > 1GB to build and run
-  CAC_MEMORY_MB = "4096"
+  CAC_MEMORY_MB = "8192"
 else
   CAC_MEMORY_MB = ENV['CAC_TRIPPLANNER_MEMORY']
 end
@@ -117,7 +117,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     if ENV['CAC_DATABASE_MEMORY'].nil?
-      DB_MEMORY_MB = "2048"
+      DB_MEMORY_MB = "512"
     else
       DB_MEMORY_MB = ENV['CAC_DATABASE_MEMORY']
     end
@@ -154,7 +154,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     if ENV['CAC_APP_MEMORY'].nil?
-      APP_MEMORY_MB = "2048"
+      APP_MEMORY_MB = "1024"
     else
       APP_MEMORY_MB = ENV['CAC_APP_MEMORY']
     end

--- a/deployment/ansible/group_vars/development_template
+++ b/deployment/ansible/group_vars/development_template
@@ -4,7 +4,7 @@ develop: true
 production: false
 
 # open trip planner vars
-otp_process_mem: 2G
+otp_process_mem: 5G
 
 # for cac_secrets
 allowed_hosts: ['127.0.0.1', 'localhost']

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -3,4 +3,4 @@ test: true
 develop: false
 production: false
 
-otp_process_mem: 5G
+otp_process_mem: 3G

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+# # Note bzip2 only installed here as workaround for unresolved but closed phantomjs
+# install issue: https://github.com/Medium/phantomjs/issues/659
 - name: Install packages
   apt: name={{ item }} state=present
   with_items:

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -3,6 +3,7 @@
   apt: name={{ item }} state=present
   with_items:
     - binutils
+    - bzip2
     - gdal-bin
     - libpq-dev
     - libproj-dev

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
@@ -29,15 +29,22 @@
   copy: src=./otp_data/ dest="{{ otp_data_dir }}/" owner={{ansible_user_id}} group={{ansible_user_id}} mode=0664
   when: develop or test
 
+- name: Check for Existing Graph (develop)
+  stat:
+    path: "{{ otp_data_dir }}/Graph.obj"
+  register: graph
+  when: develop
+
 - name: Build OTP Graph (test/develop)
   command: /usr/bin/java -Xmx{{ otp_process_mem }} -jar {{ otp_bin_dir }}/{{ otp_jar_name }} --build {{ otp_data_dir }}
   args:
     chdir: "{{ otp_bin_dir }}"
-  when: develop or test
+  register: graph_build
+  when: test or (develop and not graph.stat.exists)
 
 - name: Copy Built OTP Graph to Host (develop)
   fetch: src={{ otp_data_dir }}/Graph.obj dest=../../otp_data/ fail_on_missing=yes flat=yes
-  when: develop
+  when: develop and graph_build|changed
 
 - name: Create Graph Directory
   file: path="{{ otp_data_dir}}/{{ otp_router }}" state=directory

--- a/src/package.json
+++ b/src/package.json
@@ -7,6 +7,7 @@
     "@turf/nearest-point-on-line": "~5.0.4"
   },
   "devDependencies": {
+    "phantomjs-prebuilt": "^2.1.16",
     "aliasify": "^2.0.0",
     "apache-server-configs": "~2.15.0",
     "bower": "~1.8.2",
@@ -54,7 +55,6 @@
     "merge-stream": "~1.0.0",
     "mocha": "~4.0.1",
     "opn": "~5.1.0",
-    "phantomjs-prebuilt": "^2.1.16",
     "pump": "~1.0.2",
     "requirejs": "~2.3.5",
     "serve-index": "~1.9.1",


### PR DESCRIPTION
## Overview

If a built Graph.obj file is present in the otp_data project directory, use it during otp VM provisioning, and do not attempt to build a new graph.

Also modifies VM memory defaults, so it will no longer be necessary to customize memory allocations for the VMs to be able to build or serve the full graph as used in production.


### Notes

To cause provisioning to rebuild the graph, first remove any existing graph from `otp_data`.


## Testing Instructions

 * `vagrant destroy`
 * Delete any existing contents from the top-level project `otp_data` directory
 * Copy a built Graph.obj file to `otp_data`
 * `vagrant up`
 * Build should succeed. Once `otp` service has finished loading graph, routing should work
 * (Following steps not necessary, are testing extra credit):
 * Delete graph from `otp_data`
 * `vagrant provision otp`
 * Provisioning should attempt to build a graph, but fail because no input files are present


Closes #856.
Closes #944.
Fixes #947.
