### PR TITLE
Replace routing library and fix browser history infinite loop

### DIFF
--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -117,7 +117,7 @@
     <script src="{% static 'scripts/vendor/turf-point-on-line.js' %}"></script>
     <script src="{% static 'scripts/vendor/moment.js' %}"></script>
     <script src="{% static 'scripts/vendor/moment-duration-format.js' %}"></script>
-    <script src="{% static 'scripts/vendor/navigo.js' %}"></script>
+    <script src="{% static 'scripts/vendor/route.js' %}"></script>
     <script src="{% static 'scripts/vendor/slick.js' %}"></script>
 
     <script src="{% static 'scripts/main/cac/cac.js' %}"></script>
@@ -136,7 +136,7 @@
     <script src="{% static 'scripts/main/cac/map/cac-map-itinerary.js' %}"></script>
     <script src="{% static 'scripts/main/cac/map/cac-map-overlays.js' %}"></script>
     <script src="{% static 'scripts/main/cac/map/cac-map-templates.js' %}"></script>
-     <script src="{% static 'scripts/main/cac/control/cac-control-filter-options.js' %}"></script>
+    <script src="{% static 'scripts/main/cac/control/cac-control-filter-options.js' %}"></script>
     <script src="{% static 'scripts/main/cac/control/cac-control-mode-options.js' %}"></script>
     <script src="{% static 'scripts/main/cac/control/cac-control-modal.js' %}"></script>
     <script src="{% static 'scripts/main/cac/control/cac-control-tab.js' %}"></script>

--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -46,11 +46,11 @@
     <link href="{% static 'styles/vendor.css' %}" rel="stylesheet">
     <link href="{% static 'styles/main.css' %}" rel="stylesheet">
 
-	<link rel="apple-touch-icon" sizes="120x120" href="{% static 'images/ios-app-icon-120.png' %}" />
+    <link rel="apple-touch-icon" sizes="120x120" href="{% static 'images/ios-app-icon-120.png' %}" />
     <link rel="apple-touch-icon" sizes="152x152" href="{% static 'images/ios-app-icon-152.png' %}" />
     <link rel="apple-touch-icon" sizes="167x167" href="{% static 'images/ios-app-icon-167.png' %}" />
     <link rel="apple-touch-icon" sizes="180x180" href="{% static 'images/ios-app-icon-180.png' %}" />
-	<link rel="icon" type="image/png" href="{% static 'images/favicon.png' %}" sizes="32x32" />
+    <link rel="icon" type="image/png" href="{% static 'images/favicon.png' %}" sizes="32x32" />
     <link rel="manifest" href="/manifest.json">
 
     {% endblock %}

--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -149,6 +149,7 @@
                                 href="#">Directions</a>
                             {% endif %}
                             <a class="place-card-action place-action-details"
+                               target="_top"
                                {% if destination.is_event %}
                                href="{% url 'event-detail' pk=destination.pk %}"
                                {% else %}

--- a/python/cac_tripplanner/templates/partials/footer.html
+++ b/python/cac_tripplanner/templates/partials/footer.html
@@ -12,7 +12,7 @@
         </ul>
     </div>
     <div class="footer-about">
-        <a class="goto-about" title="Learn more about GoPhillyGo" href="/about/">
+        <a class="goto-about" title="Learn more about GoPhillyGo" href="/about/" target="_top">
             <h2>About</h2>
             <p>
                 GoPhillyGo is a project of the Clean Air Council, Azavea, and Warkulwiz Design Associates. The project is funded by the William Penn Foundation.
@@ -22,6 +22,6 @@
     <div class="footer-compact tab-control">
         <a class="nav-item explore-link" data-tab-id="EXPLORE">Explore</a>
         <a class="nav-item directions-link" data-tab-id="DIRECTIONS">Directions</a>
-        <a href="{% url 'learn-list' %}">Learn</a>
+        <a href="{% url 'learn-list' %}" target="_top">Learn</a>
     </div>
 </footer>

--- a/python/cac_tripplanner/templates/partials/header.html
+++ b/python/cac_tripplanner/templates/partials/header.html
@@ -12,6 +12,6 @@
         <a class="nav-item {% if not tab or tab == 'home'%} on {% endif %}" href="/" data-tab-id="HOME">Home</a>
         <a id="explore-header-link" class="nav-item {% if tab == 'explore'%} on {% endif %}"
             data-tab-id="EXPLORE" href="/explore">Explore</a>
-        <a class="nav-item {% if tab == 'info'%} on {% endif %}" href="{% url 'learn-list' %}">Learn</a>
+        <a class="nav-item {% if tab == 'info'%} on {% endif %}" href="{% url 'learn-list' %}" target="_top">Learn</a>
     </nav>
 </header>

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -445,7 +445,11 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
 
     // Updates the URL to match the currently-selected options
     function updateUrl() {
-        urlRouter.updateUrl(urlRouter.buildDirectionsUrlFromPrefs());
+        // If we're missing some direction preferences in the URL, we'll update
+        // the URL to include them.
+        // Replace url state in this case to avoid an infinite loop in browser history
+        var replaceUrlState = urlRouter.directionsPrefsMissingFromUrl();
+        urlRouter.updateUrl(urlRouter.buildDirectionsUrlFromPrefs(), replaceUrlState);
     }
 
     /** Helper to save current directions origin or destination to user preferences.
@@ -496,7 +500,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Routing, UserPreferen
 
         if (tabControl.isTabShowing(tabControl.TABS.DIRECTIONS)) {
             // get nearby places if no destination has been set yet
-            planTripOrShowPlaces();
+            planTripOrShowPlaces(true /* replace state */);
         } else {
             // explore tab visible
             showPlaces(true);

--- a/src/app/scripts/cac/urlrouting/cac-urlrouting.js
+++ b/src/app/scripts/cac/urlrouting/cac-urlrouting.js
@@ -22,8 +22,8 @@ CAC.UrlRouting.UrlRouter = (function (_, $, UserPreferences, Utils, Navigo) {
     var EXPLORE_ENCODE = SHARED_ENCODE.concat(['placeId', 'exploreMinutes']);
 
     var DIRECTIONS_ENCODE = SHARED_ENCODE.concat(['destination',
-                                                 'destinationText',
-                                                 'waypoints']);
+                                                  'destinationText',
+                                                  'waypoints']);
 
     var events = $({});
     var eventNames = {

--- a/src/bower.json
+++ b/src/bower.json
@@ -2,7 +2,6 @@
   "name": "src",
   "private": true,
   "dependencies": {
-    "navigo": "~5.3.0",
     "console-polyfill": "~0.3.0",
     "handlebars": "~4.0.10",
     "jquery": "~3.2.1",
@@ -16,6 +15,7 @@
     "lodash": "~4.17.4",
     "spinkit": "~1.2.5",
     "typeahead.js": "~0.10.5",
-    "slick-carousel": "~1.8.1"
+    "slick-carousel": "~1.8.1",
+    "riot-route": "^3.1.3"
   }
 }


### PR DESCRIPTION
## Overview

Replaces the routing library `navigo` with `riot-route`, enabling us to fix an issue with URL routing that resulted in an infinite redirect in the browser history for URLs missing some parameters.


### Notes

The Riot routing library hijacks events for all links that match the base URL (in our case, `/`).
In order to work-around this, I added `target="_top"` to any inter-application links on the home/explore pages, which was suggested as a work-around in the issue: https://github.com/riot/route/issues/25.


## Testing Instructions

 * `vagrant provision app`
 * Issue #1015 should be fixed
 * Other than the above fix, routing should function as before


## Checklist
- [x] No gulp lint warnings
- [ ] ~No python lint warnings~
- [ ] ~Python tests pass~


Fixes #1015 
Fixes #1024 
