### PR TITLE
Feature/kak/fix marker popup directions#985

### DIFF
--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -255,7 +255,7 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
     }
 
     function onTypeaheadCleared(event, key) {
-        if (key === 'origin') {
+        if (key === 'origin' && exploreLatLng) {
             showSpinner();
             exploreLatLng = null;
             mapControl.clearDirectionsMarker('origin');
@@ -266,7 +266,7 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
     }
 
     function onTypeaheadSelected(event, key, location) {
-        if (key === 'origin') {
+        if (key === 'origin' && location) {
             setAddress(location);
             if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
                 clickedExplore();

--- a/src/app/scripts/cac/map/cac-map-isochrone.js
+++ b/src/app/scripts/cac/map/cac-map-isochrone.js
@@ -246,7 +246,8 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
                                      'href="{{geojson.properties.website_url}}" ',
                                      'target="_blank">Visit website</a>',
                                      '<a class="destination-directions-link" ',
-                                     'id="{{geojson.properties.placeID}}">Get Directions</a></p>'
+                                     'id="{{geojson.properties.id}}_{{geojson.properties.placeID}}"',
+                                     '>Get Directions</a></p>'
                                     ].join('');
                 var template = Handlebars.compile(popupTemplate);
                 var popupContent = template({geojson: geojson});
@@ -259,9 +260,7 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
                         .bindPopup(popupContent, {className: options.selectors.poiPopupClassName});
                 destinationMarkers[markerId] = {
                     marker: marker,
-                    destination: destinations[geojson.properties.id +
-                                              '_' +
-                                              geojson.properties.placeID]
+                    destination: destinations[markerId]
                 };
 
                 // wait to bind popup click handlers until popup is in the DOM


### PR DESCRIPTION
## Overview

Fix getting directions from marker popup link. Also fixes explore mode origin field triggering on field exit, as well as on clear.

## Testing Instructions

 * Click a place marker on the map
 * Click the 'Get Directions' link in the bottom right of the marker popup
 * Should switch to directions mode, with destination populated
 * Marker highlighting and place card directions links should still work
 * On clearing origin field in explore mode, place list should only reload once (not again on field exit)
 * Setting an origin should still work

Fixes #985 
Fixes #990 
