### PR TITLE
Fix deployment with MFA

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,7 +57,7 @@ def install_dependent_roles
   ansible_roles_spec = File.join(ansible_directory, "roles.yml")
 
   YAML.load_file(ansible_roles_spec).each do |role|
-    role_name = role["src"]
+    role_name = role["name"] ? role["name"] : role["src"]
     role_version = role["version"]
     role_path = File.join(ansible_directory, "roles", role_name)
     galaxy_metadata = galaxy_install_info(role_name)

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,4 +1,7 @@
 ---
+java_version: "8u*"
+java_major_version: "8"
+
 app_username: "vagrant"
 
 packer_version: "1.0.2"

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,5 +1,5 @@
 - src: azavea.opentripplanner
-  version: 1.0.8
+  version: 1.1.0
 
 - src: azavea.nginx
   version: 0.3.1

--- a/deployment/packer/cac_packer.py
+++ b/deployment/packer/cac_packer.py
@@ -63,7 +63,7 @@ def run_packer(machine_type, region, creds):
     env = os.environ.copy()
     env['AWS_ACCESS_KEY_ID'] = creds['aws_access_key_id']
     env['AWS_SECRET_ACCESS_KEY'] = creds['aws_secret_access_key']
-    env['AWS_SECURITY_TOKEN'] = creds['aws_security_token']
+    env['AWS_SESSION_TOKEN'] = creds['aws_security_token']
 
     packer_template_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'cac.json')
     packer_command = ['packer', 'build',


### PR DESCRIPTION
## Overview

Fixes deployment AWS session not starting properly, due to
changes to packer syntax for setting AWS-related environment variables.


## Notes

Might be good to also rename and/or change `aws_security_token` to `aws_session_token`.

Will try using this fix with the next regular deployment, and will merge this if successful.


Closes #914 
