### PR TITLE
Remove fetch handler from service worker

### DIFF
--- a/python/cac_tripplanner/templates/service-worker.js
+++ b/python/cac_tripplanner/templates/service-worker.js
@@ -1,7 +1,7 @@
 // Service Worker to support functioning as a PWA
 // https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
 
-var CACHE_NAME = 'cac_tripplanner_v10';
+var CACHE_NAME = 'cac_tripplanner_v11';
 
 var cacheFiles = {{ cache_files | safe }};
 
@@ -13,13 +13,6 @@ self.addEventListener('install', function(event) {
         caches.open(CACHE_NAME).then(function(cache) {
             return cache.addAll(cacheFiles);
     }));
-});
-
-self.addEventListener('fetch', function(event) {
-    if (event.request.cache === 'only-if-cache') {
-        event.request.mode = 'same-origin';
-    }
-    return fetch(event.request); // do not use cache
 });
 
 self.addEventListener('activate', function(e) {


### PR DESCRIPTION
## Overview

This handler was causing all network requests to be done twice, the primary
symptom of which was that new items added on the Admin site would be
duplicated.


## Testing Instructions

 * Ensure that when creating a new Event, Destination or Article from the Admin site, only one item is created
 * Use `ngrok.io` to proxy your local instance over `https://`, and verify from a phone that the application can continue to be installed as a progressive web app to your home screen


## Checklist
- [x] No gulp lint warnings
- [x] No python lint warnings
- [x] Python tests pass
