### PR TITLE
Disable slider when no origin

### DIFF
--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -240,6 +240,18 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
         );
     }
 
+    function enableSlider(doEnable) {
+        if (doEnable) {
+            $(options.selectors.isochroneSliderContainer).removeClass('disabled');
+            $(options.selectors.isochroneSlider).removeClass('disabled');
+        } else {
+            $(options.selectors.isochroneSliderContainer).addClass('disabled');
+            $(options.selectors.isochroneSlider).addClass('disabled');
+        }
+        $(options.selectors.isochroneSliderContainer).prop('disabled', !doEnable);
+        $(options.selectors.isochroneSlider).prop('disabled', !doEnable);
+    }
+
     function setError(message) {
         if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
             var $alert = $(MapTemplates.alert(message, 'Cannot show travelshed', 'danger'));
@@ -258,6 +270,7 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
         if (key === 'origin' && exploreLatLng) {
             showSpinner();
             exploreLatLng = null;
+            enableSlider(false);
             mapControl.clearDirectionsMarker('origin');
             clearIsochrone();
             // get all places in sidebar when no origin set
@@ -297,8 +310,10 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
             if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
                 mapControl.setDirectionsMarkers(exploreLatLng);
             }
+            enableSlider(true);
         } else {
             exploreLatLng = null;
+            enableSlider(false);
             clearIsochrone();
         }
     }
@@ -325,6 +340,7 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
             setAddress(exploreOrigin);
         } else {
             exploreLatLng = null;
+            enableSlider(false);
         }
     }
 

--- a/src/app/styles/components/_directions-form.scss
+++ b/src/app/styles/components/_directions-form.scss
@@ -495,30 +495,37 @@
     }
 
     .directions-tab-button.isochrone-control {
-            &:after {
-                background: $gophillygo-blue;
+        &:after {
+            background: $gophillygo-blue;
+        }
+
+        &.disabled {
+            #output-directions-within,
+            #isochrone-slider {
+                opacity: .2;
             }
         }
+    }
 
-        .directions-to label {
-            padding-right: 1em;
-            margin-right: .2em;
+    .directions-to label {
+        padding-right: 1em;
+        margin-right: .2em;
+    }
+
+    #output-directions-within {
+        position: relative;
+        min-width: 5em;
+        margin: 0 2rem 0 .5rem;
+        color: $white;
+        font-size: 1.4rem;
+        font-weight: $font-weight-medium;
+        line-height: 30px;
+        text-align: right;
+
+        &:after {
+            content: ' minutes';
         }
-
-        #output-directions-within {
-            position: relative;
-            min-width: 5em;
-            margin: 0 2rem 0 .5rem;
-            color: $white;
-            font-size: 1.4rem;
-            font-weight: $font-weight-medium;
-            line-height: 30px;
-            text-align: right;
-
-            &:after {
-                content: ' minutes';
-            }
-        }
+    }
 }
 
 @keyframes full-rotation {


### PR DESCRIPTION
Set a `disabled` class and the `disabled` property on the explore mode range slider and parent control
whenever the origin field is empty or not set to a location yet.

(Not styled, so it looks the same whether enabled or disabled.)

Closes #905.

