### PR TITLE
Hide events in mobile All filter. Show up to one in map sidebar.

### DIFF
--- a/src/app/styles/components/_place-list.scss
+++ b/src/app/styles/components/_place-list.scss
@@ -214,9 +214,19 @@
         margin: 0;
         padding: 0;
 
+        // Just show one event in map view "All" filter
+        .body-map &[data-filter="All"] .event-card:not(:first-of-type) {
+            display: none;
+        }
+
         @include respond-to('xs') {
             flex-flow: column nowrap;
             align-items: center;
+
+            // Hide events completely from mobile "All" filter
+            &[data-filter="All"] .event-card {
+                display: none;
+            }
         }
     }
 }


### PR DESCRIPTION
## Overview

In the desktop home view, we show up to two events at the top
of the two-column place list in the All filter. In mobile home view
and in desktop map view, the place list is a single column, which
makes those top slots extra valuable.

This PR uses the `data-filter` attribute added in #974 to hide
events in the mobile All filter, and to show max one event in the
map sidebar.


### Demo

#### Desktop Home
![image](https://user-images.githubusercontent.com/128699/35049609-932540e0-fb6e-11e7-8f7c-6a9cc723b576.png)

#### Desktop Map
![image](https://user-images.githubusercontent.com/128699/35049622-a37844e2-fb6e-11e7-83d1-fef4b72ad17b.png)

#### Mobile Home
![image](https://user-images.githubusercontent.com/128699/35049651-c444f986-fb6e-11e7-9e01-00a2a97b187e.png)



### Notes

In #962 I proposed we hide events completely from the All filter in both mobile home and desktop map views. After implementing it, I decided to show max one event in the desktop map view, as there's often more vertical real estate. We can easily adjust this in the future.


## Testing Instructions

 * `vagrant ssh app`
 * `cd /opt/app/src && npm run gulp-development`
 * Ensure you have at least two published upcoming events.
 * Hard refresh `http://localhost:8024`
 * Desktop home "All": Confirm **two events** appear at the top of the home view.
 * Desktop map "All": Click Explore. Confirm **one event** appears at the top of the list.
 * Mobile home "All": Load on a phone or emulate mobile. Confirm **no events** appear.
 * Mobile home "Events": Switch to events filter. Confirm events are shown.

Connects #974, #966, #962 
