### PR TITLE
Fix bike+transit isochrone timeouts

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -10,7 +10,7 @@ virtualenv_version: 15.1.0
 otp_router: "default"
 
 # used by nginx and gunicorn to set timeouts; OTP defaults to 30s
-otp_session_timeout_s: 30
+otp_session_timeout_s: 90
 
 s3_otp_data: cleanair-otp-data
 

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/templates/router-config.json.j2
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/templates/router-config.json.j2
@@ -1,4 +1,5 @@
 {
+    timeout: {{ otp_session_timeout_s }},
     updaters: [
         {
             type: "bike-rental",

--- a/src/app/scripts/cac/map/cac-map-isochrone.js
+++ b/src/app/scripts/cac/map/cac-map-isochrone.js
@@ -132,6 +132,10 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
      * @return {Object} Promise resolving to JSON with destinations
      */
     function getIsochrone(deferred, params, zoomToFit) {
+
+        // remove optimization parameter, if set; causes excessively long isochrone query times
+        delete params.optimize;
+
         // Check if there's already an active request. If there is one,
         // then we can't make a query yet -- store it as pending.
         // If there was already a pending query, immediately resolve it.


### PR DESCRIPTION
## Overview

Do not send optimization parameter when fetching isochrones, as in bike+transit mode, it causes excessively long query times.

Also bump timeout for OTP/nginx/gunicorn to 90 seconds to allow for longer isochrone query times.


### Demo

One hour isochrone for bike+transit found in 25s locally. (Was taking over 3 minutes while passing `GREENWAYS` parameter):
![image](https://user-images.githubusercontent.com/960264/37993208-d7ea44a2-31db-11e8-9846-d15f695cc26d.png)

Timeout being recognized in OTP startup logs:
![image](https://user-images.githubusercontent.com/960264/37993295-279738d4-31dc-11e8-9a99-194cdddc6b88.png)


### Notes

Explicitly sets a timeout for OpenTripPlanner in the router configuration, instead of using the default. Documentation on the router configuration options is [here](http://docs.opentripplanner.org/en/latest/Configuration/#timeouts).


## Testing Instructions

 * Reprovision `otp` and `app` servers
 * Go to 'explore' mode and select bike with transit as the mode
 * Set an origin
 * Should get results without error
 * Move travel time slider to 60 minutes (max amount)
 * Should still get results without timing out


Fixes #1017 

