### PR TITLE
Feature/kak/explore mode markers#957

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -89,7 +89,6 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
     }
 
     DirectionsControl.prototype = {
-        clearDirections: clearDirections,
         setDirections: setDirections,
         setOptions: setOptions,
         setFromUserPreferences: setFromUserPreferences
@@ -176,14 +175,9 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
             UserPreferences.setPreference('method', 'directions');
             setFromUserPreferences();
         } else {
-            clearDirections();
+            clearItineraries();
             showPlaces(true);
         }
-    }
-
-    function clearDirections() {
-        mapControl.setDirectionsMarkers(null, null);
-        clearItineraries();
     }
 
     function clearItineraries() {

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -252,6 +252,7 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
         if (key === 'origin') {
             showSpinner();
             exploreLatLng = null;
+            mapControl.clearDirectionsMarker('origin');
             clearIsochrone();
             // get all places in sidebar when no origin set
             getNearbyPlaces();


### PR DESCRIPTION
## Overview

Fix origin marker display and removal on 'explore' tab.


### Notes

Marker was being set, but then immediately cleared again by the (not shown) 'directions' tab; this was fallout from the work done to sometimes displaying 'explore' tab's places list conditionally in the 'directions' tab.


## Testing Instructions

- Set an origin on home page. Click 'View map'; origin marker should be visible
- Refresh map page in explore mode'; origin marker should be visible
- Get directions, the click 'explore' tab switcher'; origin marker should be visible
- Clear origin typeahead field in 'explore' tab; origin marker should disappear
- Setting origin in typeahead on 'explore' tab should still set marker (this still worked before)
- When 'explore' tab has origin marker showing, it should disappear on navigation to home page


Closes #957
