### PR TITLE
Change bike layer from Carto

### DIFF
--- a/src/app/scripts/cac/map/cac-map-overlays.js
+++ b/src/app/scripts/cac/map/cac-map-overlays.js
@@ -38,14 +38,7 @@ CAC.Map.OverlaysControl = (function ($, cartodb, L, Utils) {
 
     function bikeRoutesOverlay(map) {
         var layerGroup = cartodb.L.featureGroup([]);
-        var url = 'https://cac-tripplanner.cartodb.com/api/v2/viz/501dbdc8-f4ea-11e4-8c9e-0e018d66dc29/viz.json';
-        // TODO: fix attribution
-        // cartodb.js does not allow for changing the layer attribution, and has lso somehow
-        // broken the setAttribute method on the layer object.
-        //var attribution = ['Bike routes data:',
-        //                   '<a href="http://www.dvrpc.org/mapping/data.htm">DVRPC</a>,',
-        //                   '<a href="https://www.opendataphilly.org/dataset/bike-network">City of Philadelphia</a>'
-        //                   ].join(' ');
+        var url = 'https://cac-tripplanner.cartodb.com/api/v2/viz/77aa8a63-fd35-4f6e-b5d5-361cbbdb45cb/viz.json';
         cartodb.createLayer(map, url).on('done', function(layer) {
             layerGroup.addLayer(layer);
             // Wait until layer has loaded to bring it to front.  Otherwise, it loads behind


### PR DESCRIPTION
## Overview

Switch to new bike layer Carto visualization.

## Demo

Light base map (default):
![bike_routes_layer](https://user-images.githubusercontent.com/960264/39256092-0795d1c4-487c-11e8-9330-2298a9a8893b.png)


Dark base map:
![bike_routes_layer_dark](https://user-images.githubusercontent.com/960264/39256068-fc2576d2-487b-11e8-957d-ef8f194874c6.png)

Satellite base map:
![bike_routes_layer_satellite](https://user-images.githubusercontent.com/960264/39256079-00f6bce8-487c-11e8-81a8-f6921fb3c208.png)

## Notes

The white routes disappear on the default light map.


## Testing

 - `vagrant ssh app`
 - `cd /opt/app/src && npm run gulp-development`
 - Clear service worker cache for local site
 - http://locahost:8024
 - Go to map and toggle on bike routes layer

Closes #1022.

