### PR TITLE
Display error message if OTP unresposive

### DIFF
--- a/src/app/scripts/cac/control/cac-control-itinerary-list.js
+++ b/src/app/scripts/cac/control/cac-control-itinerary-list.js
@@ -88,11 +88,20 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates) {
      * @param {Object} Error object returned from OTP
      */
     function setItinerariesError(error) {
-        var msg = error.msg;
-        // override default error message for out-of-bounds or non-navigable orign/destination
-        if (msg.indexOf('Your start or end point might not be safely accessible') > -1) {
-            msg = 'Make sure the origin and destination are accessible addresses within the Greater Philadelphia area.';
+
+        // default message; will use in case OTP unresponsive
+        var msg = 'Cannot currently plan trip. Please try again later.';
+
+        // If OTP responded with an error, use its message
+        if (error && error.msg) {
+            msg = error.msg;
+            // override default error message for out-of-bounds or non-navigable orign/destination
+            if (msg.indexOf('Your start or end point might not be safely accessible') > -1) {
+                msg = 'Make sure the origin and destination are accessible addresses within ' +
+                      'the Greater Philadelphia area.';
+            }
         }
+
         var alert = MapTemplates.alert(msg, 'Could not plan trip', 'danger');
         $container.html(alert);
 


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed.


### Demo

![image](https://user-images.githubusercontent.com/960264/35230758-f3c43006-ff64-11e7-8795-fe447c39c93c.png)


### Notes

A situation that shouldn't happen in production, but good to guard against nonetheless.


## Testing Instructions

 * Stop the OTP server: `vagrant halt otp`
 * Alternatively, restart OTP server, then access site before graph has loaded: `vagrant restart otp`
 * Attempt to plan a trip
 * Should get error message
 * With OTP running and the graph loaded, trip plan should still display


Fixes #978.

