### PR TITLE
Add activity icons on detail page

### DIFF
--- a/python/cac_tripplanner/templates/partials/destination-detail.html
+++ b/python/cac_tripplanner/templates/partials/destination-detail.html
@@ -33,9 +33,21 @@
                 </ul>
                 <ul class="info-place-activities">
                     {% has_activity destination 'cycling' as has_cycling %}
+                    {% has_activity destination 'hiking' as has_hiking %}
+                    {% has_activity destination 'water recreation' as has_water_rec %}
                     {% if has_cycling %}
                     <li class="activity" title="Cycling">
                         <i class="icon-cycling"></i>
+                    </li>
+                    {% endif %}
+                    {% if has_hiking %}
+                    <li class="activity" title="Hiking">
+                        <i class="icon-hiking"></i>
+                    </li>
+                    {% endif %}
+                    {% if has_water_rec %}
+                    <li class="activity" title="Water recreation">
+                        <i class="icon-water"></i>
                     </li>
                     {% endif %}
                     {% if destination.accessible %}

--- a/python/cac_tripplanner/templates/partials/event-detail.html
+++ b/python/cac_tripplanner/templates/partials/event-detail.html
@@ -1,3 +1,4 @@
+{% load destination_extras %}
 {% load tz %}
 <article class="info-article">
     <header class="info-article-header">
@@ -45,6 +46,31 @@
                     {{ event.end_date|date:"D M j" }} &middot; {{ event.end_date|time:"fA"|lower }}
                 </div>
                 {% endif %}
+                <ul class="info-event-activities">
+                    {% has_activity event 'cycling' as has_cycling %}
+                    {% has_activity event 'hiking' as has_hiking %}
+                    {% has_activity event 'water recreation' as has_water_rec %}
+                    {% if has_cycling %}
+                    <li class="activity" title="Cycling">
+                        <i class="icon-cycling"></i>
+                    </li>
+                    {% endif %}
+                    {% if has_hiking %}
+                    <li class="activity" title="Hiking">
+                        <i class="icon-hiking"></i>
+                    </li>
+                    {% endif %}
+                    {% if has_water_rec %}
+                    <li class="activity" title="Water recreation">
+                        <i class="icon-water"></i>
+                    </li>
+                    {% endif %}
+                    {% if destination.accessible %}
+                    <li class="activity" title="Wheelchair accessible">
+                        <i class="icon-wheelchair"></i>
+                    </li>
+                    {% endif %}
+                </ul>
             </div>
         </div>
     </header>

--- a/src/app/styles/layouts/_info.scss
+++ b/src/app/styles/layouts/_info.scss
@@ -164,7 +164,8 @@
         }
     }
 
-    .info-place-activities {
+    .info-place-activities,
+    .info-event-activities {
         display: flex;
         flex-flow: row nowrap;
         align-items: flex-start;
@@ -188,6 +189,14 @@
             @include respond-to('xxs') {
                 margin-right: .1rem;
             }
+        }
+    }
+
+    .info-event-activities {
+        margin-top: 1.6rem;
+
+        @include respond-to('xs') {
+            margin-top: 0;
         }
     }
 
@@ -231,6 +240,11 @@
             justify-content: flex-start;
             margin: -12px 0 8px;
             align-items: stretch;
+
+            .info-event-time,
+            .info-event-date:nth-child(2) {
+                margin-right: 1.6rem;
+            }
 
             .info-event-time::before {
                 content: ' · ';
@@ -334,7 +348,6 @@
                     height: 36px;
                 }
             }
-
         }
     }
 


### PR DESCRIPTION
## Overview

Add hiking and water recreation icons to destination detail page as activity markers.


### Demo

![image](https://user-images.githubusercontent.com/960264/35831528-ff33e542-0a97-11e8-8192-abf349c91dce.png)


### Notes

Events also have their own admin interface flags for activities, but there is no place in the events detail page to display them. @lederer should we put those in somewhere?

## Testing Instructions

 * Add an event with activities to the admin site: http://localhost:8024/admin/destinations/event/add/
 * View its detail page in the front-end app
 * All relevant activity icons should appear in the top right of the summary


Closes #975.
