### PR TITLE
Set current filter as property on place list

### DIFF
--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -85,7 +85,7 @@
                     <input type="hidden" name="destination-filter" value="All">
                 </div>
             </header>
-            <ul class="place-list">
+            <ul class="place-list" data-filter="All">
                 {% for destination in destinations %}
                 <li class="place-card {% if destination.is_event %}event-card {% endif %} no-origin"
                     {% get_directions_id destination as directions_id %}

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -367,6 +367,7 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
             destinations = _.sortBy(destinations, ['duration']);
             var places = HomeTemplates.destinations(destinations,
                                                     text,
+                                                    filter,
                                                     tabControl.isTabShowing(tabControl.TABS.HOME));
             $(options.selectors.placesContent).html(places);
             // send event that places content changed

--- a/src/app/scripts/cac/home/cac-home-templates.js
+++ b/src/app/scripts/cac/home/cac-home-templates.js
@@ -111,7 +111,7 @@ CAC.Home.Templates = (function (Handlebars, moment) {
         var source = [
             '{{> (filterPartial isHome) }}',
             '{{#unless alternateMessage}}',
-            '<ul class="place-list">',
+            '<ul class="place-list" data-filter="{{currentFilter}}">',
                 '{{#each destinations}}',
                 '<li class="place-card {{#unless this.formattedDuration}}no-origin{{/unless}} ',
                     '{{#if this.is_event}}event-card{{/if}}" ',
@@ -206,13 +206,15 @@ CAC.Home.Templates = (function (Handlebars, moment) {
      *
      * @param useDestinations {Array} Collection of JSON destinations from /api/destinations/search
      * @param alternateMessage {String} Text to display if there are no destinations
+     * @param currentFilter {String} Currently applied list filter; one of `filterOptions`
      * @param isHome {Boolean} True if currently on home page (and not map page)
      * @return html {String} Snippets for boxes to display on home page for each destination
      */
-    function destinations(useDestinations, alternateMessage, isHome) {
+    function destinations(useDestinations, alternateMessage, currentFilter, isHome) {
         return destinationListTemplate({destinations: useDestinations,
                                        alternateMessage: alternateMessage,
                                        filterOptions: filterOptions,
+                                       currentFilter: currentFilter,
                                        isHome: isHome},
                                        {data: {level: Handlebars.logger.WARN}});
     }


### PR DESCRIPTION
## Overview

Set on `data-filter` property of place list `ul` the current filter applied.


### Demo

First page load (Django template):
![data_filter_page_load_template](https://user-images.githubusercontent.com/960264/35001479-d72827e0-fab4-11e7-8edb-fa56f732733e.png)

Applied filter (JS template):
![data_filter_after_toggle](https://user-images.githubusercontent.com/960264/35001495-dea99dbe-fab4-11e7-80fe-7901b7a615b8.png)


### Notes

Since currently only one filter at a time may be used, it is a simple string.


## Testing Instructions

 * `vagrant ssh app`
 * `cd /opt/app/src && npm run gulp-development`
 * Clear app cache on browser
 * Check `data-filter` property on place list `ul` after first home page load (Django template)
 * Check `data-filter` property after picking a filter option (JS template)


Closes #966.
