### PR TITLE
Events UI polish

### DIFF
--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -158,7 +158,7 @@
                         <div class="place-card-badges">
                             {% has_activity destination 'cycling' as has_cycling %}
                             {% if has_cycling %}
-                            <span class="badge activity" title="Biking trails">
+                            <span class="badge activity" title="Cycling">
                                 <i class="icon-cycling"></i>
                             </span>
                             {% endif %}

--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -122,17 +122,16 @@
                                 {% if destination.start_date|localtime|date:"D N j" == destination.end_date|localtime|date:"D N j" %}
                                 <!-- same-day event -->
                                 <div class="event-date event-time">
-                                    {{ destination.start_date|date:"D N j" }}
-                                    &middot; {{ destination.start_date|time:"P" }}
+                                    {{ destination.start_date|date:"D M j" }}
+                                    &middot;
+                                    {{ destination.start_date|time:"fA" }}
                                 </div>
                                 {% else %}
                                 <!-- event ends on different day than it starts -->
                                 <div class="event-date event-time">
-                                    {{ destination.start_date|date:"D N j" }} {{ destination.start_date|time:"P" }}
-                                    &mdash;
-                                </div>
-                                <div class="event-date event-time">
-                                    {{ destination.end_date|date:"D N j" }} {{ destination.end_date|time:"P" }}
+                                    {{ destination.start_date|date:"D M j" }}
+                                    &ndash;
+                                    {{ destination.end_date|date:"D M j" }}
                                 </div>
                                 {% endif %}
                             {% endif %}

--- a/python/cac_tripplanner/templates/partials/destination-detail.html
+++ b/python/cac_tripplanner/templates/partials/destination-detail.html
@@ -34,7 +34,7 @@
                 <ul class="info-place-activities">
                     {% has_activity destination 'cycling' as has_cycling %}
                     {% if has_cycling %}
-                    <li class="activity" title="Biking trails">
+                    <li class="activity" title="Cycling">
                         <i class="icon-cycling"></i>
                     </li>
                     {% endif %}

--- a/python/cac_tripplanner/templates/partials/event-detail.html
+++ b/python/cac_tripplanner/templates/partials/event-detail.html
@@ -7,8 +7,10 @@
             <div class="info-article-header-main">
                 <h2 class="info-article-title">{{ event.name }}</h2>
                 {% if event.destination %}
-                <h3 class="info-article-subtitle">
-                    <a href="{% url 'place-detail' pk=event.destination.pk %}">
+                <h3 class="info-event-destination">
+                    at
+                    <a class="info-event-destination-link"
+                        href="{% url 'place-detail' pk=event.destination.pk %}">
                         {{ event.destination.name }}
                     </a>
                 </h3>
@@ -25,23 +27,22 @@
                 </div>
             </div>
             <div class="info-event-meta">
-                {% if event.start_date|localtime|date:"D N j" == event.end_date|localtime|date:"D N j" %}
+                {% if event.start_date|localtime|date:"D M j" == event.end_date|localtime|date:"D M j" %}
                 <!-- same-day event -->
                 <div class="info-event-date">
-                    {{ event.start_date|date:"D N j" }}
+                    {{ event.start_date|date:"D M j" }}&nbsp;
                 </div>
                 <div class="info-event-time">
-                    <span class="start-time">{{ event.start_date|time:"P" }}</span>
-                    &ndash;
-                    <span class="end-time">{{ event.end_date|time:"P" }}</span>
+                    <span class="start-time">{{ event.start_date|time:"fA"|lower }}</span>&ndash;<span class="end-time">{{ event.end_date|time:"fA"|lower }}</span>
                 </div>
                 {% else %}
                 <!-- event ends on different day than it starts -->
-                <div class="info-event-date info-event-time">
-                    {{ event.start_date|date:"D N j" }} {{ event.start_date|time:"P" }}&ndash;
+                <div class="info-event-date">
+                    {{ event.start_date|date:"D M j" }} &middot; {{ event.start_date|time:"fA"|lower }}
+                    &nbsp;&ndash;&nbsp;
                 </div>
-                <div class="info-event-date info-event-time">
-                    {{ event.end_date|date:"D N j" }} {{ event.end_date|time:"P" }}
+                <div class="info-event-date">
+                    {{ event.end_date|date:"D M j" }} &middot; {{ event.end_date|time:"fA"|lower }}
                 </div>
                 {% endif %}
             </div>

--- a/src/app/scripts/cac/home/cac-home-templates.js
+++ b/src/app/scripts/cac/home/cac-home-templates.js
@@ -170,7 +170,7 @@ CAC.Home.Templates = (function (Handlebars, moment) {
                         '</div>',
                         '<div class="place-card-badges">',
                             '{{#if this.cycling}}',
-                            '<span class="badge activity" title="Biking trails">',
+                            '<span class="badge activity" title="Cycling">',
                                 '<i class="icon-cycling"></i>',
                             '</span>',
                             '{{/if}}',

--- a/src/app/scripts/cac/home/cac-home-templates.js
+++ b/src/app/scripts/cac/home/cac-home-templates.js
@@ -98,7 +98,7 @@ CAC.Home.Templates = (function (Handlebars, moment) {
          Handlebars.registerHelper('eventTime', function(dateTime) {
             var dt = moment(dateTime); // get ISO string
             // format time portion like: 10:19 am
-            return new Handlebars.SafeString(dt.format('h:mm a'));
+            return new Handlebars.SafeString(dt.format('h:mmA'));
         });
 
          // Helper to check if event starts and ends on the same day
@@ -141,15 +141,15 @@ CAC.Home.Templates = (function (Handlebars, moment) {
                             '{{#if this.is_event }}',
                                 '{{#if (sameDay this.start_date this.end_date) }}',
                                 '<div class="event-date event-time">',
-                                    '{{eventDate this.start_date }} ',
-                                    '&middot; {{eventTime this.start_date }}',
+                                    '{{eventDate this.start_date }}',
+                                    ' &middot; ',
+                                    '{{eventTime this.start_date }}',
                                 '</div>',
                                 '{{else}}',
                                 '<div class="event-date event-time">',
-                                    '{{eventDate this.start_date }} {{eventTime this.start_date }}&mdash;',
-                                '</div>',
-                                '<div class="event-date event-time">',
-                                    '{{eventDate this.end_date }} {{eventTime this.end_date }}',
+                                    '{{eventDate this.start_date }}',
+                                    ' &ndash; ',
+                                    '{{eventDate this.end_date }}',
                                 '</div>',
                                 '{{/if}}',
                             '{{/if}}',

--- a/src/app/styles/components/_place-card.scss
+++ b/src/app/styles/components/_place-card.scss
@@ -81,8 +81,9 @@
     .event-date-time {
         display: none;
         flex: none;
-        color: $lt-gray;
+        color: $font-color;
         font-size: 1.1rem;
+        font-weight: $font-weight-semibold;
         text-align: right;
         text-transform: uppercase;
         white-space: nowrap;

--- a/src/app/styles/components/_spinner.scss
+++ b/src/app/styles/components/_spinner.scss
@@ -1,11 +1,17 @@
 .sk-spinner {
     display: flex;
     position: absolute;
+    left: 0;
+    right: 0;
     flex-flow: row nowrap;
     justify-content: center;
     width: 100%;
 
     &.hidden {
         display: none;
+    }
+
+    &.sk-three-bounce .sk-child {
+        background-color: $gophillygo-blue;
     }
 }

--- a/src/app/styles/layouts/_info.scss
+++ b/src/app/styles/layouts/_info.scss
@@ -112,7 +112,7 @@
         margin: 24px 0;
 
         @include respond-to('xs') {
-            flex-direction: column;
+            flex-direction: column-reverse;
             align-items: stretch;
         }
     }
@@ -129,7 +129,7 @@
         @include respond-to('xs') {
             flex-direction: row;
             align-items: center;
-            margin: 3.2rem 0 0;
+            margin: -.8rem 0 .8rem;
         }
     }
 
@@ -141,7 +141,7 @@
         margin: 1rem 0 0;
         padding: 0;
         color: $gophillygo-green;
-        font-size: 1.4rem;
+        font-size: 1.6rem;
         list-style: none;
 
         @include respond-to('xs') {
@@ -151,7 +151,7 @@
         }
 
         .category {
-            margin-bottom: 1em;
+            margin-bottom: .8rem;
             line-height: 1.2;
 
             @include respond-to('xs') {
@@ -204,6 +204,38 @@
         font-size: 3rem;
         font-weight: $font-weight-medium;
         line-height: 1.5;
+    }
+
+    .info-event-destination {
+        margin: .8rem 0;
+        font-size: 1.8rem;
+        font-weight: $font-weight-medium;
+        line-height: 1.5;
+    }
+
+    .info-event-destination-link {
+        @include delinkify($gophillygo-blue);
+    }
+
+    .info-event-meta {
+        flex: none;
+        margin-left: 30px;
+        font-size: 1.8rem;
+        font-weight: $font-weight-bold;
+        line-height: 2;
+
+        @include respond-to('xs') {
+            display: flex;
+            flex-flow: row wrap;
+            align-items: center;
+            justify-content: flex-start;
+            margin: -12px 0 8px;
+            align-items: stretch;
+
+            .info-event-time::before {
+                content: ' · ';
+            }
+        }
     }
 
     .info-article-aside {
@@ -267,7 +299,7 @@
         text-transform: uppercase;
 
         @include respond-to('xxs') {
-            justify-content: space-between;
+            margin-top: 2rem;
             font-size: 1.4rem;
             line-height: 2.6;
         }
@@ -278,11 +310,6 @@
             padding: 0 1em;
             background-color: $gophillygo-blue;
             cursor: pointer;
-
-            @include respond-to('xxs') {
-                margin-right: .4rem;
-                padding: 0 .6em;
-            }
         }
 
         .place-website-link {
@@ -291,11 +318,6 @@
             padding: 0 1em;
             background-color: $gophillygo-purple;
             cursor: pointer;
-
-            @include respond-to('xxs') {
-                margin-right: 0;
-                padding: 0 .6em;
-            }
         }
 
         .place-awe-link {


### PR DESCRIPTION
## Overview

This PR polishes up the format, layout, and visual treatment of event dates and times, as a follow-up to the new events system in #962 

I also slipped a couple of unrelated tweaks in:
- Cycling activity tooltip: "Biking trails" -> "Cycling" (#963)
- Changed the spinner color to fit overall site visd


### Demo

#### Multi-day and one-day event preview cards
![image](https://user-images.githubusercontent.com/128699/34951486-7bdd0534-f9e4-11e7-84f5-ced219a5748c.png)

#### One-day event detail, wide
![image](https://user-images.githubusercontent.com/128699/34951357-fccc3332-f9e3-11e7-9f7f-10ff7af6cfb6.png)

#### One-day event detail, narrow
![image](https://user-images.githubusercontent.com/128699/34951365-0ded81c0-f9e4-11e7-9093-809229ce0176.png)

#### Multi-day event detail, wide
![image](https://user-images.githubusercontent.com/128699/34951397-2a18acb2-f9e4-11e7-8530-765cc74c37f2.png)

#### Multi-day event detail, narrow
![image](https://user-images.githubusercontent.com/128699/34951389-1e39ef96-f9e4-11e7-834d-ad92e90b83c8.png)


### Notes

As a consequence of getting the narrow event detail page to look reasonable, the narrow *place* detail page has also changed slightly. The activities are now rendered above the place name instead of below the place actions. I think this is actually an improvement.

![image](https://user-images.githubusercontent.com/128699/34951466-6e12995a-f9e4-11e7-8327-dc355134b952.png)


## Testing Instructions

 * Create a one-day and a multi-day event
 * Confirm their previews cards look reasonable
 * Confirm their detail pages look reasonable, across screen widths


Connects #962, #963 
