### PR TITLE
Rename canoeing activity

### DIFF
--- a/python/cac_tripplanner/destinations/migrations/0034_rename_canoeing.py
+++ b/python/cac_tripplanner/destinations/migrations/0034_rename_canoeing.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def rename_activity(apps, from_name, to_name):
+    """Helper to rename an Activity"""
+    Activity = apps.get_model('destinations', 'Activity')
+
+    try:
+        activity = Activity.objects.get(name=from_name)
+        activity.name = to_name
+        activity.save()
+    except Activity.DoesNotExist:
+        # in case activity to rename does not exist, do nothing
+        return
+
+
+def rename_canoeing_activity_to_water_recreation(apps, schema_editor):
+    """Forewards migration; rename 'canoeing' Activity to 'water recreation'"""
+    rename_activity(apps, 'canoeing', 'water recreation')
+
+
+def rename_water_recreation_activity_to_canoeing(apps, schema_editor):
+    """"Backwards migration; rename 'water recreation' Activity to 'canoeing'"""
+    rename_activity(apps, 'water recreation', 'canoeing')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('destinations', '0033_auto_20171221_1625'),
+    ]
+
+    operations = [
+        migrations.RunPython(rename_canoeing_activity_to_water_recreation,
+                             rename_water_recreation_activity_to_canoeing),
+    ]


### PR DESCRIPTION
## Overview

Data migration to rename "canoeing" to "water activity".


### Demo

![renamed_canoeing](https://user-images.githubusercontent.com/960264/34999593-227430ae-fab0-11e7-849c-0a9b48a03477.png)


## Testing Instructions

 * Assign 'canoeing' activity to at least one destination in http://localhost:8024/admin
 * Run migrations
 * 'Canoeing' on the activity should now be 'water activity' and still be selected
 * Can test backwards migration with `./manage.py migrate destinations 0033`
 * After backwards migration, should be 'canoeing' again


Closes #969.
