### PR TITLE
Disable service worker cache

### DIFF
--- a/python/cac_tripplanner/templates/service-worker.js
+++ b/python/cac_tripplanner/templates/service-worker.js
@@ -1,7 +1,7 @@
 // Service Worker to support functioning as a PWA
 // https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
 
-var CACHE_NAME = 'cac_tripplanner_v6';
+var CACHE_NAME = 'cac_tripplanner_v7';
 
 var cacheFiles = {{ cache_files | safe }};
 
@@ -15,36 +15,8 @@ self.addEventListener('install', function(event) {
     }));
 });
 
-/**
- * Handle service worker requests, fetching from cache if already cached,
- * or putting in cache if it's hosted on this domain.
- */
 self.addEventListener('fetch', function(event) {
-    event.respondWith(caches.match(event.request).then(function(response) {
-        // caches.match() always resolves
-        // but in case of success response will have value
-        if (response !== undefined) {
-            return response;
-        } else {
-            return fetch(event.request).then(function (response) {
-                // Only cache static and media assets on this domain
-                var url = event.request.url;
-                if (url.startsWith(location.origin) &&
-                    (url.includes('/static') || url.includes('/media'))) {
-
-                    var responseClone = response.clone();
-                    caches.open(CACHE_NAME).then(function (cache) {
-                        cache.put(event.request, responseClone);
-                    });
-                }
-                return response;
-            }).catch(function (error) {
-                console.error(error);
-                console.error(event);
-                return fetch(event.request);
-            });
-        }
-    }));
+    return fetch(event.request); // do not use cache
 });
 
 self.addEventListener('activate', function(e) {


### PR DESCRIPTION
As a workaround for #1005, do not cache files with the service worker.
Service worker still installs, but does not attempt to use files from cache.

Test by disabling network and reloading page: nothing should load.
