### PR TITLE
Expand nginx configuration for admin editing

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.app/templates/nginx-default.j2
+++ b/deployment/ansible/roles/cac-tripplanner.app/templates/nginx-default.j2
@@ -46,7 +46,7 @@ server {
         proxy_pass http://127.0.0.1:8000;
     }
 
-    location /admin/destinations/destination/add/ {
+    location ^~ /admin/destinations/ {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_redirect off;


### PR DESCRIPTION
Fix `413: Request entity too large` nginx errors when uploading images in admin interface.
Expand rule set allowing large uploads on destination add to also include destination edit
and event add or edit.
