### PR TITLE
Feature/kak/prod build places#980

### DIFF
--- a/src/app/scripts/cac/search/cac-geocoder.js
+++ b/src/app/scripts/cac/search/cac-geocoder.js
@@ -116,7 +116,7 @@ CAC.Search.Geocoder = (function ($, SearchParams) {
             distance: 900,  // radius, in meters, to search within; defaults to 100m
             returnIntersection: true,
             f: 'pjson',
-            cache: true
+            cache: false  // otherwise might get 304s
         };
 
         $.ajax(reverseUrl, {

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -64,6 +64,7 @@ var scriptOrder = [
     '**/cac/user/*.js',
     '**/cac/search/*.js',
     '**/cac/routing/*.js',
+    '**/cac/places/*.js',
     '**/cac/urlrouting/*.js',
     '**/cac/control/cac-control-mode-options.js',
     '**/cac/control/*.js',


### PR DESCRIPTION
## Overview

Fixes a couple of small issues:
 - reverse geocode endpoint started returning 304s, so disable caching with jQuery
 - fix production build order for added directory


## Testing Instructions

 * `npm run gulp-production` in `/opt/app/src` on the `app` VM
 * Set `if debug` to `if False` in the `base.html` template, to serve production JS locally
 * Clear service worker
 * Should be able to geocode origin
 * Should load places after geocoding origin, without console error


Fixes #980 
Fixes #981 
