### PR TITLE
Only use explore tab loader on explore tab

### DIFF
--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -133,6 +133,12 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
 
     // Helper to hide places list and show loading spinner in its place
     function showSpinner() {
+        // Directions tab shows its own spinner, with slightly different placement.
+        // When explore tab content (places list) displays within the directions tab,
+        // the directions tab handles showing/hiding its own spinner around it.
+        if (!tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
+            return;
+        }
         $(options.selectors.placesContent).addClass('hidden');
         $(options.selectors.spinner).removeClass('hidden');
     }


### PR DESCRIPTION
## Overview

Fixes second loader (spinner) showing under "Choose a route" text on directions origin change.


### Notes

Reproducing the issue seems to be easier with long trips involving transit that return multiple options.
See #984 for what the issue looks like.


## Testing Instructions

 * Plan a trip
 * Move the origin, or change the origin via the text box
 * After routes display, there should be no loader showing under "Choose a route" text
 * Loaders should otherwise display as expected, including in explore mode


Fixes #984.
