### PR TITLE
Update deployment related dependencies

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant.require_version ">= 1.5"
+Vagrant.require_version ">= 2.0"
 require "yaml"
 
 CAC_SHARED_FOLDER_TYPE = ENV.fetch("CAC_SHARED_FOLDER_TYPE", "nfs")
@@ -111,6 +111,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     database.ssh.forward_x11 = true
 
     database.vm.provision "ansible" do |ansible|
+      ansible.compatibility_mode = "2.0"
       ansible.playbook = "deployment/ansible/database.yml"
       ansible.inventory_path = ANSIBLE_INVENTORY_PATH
       ansible.raw_arguments = ["--timeout=60"]
@@ -148,6 +149,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     app.ssh.forward_x11 = true
 
     app.vm.provision "ansible" do |ansible|
+      ansible.compatibility_mode = "2.0"
       ansible.playbook = "deployment/ansible/app.yml"
       ansible.inventory_path = ANSIBLE_INVENTORY_PATH
       ansible.raw_arguments = ["--timeout=60"]
@@ -177,6 +179,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     otp.ssh.forward_x11 = true
 
     otp.vm.provision "ansible" do |ansible|
+      ansible.compatibility_mode = "2.0"
       ansible.playbook = "deployment/ansible/otp.yml"
       ansible.inventory_path = ANSIBLE_INVENTORY_PATH
       ansible.raw_arguments = ["--timeout=60"]

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,7 +1,7 @@
 ---
 app_username: "vagrant"
 
-packer_version: "0.7.5"
+packer_version: "1.0.2"
 
 nodejs_version: 8.10.0
 

--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -28,6 +28,7 @@ cac_python_dependencies:
     - { name: 'psycopg2', version: '2.7.4' }
     - { name: 'pytz', version: '2018.3' }
     - { name: 'pyyaml', version: '3.12' }
-    - { name: 'troposphere', version: '0.7.2'}
+    - { name: 'troposphere', version: '1.8.1' }
+    - { name: 'majorkirby', version: '0.2.1' }
     # Note: django-wpadmin is installed manually to work around the fact that ansible-pip
     # ignores editable=False

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -21,15 +21,6 @@
 - name: Install django-wpadmin manually to work around ansible bug
   command: pip install --upgrade 'git+https://github.com/azavea/django-wpadmin@v1.11#egg=django-wpadmin'
 
-# TODO: #914 replace major kirby
-# TODO: peg this to a version, rather than a commit, when released
-# ansible pip module installs this in /tmp/src for some reason, so we use the
-# command instead
-- name: Install majorkirby
-  command: pip install "git+https://github.com/azavea/majorkirby@7688e19e61bf9d218c03a2af6d469d0626b86918#egg=majorkirby"
-           creates=/usr/local/lib/python2.7/dist-packages/majorkirby/__init__.py
-  when: develop
-
 - name: Touch log file and set permissions
   file: path={{ app_log }} state=touch owner={{ app_username }} group={{ app_username }} mode=0664
 
@@ -81,6 +72,6 @@
   template: src=nginx-default.j2 dest=/etc/nginx/sites-available/default
   notify: Restart nginx
 
-- { include: jslibs.yml }
+- { import_tasks: jslibs.yml }
 
-- { include: dev-test-dependencies.yml, when: develop or test }
+- { import_tasks: dev-test-dependencies.yml, when: develop or test }

--- a/deployment/cloudformation/app.py
+++ b/deployment/cloudformation/app.py
@@ -370,15 +370,17 @@ class AppServerStack(StackNode):
             LoadBalancerNames=[Ref(app_server_load_balancer)],
             MaxSize=Ref(self.param_max_size),
             MinSize=Ref(self.param_min_size),
-            NotificationConfiguration=asg.NotificationConfiguration(
-                TopicARN=Ref(self.param_notification_arn),
-                NotificationTypes=[
-                    asg.EC2_INSTANCE_LAUNCH,
-                    asg.EC2_INSTANCE_LAUNCH_ERROR,
-                    asg.EC2_INSTANCE_TERMINATE,
-                    asg.EC2_INSTANCE_TERMINATE_ERROR
-                ]
-            ),
+            NotificationConfigurations=[
+                asg.NotificationConfigurations(
+                    TopicARN=Ref(self.param_notification_arn),
+                    NotificationTypes=[
+                        asg.EC2_INSTANCE_LAUNCH,
+                        asg.EC2_INSTANCE_LAUNCH_ERROR,
+                        asg.EC2_INSTANCE_TERMINATE,
+                        asg.EC2_INSTANCE_TERMINATE_ERROR
+                    ]
+                )
+            ],
             VPCZoneIdentifier=Ref(self.param_private_subnets),
             Tags=[
                 asg.Tag('Name', '{}Server'.format(self.STACK_NAME_PREFIX), True),

--- a/deployment/packer/cac.json
+++ b/deployment/packer/cac.json
@@ -78,8 +78,9 @@
         "mkdir -p {{user `ansible_staging_directory`}}",
         "mkdir -p {{user `intermediate_directory`}}",
         "sudo apt-get -y install build-essential python-dev python-pip git",
+        "sudo pip install --upgrade pip",
         "sudo pip install paramiko==1.16.0",
-        "sudo pip install ansible==2.1.0.0"
+        "sudo pip install ansible==2.4.2.0"
       ]
     },
     {
@@ -105,6 +106,7 @@
       "playbook_file": "{{user `local_project_directory`}}/deployment/ansible/app.yml",
       "inventory_file": "{{user `local_project_directory`}}/deployment/ansible/hosts/hosts.app",
       "group_vars": "{{user `local_project_directory`}}/deployment/ansible/group_vars/",
+      "staging_directory": "{{user `ansible_staging_directory`}}",
       "extra_arguments": [
           "--user 'ubuntu'"
       ],


### PR DESCRIPTION
## Overview

Go through and update all deployment related dependencies for this project. The list of changes includes:

- Vagrant
- Ansible
- Packer
- Troposphere
- Major Kirby

Resolves https://github.com/azavea/cac-tripplanner/issues/914

## Testing Instructions

To test these changes I executed the following high level operations:

- Provision the development environment w/ Vagrant and Ansible
- Create an application server AMI w/ Packer
- Launch a CloudFormation OTP stack w/ Troposphere and MK

Although this was not an exhaustive test of every aspect of the deployment process, I feel as though it covers all of the major components in a way that tested all of the upgrades for obvious failures.

A more thorough test would be to go through a production deployment, or at least bring up a complete dark stack. Happy to pair through that process sooner rather than waiting for the next GPG production deployment.

## Checklist
- [x] No gulp lint warnings
- [x] No python lint warnings
~- [ ] Python tests pass~



