### PR TITLE
Feature/kak/optimizer flags#986

### DIFF
--- a/python/cac_tripplanner/templates/partials/modals.html
+++ b/python/cac_tripplanner/templates/partials/modals.html
@@ -55,10 +55,10 @@
             What kind of ride?
         </header>
         <ul class="modal-list modal-contents modal-list-narrow">
-            <li id="bikeTriangleAny" class="modal-list-choice selected">Any</li>
-            <li id="bikeTriangleFast" class="modal-list-choice">Fast</li>
-            <li id="bikeTriangleFlat" class="modal-list-choice">Flat</li>
-            <li id="bikeTriangleSafe" class="modal-list-choice">Safe</li>
+            <li id="bikeOptimizeSafe" class="modal-list-choice selected">Safe</li>
+            <li id="bikeOptimizeFast" class="modal-list-choice">Fast</li>
+            <li id="bikeOptimizeFlat" class="modal-list-choice">Flat</li>
+            <li id="bikeOptimizeAny" class="modal-list-choice">Any</li>
         </ul>
     </div>
 

--- a/python/cac_tripplanner/templates/partials/modals.html
+++ b/python/cac_tripplanner/templates/partials/modals.html
@@ -55,10 +55,9 @@
             What kind of ride?
         </header>
         <ul class="modal-list modal-contents modal-list-narrow">
-            <li id="bikeOptimizeSafe" class="modal-list-choice selected">Safe</li>
+            <li id="bikeOptimizeSafe" class="modal-list-choice selected">Safe (default)</li>
             <li id="bikeOptimizeFast" class="modal-list-choice">Fast</li>
             <li id="bikeOptimizeFlat" class="modal-list-choice">Flat</li>
-            <li id="bikeOptimizeAny" class="modal-list-choice">Any</li>
         </ul>
     </div>
 

--- a/python/cac_tripplanner/templates/partials/modals.html
+++ b/python/cac_tripplanner/templates/partials/modals.html
@@ -6,7 +6,7 @@
         <ul class="modal-list modal-contents">
             <li class="modal-list-indego">Indego bike sharing</li>
             <li class="modal-list-timing">Arrive or Depart at…</li>
-            <li class="modal-list-ride">Ride quality</li>
+            <li class="modal-list-ride">Safe ride</li>
         </ul>
         <footer class="modal-footer">
             <button name="close-modal" class="btn-close-modal">Close</button>
@@ -55,9 +55,9 @@
             What kind of ride?
         </header>
         <ul class="modal-list modal-contents modal-list-narrow">
-            <li id="bikeOptimizeSafe" class="modal-list-choice selected">Safe (default)</li>
-            <li id="bikeOptimizeFast" class="modal-list-choice">Fast</li>
-            <li id="bikeOptimizeFlat" class="modal-list-choice">Flat</li>
+            <li id="bikeOptimizeSafe" class="modal-list-choice selected">Safe ride <span class="btw">Default</span></li>
+            <li id="bikeOptimizeFast" class="modal-list-choice">Fast ride</li>
+            <li id="bikeOptimizeFlat" class="modal-list-choice">Flat ride</li>
         </ul>
     </div>
 

--- a/python/cac_tripplanner/templates/service-worker.js
+++ b/python/cac_tripplanner/templates/service-worker.js
@@ -1,7 +1,7 @@
 // Service Worker to support functioning as a PWA
 // https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
 
-var CACHE_NAME = 'cac_tripplanner_v4';
+var CACHE_NAME = 'cac_tripplanner_v5';
 
 var cacheFiles = {{ cache_files | safe }};
 

--- a/src/app/scripts/cac/control/cac-control-directions-form.js
+++ b/src/app/scripts/cac/control/cac-control-directions-form.js
@@ -164,7 +164,12 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
                 // prevent typeahead dropdown from opening by removing focus
                 clearFocus();
 
+                // use the exact location marker is at, rather than reverse geocode location
+                data.location.x = position.lng;
+                data.location.y = position.lat;
+
                 var location = Utils.convertReverseGeocodeToLocation(data);
+
                 UserPreferences.setPreference(key, location);
                 /*jshint camelcase: false */
                 var fullAddress = data.address.Match_addr;

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -152,6 +152,12 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
                 itineraryControl.draggableItinerary(currentItinerary);
             }
 
+            // snap start and end points to where first itinerary starts and ends
+            // (in case one or both markers is someplace unroutable, like in a river)
+            directions.origin = [currentItinerary.from.lat, currentItinerary.from.lon];
+            directions.destination = [currentItinerary.to.lat, currentItinerary.to.lon];
+            updateLocationPreference('origin');
+            updateLocationPreference('destination');
             // put markers at start and end
             mapControl.setDirectionsMarkers(directions.origin, directions.destination);
             itineraryListControl.setItineraries(itineraries);
@@ -419,6 +425,31 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
     // Updates the URL to match the currently-selected options
     function updateUrl() {
         urlRouter.updateUrl(urlRouter.buildDirectionsUrlFromPrefs());
+    }
+
+    /** Helper to save current directions origin or destination to user preferences.
+     *
+     * @param location {String} Either 'origin' or 'destination'
+     */
+    function updateLocationPreference(location) {
+        var preferenceLocation = UserPreferences.getPreference(location);
+        var newLocationY = directions[location][0];
+        var newLocationX = directions[location][1];
+
+        preferenceLocation.location = {
+            x: newLocationX,
+            y: newLocationY
+        };
+
+        preferenceLocation.extent = {
+            xmax: newLocationX,
+            xmin: newLocationX,
+            ymax: newLocationY,
+            ymin: newLocationY
+        };
+
+        // update location in user preferences, but not the string for it
+        UserPreferences.setPreference(location, preferenceLocation);
     }
 
     /**

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -2,7 +2,7 @@
  *  View control for the directions form
  *
  */
-CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferences, Utils) {
+CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferences) {
 
     'use strict';
 
@@ -227,13 +227,13 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
 
         if (mode.indexOf('BICYCLE') > -1) {
             // set bike trip optimization option
-            var bikeTriangle = UserPreferences.getPreference('bikeTriangle');
-            bikeTriangle = Utils.getBikeTriangle(bikeTriangle);
-            if (bikeTriangle) {
-                $.extend(otpOptions, {optimize: 'TRIANGLE'}, bikeTriangle);
+            var bikeOptimize = UserPreferences.getPreference('bikeOptimize');
+            if (bikeOptimize !== 'ANY') {
+                $.extend(otpOptions, {optimize: bikeOptimize});
             }
         } else {
-            $.extend(otpOptions, { wheelchair: UserPreferences.getPreference('wheelchair') });
+            $.extend(otpOptions, { wheelchair: UserPreferences.getPreference('wheelchair'),
+                                   optimize: 'GREENWAYS' });
         }
 
         $.extend(otpOptions, {
@@ -446,4 +446,4 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
         }
     }
 
-})(_, jQuery, moment, CAC.Control, CAC.Routing.Plans, CAC.User.Preferences, CAC.Utils);
+})(_, jQuery, moment, CAC.Control, CAC.Routing.Plans, CAC.User.Preferences);

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -156,8 +156,8 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
             // (in case one or both markers is someplace unroutable, like in a river)
             directions.origin = [currentItinerary.from.lat, currentItinerary.from.lon];
             directions.destination = [currentItinerary.to.lat, currentItinerary.to.lon];
-            updateLocationPreference('origin');
-            updateLocationPreference('destination');
+            updateLocationPreferenceWithDirections('origin');
+            updateLocationPreferenceWithDirections('destination');
             // put markers at start and end
             mapControl.setDirectionsMarkers(directions.origin, directions.destination);
             itineraryListControl.setItineraries(itineraries);
@@ -429,10 +429,15 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
 
     /** Helper to save current directions origin or destination to user preferences.
      *
-     * @param location {String} Either 'origin' or 'destination'
+     * @param key {String} Either 'origin' or 'destination'
      */
-    function updateLocationPreference(location) {
-        var preferenceLocation = UserPreferences.getPreference(location);
+    function updateLocationPreferenceWithDirections(key) {
+        var preferenceLocation = UserPreferences.getPreference(key);
+
+        if (!directions[location] || directions[location].length < 2) {
+            return;
+        }
+
         var newLocationY = directions[location][0];
         var newLocationX = directions[location][1];
 

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -234,7 +234,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
         if (mode.indexOf('BICYCLE') > -1) {
             // set bike trip optimization option
             var bikeOptimize = UserPreferences.getPreference('bikeOptimize');
-            if (bikeOptimize !== 'ANY') {
+            if (bikeOptimize) {
                 $.extend(otpOptions, {optimize: bikeOptimize});
             }
         } else {

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -136,7 +136,7 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
         // Directions tab shows its own spinner, with slightly different placement.
         // When explore tab content (places list) displays within the directions tab,
         // the directions tab handles showing/hiding its own spinner around it.
-        if (!tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
+        if (tabControl.isTabShowing(tabControl.TABS.DIRECTIONS)) {
             return;
         }
         $(options.selectors.placesContent).addClass('hidden');

--- a/src/app/scripts/cac/control/cac-control-trip-options.js
+++ b/src/app/scripts/cac/control/cac-control-trip-options.js
@@ -62,7 +62,6 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
                 'noWheelchair': {name: 'wheelchair', value: undefined},
                 'noBikeShare': {name: 'bikeShare', value: undefined},
                 'useBikeShare': {name: 'bikeShare', value: true},
-                'bikeOptimizeAny': {name: 'bikeOptimize', value: 'ANY'},
                 'bikeOptimizeFast': {name: 'bikeOptimize', value: 'QUICK'},
                 'bikeOptimizeFlat': {name: 'bikeOptimize', value: 'FLAT'},
                 'bikeOptimizeSafe': {name: 'bikeOptimize', value: 'GREENWAYS'},

--- a/src/app/scripts/cac/control/cac-control-trip-options.js
+++ b/src/app/scripts/cac/control/cac-control-trip-options.js
@@ -11,7 +11,7 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
         defaultMenuText: {
             bikeShare: 'Indego bike sharing',
             timing: 'Arrive or Depart at…',
-            bikeOptimize: 'Ride quality',
+            bikeOptimize: 'Safe ride',
             accessibility: 'Accessibility'
         },
         selectors: {

--- a/src/app/scripts/cac/control/cac-control-trip-options.js
+++ b/src/app/scripts/cac/control/cac-control-trip-options.js
@@ -1,7 +1,7 @@
 /**
  * Manage modals used to set and display trip planning options.
  */
-CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferences) {
+CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferences, Utils) {
     'use strict';
 
     var defaults = {
@@ -11,7 +11,7 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
         defaultMenuText: {
             bikeShare: 'Indego bike sharing',
             timing: 'Arrive or Depart at…',
-            bikeTriangle: 'Ride quality',
+            bikeOptimize: 'Ride quality',
             accessibility: 'Accessibility'
         },
         selectors: {
@@ -62,15 +62,15 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
                 'noWheelchair': {name: 'wheelchair', value: undefined},
                 'noBikeShare': {name: 'bikeShare', value: undefined},
                 'useBikeShare': {name: 'bikeShare', value: true},
-                'bikeTriangleAny': {name: 'bikeTriangle', value: undefined},
-                'bikeTriangleFast': {name: 'bikeTriangle', value: 'fast'},
-                'bikeTriangleFlat': {name: 'bikeTriangle', value: 'flat'},
-                'bikeTriangleSafe': {name: 'bikeTriangle', value: 'safe'},
+                'bikeOptimizeAny': {name: 'bikeOptimize', value: 'ANY'},
+                'bikeOptimizeFast': {name: 'bikeOptimize', value: 'QUICK'},
+                'bikeOptimizeFlat': {name: 'bikeOptimize', value: 'FLAT'},
+                'bikeOptimizeSafe': {name: 'bikeOptimize', value: 'GREENWAYS'},
                 'arriveBy': {name: 'arriveBy', value: true},
                 'departAt': {name: 'arriveBy', value: false}
             },
             // distinct 'name' in optionPreferences above
-            preferences: ['wheelchair', 'bikeShare', 'bikeTriangle', 'arriveBy']
+            preferences: ['wheelchair', 'bikeShare', 'bikeOptimize', 'arriveBy']
         }
     };
     var events = $({});
@@ -291,6 +291,9 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
                     if (selectedOptionId === 'useBikeShare') {
                         UserPreferences.setPreference('arriveBy', false);
                         UserPreferences.setPreference('dateTime', undefined);
+                    } else  if (selectedOptionId === 'bikeOptimizeSafe') {
+                        // safe mode is default for bike optimization
+                        UserPreferences.setPreference(setting.name, undefined);
                     }
                 } else {
                     console.error('selected unrecognized option with ID: ' + selectedOptionId);
@@ -333,7 +336,7 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
         var source = [
             '<li class="modal-list-indego {{#if setBikeShare}} selected{{/if}}">{{bikeShare}}</li>',
             '<li class="modal-list-timing {{#if setTiming}} selected{{/if}}">{{timing}}</li>',
-            '<li class="modal-list-ride {{#if setTriangle}} selected{{/if}}">{{bikeTriangle}}</li>'
+            '<li class="modal-list-ride {{#if setBikeOptimize}} selected{{/if}}">{{bikeOptimize}}</li>'
         ].join('');
 
         var bikeShare = options.defaultMenuText.bikeShare;
@@ -347,16 +350,12 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
             }
         }
 
-        var bikeTriangle = options.defaultMenuText.bikeTriangle;
-        var setTriangle = false;
-        if (!UserPreferences.isDefault('bikeTriangle')) {
-            setTriangle = true;
-            var bikePreference = UserPreferences.getPreference('bikeTriangle');
-            bikeTriangle = [
-                bikePreference.charAt(0).toUpperCase(),
-                bikePreference.slice(1),
-                ' ride'
-            ].join('');
+        var bikeOptimize = options.defaultMenuText.bikeOptimize;
+        var setBikeOptimize = false;
+        if (!UserPreferences.isDefault('bikeOptimize')) {
+            setBikeOptimize = true;
+            var bikePreference = UserPreferences.getPreference('bikeOptimize');
+            bikeOptimize = Utils.getBikeOptimizeLabel(bikePreference);
         }
 
         var timing = getTimingText();
@@ -371,8 +370,8 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
             setBikeShare: setBikeShare,
             timing: timing,
             setTiming: setTiming,
-            bikeTriangle: bikeTriangle,
-            setTriangle: setTriangle
+            bikeOptimize: bikeOptimize,
+            setBikeOptimize: setBikeOptimize
         });
 
         return html;
@@ -623,4 +622,4 @@ CAC.Control.TripOptions = (function ($, Handlebars, moment, Modal, UserPreferenc
         UserPreferences.setPreference('dateTime', undefined);
     }
 
-})(jQuery, Handlebars, moment, CAC.Control.Modal, CAC.User.Preferences);
+})(jQuery, Handlebars, moment, CAC.Control.Modal, CAC.User.Preferences, CAC.Utils);

--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -470,9 +470,9 @@ CAC.Pages.Home = (function ($, FilterOptions, ModeOptions,  MapControl, TripOpti
             }
             isDefault = UserPreferences.isDefault('bikeShare') && isDefault;
 
-            var rideType = UserPreferences.getPreference('bikeTriangle');
-            isDefault = UserPreferences.isDefault('bikeTriangle') && isDefault;
-            rideTypeOrAccessibility = rideType.charAt(0).toUpperCase() + rideType.slice(1) + ' ride';
+            var rideType = UserPreferences.getPreference('bikeOptimize');
+            isDefault = UserPreferences.isDefault('bikeOptimize') && isDefault;
+            rideTypeOrAccessibility = Utils.getBikeOptimizeLabel(rideType);
         } else {
             var wheelchair = UserPreferences.getPreference('wheelchair');
             isDefault = UserPreferences.isDefault('wheelchair') && isDefault;

--- a/src/app/scripts/cac/places/cac-places.js
+++ b/src/app/scripts/cac/places/cac-places.js
@@ -68,7 +68,7 @@ CAC.Places.Places = (function(_, $, moment, Routing, UserPreferences) {
         if (mode.indexOf('BICYCLE') > -1) {
             // set bike trip optimization option
             var bikeOptimize = UserPreferences.getPreference('bikeOptimize');
-            if (bikeOptimize !== 'ANY') {
+            if (bikeOptimize) {
                 $.extend(otpOptions, {optimize: bikeOptimize});
             }
         } else {

--- a/src/app/scripts/cac/places/cac-places.js
+++ b/src/app/scripts/cac/places/cac-places.js
@@ -1,4 +1,4 @@
-CAC.Places.Places = (function(_, $, moment, Routing, UserPreferences, Utils) {
+CAC.Places.Places = (function(_, $, moment, Routing, UserPreferences) {
     'use strict';
 
     var module = {
@@ -67,13 +67,13 @@ CAC.Places.Places = (function(_, $, moment, Routing, UserPreferences, Utils) {
 
         if (mode.indexOf('BICYCLE') > -1) {
             // set bike trip optimization option
-            var bikeTriangle = UserPreferences.getPreference('bikeTriangle');
-            bikeTriangle = Utils.getBikeTriangle(bikeTriangle);
-            if (bikeTriangle) {
-                $.extend(otpOptions, {optimize: 'TRIANGLE'}, bikeTriangle);
+            var bikeOptimize = UserPreferences.getPreference('bikeOptimize');
+            if (bikeOptimize !== 'ANY') {
+                $.extend(otpOptions, {optimize: bikeOptimize});
             }
         } else {
-            $.extend(otpOptions, { wheelchair: UserPreferences.getPreference('wheelchair') });
+            $.extend(otpOptions, { wheelchair: UserPreferences.getPreference('wheelchair'),
+                                   optimize: 'GREENWAYS' });
         }
 
         return otpOptions;
@@ -152,4 +152,4 @@ CAC.Places.Places = (function(_, $, moment, Routing, UserPreferences, Utils) {
         return promises;
     }
 
-})(_, jQuery, moment, CAC.Routing.Plans, CAC.User.Preferences, CAC.Utils);
+})(_, jQuery, moment, CAC.Routing.Plans, CAC.User.Preferences);

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -143,6 +143,7 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
             toPlace: coordsTo.join(','),
             time: when.format('hh:mma'),
             date: when.format('MM-DD-YYYY'),
+            locale: 'en'
         };
 
         var params = $.param($.extend(formattedOpts, extraOptions));

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -15,7 +15,7 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
                          'mode',
                          'maxWalk',
                          'wheelchair',
-                         'bikeTriangle',
+                         'bikeOptimize',
                          'arriveBy',
                          'dateTime'];
 

--- a/src/app/scripts/cac/user/cac-user-preferences.js
+++ b/src/app/scripts/cac/user/cac-user-preferences.js
@@ -33,7 +33,7 @@ CAC.User.Preferences = (function(Storages, _) {
     var defaults = {
         arriveBy: false, // depart at set time, by default
         bikeShare: false,
-        bikeTriangle: 'any',
+        bikeOptimize: 'GREENWAYS',
         dateTime: undefined, // explicitly list here for isDefault check
         destinationFilter: 'All',
         exploreMinutes: 15,

--- a/src/app/scripts/cac/user/cac-user-preferences.js
+++ b/src/app/scripts/cac/user/cac-user-preferences.js
@@ -78,6 +78,14 @@ CAC.User.Preferences = (function(Storages, _) {
             val = _.has(defaults, preference) ? defaults[preference] : undefined;
         } else {
             val = JSON.parse(val);
+
+            // ensure bike optimization parameter is allowed
+            if (preference === 'bikeOptimize') {
+                if (!['GREENWAYS', 'FLAT', 'QUICK'].includes(val)) {
+                    val = 'GREENWAYS';
+                    setPreference(preference, val, true);
+                }
+            }
         }
         return val;
     }

--- a/src/app/scripts/cac/utils.js
+++ b/src/app/scripts/cac/utils.js
@@ -53,30 +53,6 @@ CAC.Utils = (function (_, moment) {
         wy: 'Wy',
     };
 
-    // Note:  the three bike options must sum to 1, or OTP won't plan the trip
-    var bikeTriangle = {
-        any: {
-            triangleSafetyFactor: 0.34,
-            triangleSlopeFactor: 0.33,
-            triangleTimeFactor: 0.33
-        },
-        flat: {
-            triangleSafetyFactor: 0.17,
-            triangleSlopeFactor: 0.66,
-            triangleTimeFactor: 0.17
-        },
-        fast: {
-            triangleSafetyFactor: 0.17,
-            triangleSlopeFactor: 0.17,
-            triangleTimeFactor: 0.66
-        },
-        safe: {
-            triangleSafetyFactor: 0.66,
-            triangleSlopeFactor: 0.17,
-            triangleTimeFactor: 0.17
-        }
-    };
-
     // linestring colors for each mode
     var brandColors = {
         BLUE: '#2e68a3',
@@ -101,12 +77,12 @@ CAC.Utils = (function (_, moment) {
     };
 
     var module = {
-        getBikeTriangle: getBikeTriangle,
         convertReverseGeocodeToLocation: convertReverseGeocodeToLocation,
         defaultBackgroundLineColor: defaultBackgroundLineColor,
         defaultModeColor: defaultModeColor,
         getImageUrl: getImageUrl,
         abbrevStreetName: abbrevStreetName,
+        getBikeOptimizeLabel: getBikeOptimizeLabel,
         getUrlParams: getUrlParams,
         encodeUrlParams: encodeUrlParams,
         getModeColor: getModeColor,
@@ -115,22 +91,6 @@ CAC.Utils = (function (_, moment) {
     };
 
     return Object.freeze(module);
-
-    /**
-     * Get OTP values for the bikeTriangle parameter, which weights based on
-     * relative preference for safety, speed, or flatness of route.
-     *
-     * @param {string} option Key for which option to prefer
-     * @returns {Object} Values that sum to 1 and weight for the preferred option
-     */
-    function getBikeTriangle(option) {
-        if (_.has(bikeTriangle, option)) {
-            return bikeTriangle[option];
-        }
-
-        console.error('bike triangle option ' + option + ' not found');
-        return bikeTriangle.any;
-    }
 
     /**
      * Convert ESRI reverse geocode response into location formatted like typeahead results.
@@ -197,6 +157,20 @@ CAC.Utils = (function (_, moment) {
             parts.splice(0, 0, streetNumber);
         }
         return parts.join(' ');
+    }
+
+    // Return user-facing label for a bike ride type selection
+    function getBikeOptimizeLabel(optimizeSelection) {
+        var bikeOptimizeStrings = {
+            'ANY': 'Any ride',
+            'FLAT': 'Flat ride',
+            'QUICK': 'Fast ride',
+            'GREENWAYS': 'Safe ride'
+        };
+
+        return _.has(bikeOptimizeStrings, optimizeSelection) ?
+            bikeOptimizeStrings[optimizeSelection] :
+            bikeOptimizeStrings.GREENWAYS;
     }
 
     // Use with images in the app/images folder

--- a/src/app/scripts/cac/utils.js
+++ b/src/app/scripts/cac/utils.js
@@ -162,10 +162,9 @@ CAC.Utils = (function (_, moment) {
     // Return user-facing label for a bike ride type selection
     function getBikeOptimizeLabel(optimizeSelection) {
         var bikeOptimizeStrings = {
-            'ANY': 'Any ride',
             'FLAT': 'Flat ride',
             'QUICK': 'Fast ride',
-            'GREENWAYS': 'Safe ride'
+            'GREENWAYS': 'Safe ride (default)'
         };
 
         return _.has(bikeOptimizeStrings, optimizeSelection) ?

--- a/src/app/scripts/cac/utils.js
+++ b/src/app/scripts/cac/utils.js
@@ -164,7 +164,7 @@ CAC.Utils = (function (_, moment) {
         var bikeOptimizeStrings = {
             'FLAT': 'Flat ride',
             'QUICK': 'Fast ride',
-            'GREENWAYS': 'Safe ride (default)'
+            'GREENWAYS': 'Safe ride (Default)'
         };
 
         return _.has(bikeOptimizeStrings, optimizeSelection) ?

--- a/src/app/styles/components/_modal.scss
+++ b/src/app/styles/components/_modal.scss
@@ -182,7 +182,7 @@
     padding: 0;
 
     &.modal-list-narrow li {
-        padding-left: 100px;
+        padding-left: 80px;
     }
 
     li {
@@ -195,6 +195,14 @@
 
         .modal-share & {
             height: 5rem;
+        }
+
+        .btw {
+            margin-left: .8rem;
+            color: $lt-gray;
+            font-size: 1.2rem;
+            font-weight: $font-weight-medium;
+            text-transform: uppercase;
         }
 
         &:hover {

--- a/src/test/spec/user/cac-user-preferences-test.js
+++ b/src/test/spec/user/cac-user-preferences-test.js
@@ -49,7 +49,7 @@
 
         it('Should fall back on default value when not set by user', function(done) {
             // is in defaults but not in user settings
-            expect(UserPreferences.getPreference('bikeTriangle')).toEqual('any');
+            expect(UserPreferences.getPreference('bikeOptimize')).toEqual('GREENWAYS');
 
             // is in defaults, but overridden by user setting
             UserPreferences.setPreference('bikeTriangle', 'warp7');


### PR DESCRIPTION
## Overview

Switch away from using the "bike triangle" optimizer parameters, which set values summing to one for how much to weight for safety, speed, and elevation change when planning a bicycle trip, to using optimizer mode flags for each three of those considerations. The "safe" flag replacement, `GREENWAYS`, also works for walking trips and is sent for all non-bike trips. The default for bike trips has been changed from 'any' (no optimizer flag sent) to 'safe' (the new `GREENWAYS` flag).

Also, this PR fixes the spinner not showing on the homepage on place list reload, and modifies the way origin/destination marker drags are handled. The marker locations when getting directions are updated to the start/end points pulled from the encoded polyline for the first itinerary returned, in order to pin the marker to the street network (in case it was dropped somewhere unroutable), instead of moving the marker to its reverse geocoded location. This fixes issues around attempting to route to/from places that are routable, but not by a street address known to the geocoder, like on paths.


### Demo

Default bike route, now going along the Camden waterfront (with 'safe' mode):
![image](https://user-images.githubusercontent.com/960264/35832557-b6a59eb6-0a9b-11e8-8f9e-993136e41105.png)

On changing to 'any' mode (no optimization flag set; OTP defaults to maximize for speed):
![image](https://user-images.githubusercontent.com/960264/35832574-c9b577d8-0a9b-11e8-97a5-a88478286674.png)


### Notes

[Here](https://github.com/opentripplanner/OpenTripPlanner/commit/ec9db2e36e5f099af80ecfb0c378865c20f80cb8) is what the `GREENWAYS` flag actually does.

The inbuilt OTP trip planner app runs locally [here](http://localhost:9090/). It can be helpful to see behavior without origin/destination markers getting snapped to the itinerary/street network.


## Testing Instructions

Note: going to pull updated OSM tomorrow (Tuesday) and provide a rebuilt graph for testing that should reflect behavior that would be in the next deployment.

 * Toggling routing options in modal should function as expected
 * Try planning trips to check for any strange behavior, especially around paths
 * Try moving markers around; if dropped somewhere unroutable, should move to start/end of path
 * Spinner on home page should function as expected on origin change or filter apply


Closes #986 
