### PR TITLE
Cancel outstanding trip plan request

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -22,7 +22,6 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
     };
     var options = {};
 
-    // cancel previous trip request when issuing a new one
     var planTripRequest = null;
     var OUTDATED_REQUEST_ERROR = 'outdated request';
 
@@ -180,9 +179,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
             itineraryListControl.show();
             // highlight first itinerary in sidebar as well as on map
             findItineraryBlock(currentItinerary.id).addClass(options.selectors.selectedItineraryClass);
-            planTripRequest = null;
         }, function (error) {
-            planTripRequest = null;
             // Cancelled requests are expected; do not display an error message to user.
             // Just keep showing the loading animation until a subsequent request completes.
             if (error && error.message === OUTDATED_REQUEST_ERROR) {
@@ -196,7 +193,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
             itineraryListControl.setItinerariesError(error);
             itineraryListControl.show();
         });
-    }, DIRECTION_THROTTLE_MILLIS);
+    }, DIRECTION_THROTTLE_MILLIS, {leading: true, trailing: true});
 
     return DirectionsControl;
 

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -22,6 +22,10 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
     };
     var options = {};
 
+    // cancel previous trip request when issuing a new one
+    var planTripRequest = null;
+    var OUTDATED_REQUEST_ERROR = 'outdated request';
+
     var currentItinerary = null;
 
     var directions = {
@@ -98,7 +102,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
      * Set user preferences before planning trip.
      * Throttled to cut down on requests.
      */
-    var planTrip = _.throttle(function() {  // jshint ignore:line
+    var planTrip = _.debounce(function() {  // jshint ignore:line
         showPlaces(false);
         if (!(directions.origin && directions.destination)) {
             directionsFormControl.setError('origin');
@@ -128,8 +132,20 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
 
         tabControl.setTab(tabControl.TABS.DIRECTIONS);
 
-        Routing.planTrip(directions.origin, directions.destination, date, otpOptions)
-        .then(function (itineraries) {
+        // If a previous request is in progress, cancel it before issuing the new one.
+        // Prevents callbacks being executed out of order.
+        if (planTripRequest) {
+            planTripRequest.reject(Error(OUTDATED_REQUEST_ERROR));
+        }
+
+        planTripRequest = Routing.planTrip(directions.origin,
+                                           directions.destination,
+                                           date,
+                                           otpOptions,
+                                           true);
+
+
+        planTripRequest.then(function (itineraries) {
             $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
             // Add the itineraries to the map, highlighting the first one
             var isFirst = true;
@@ -164,7 +180,15 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
             itineraryListControl.show();
             // highlight first itinerary in sidebar as well as on map
             findItineraryBlock(currentItinerary.id).addClass(options.selectors.selectedItineraryClass);
+            planTripRequest = null;
         }, function (error) {
+            planTripRequest = null;
+            // Cancelled requests are expected; do not display an error message to user.
+            // Just keep showing the loading animation until a subsequent request completes.
+            if (error && error.message === OUTDATED_REQUEST_ERROR) {
+                return;
+            }
+
             console.error('failed to plan trip');
             console.error(error);
             $(options.selectors.spinner).addClass(options.selectors.hiddenClass);

--- a/src/app/scripts/cac/places/cac-places.js
+++ b/src/app/scripts/cac/places/cac-places.js
@@ -127,7 +127,7 @@ CAC.Places.Places = (function(_, $, moment, Routing, UserPreferences) {
             if (xCoord && yCoord) {
                 var placeCoords = [yCoord, xCoord];
                 // get travel time to destination and update place card
-                Routing.planTrip(exploreLatLng, placeCoords, date, otpOptions)
+                Routing.planTrip(exploreLatLng, placeCoords, date, otpOptions, false)
                 .then(function (itineraries) {
                     if (itineraries && itineraries.length) {
                         var itinerary = itineraries[0];

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -15,11 +15,14 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
      * @param {array} coordsTo The coords in lat-lng which we would like to travel to
      * @param {Object} when moment.js date/time object for when the trip should be
      * @param {String} extraOptions Modes of travel to use for this trip, other options
+     * @param {boolean} returnDeferred If true, return mutable jQuery deferred object, rather than
+     *                                 immutable promise. Allows cancelling request.
      *
-     * @return {promise} The promise object which - if successful - resolves to a
-     *                   an object with itineraries
+     * @return {Promise or Deferred} The promise/deferred which - if successful - resolves to a
+     *                               an object with itineraries. Returns promise unless
+     *                               `returnDeferred` is `true`.
      */
-    function planTrip(coordsFrom, coordsTo, when, extraOptions) {
+    function planTrip(coordsFrom, coordsTo, when, extraOptions, returnDeferred) {
         var deferred = $.Deferred();
         var urlParams = prepareParams(coordsFrom, coordsTo, when, extraOptions);
 
@@ -67,7 +70,7 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
         }).fail(function (error) {
             deferred.reject(error);
         });
-        return deferred.promise();
+        return returnDeferred ? deferred : deferred.promise();
     }
 
     /**


### PR DESCRIPTION
## Overview

When finding directions in response to directions form input, cancel previous routing request
before issuing a new one.

Fixes outdated results being displayed when the routing requests resolve out of order.


### Notes

Changed `throttle` to `debounce` in case [this lodash issue](https://github.com/lodash/lodash/issues/3051) still exists (issue was closed in favor of a related PR, but the PR was never merged).

Changed trip plan routing function to optionally return `Deferred` instead of an immutable `Promise` so it can be cancelled in the requesting control. Did that instead of modifying the trip plan routing function to cancel requests itself, as in other cases we do want to allow multiple routing requests to fire simultaneously and return as soon as they resolve, particularly when finding travel times from the origin to all destinations.


## Testing Instructions

(To reproduce the issue, try the steps below on the production site.)

 * Plan a bicycle trip; the longer the better, to increase query time
 * After loading animation displays, toggle the transit button repeatedly while animation is still showing
 * Loading animation should continue to show until results display
 * Itineraries displayed should match the last directions form input options set (with transit, or not)
 * Finding travel times to full destinations list should continue to work as expected


Fixes #998.
