### PR TITLE
Feature/kak/privacy and terms#1055

### DIFF
--- a/python/cac_tripplanner/cac_tripplanner/urls.py
+++ b/python/cac_tripplanner/cac_tripplanner/urls.py
@@ -18,6 +18,10 @@ urlpatterns = [
     url('^manifest.json$', dest_views.manifest),
     url('^service-worker.js$', dest_views.service_worker),
 
+    # Privacy policy and ToS
+    url(r'^privacy_policy$', dest_views.privacy_policy, name='privacy_policy'),
+    url(r'^terms_of_service$', dest_views.terms_of_service, name='terms_of_service'),
+
     # User destination flags
     url(r'^api/user_flag/', dest_views.UserFlagView.as_view()),
 

--- a/python/cac_tripplanner/destinations/views.py
+++ b/python/cac_tripplanner/destinations/views.py
@@ -80,11 +80,13 @@ def explore(request):
     return base_view(request, 'home.html', context=context)
 
 def privacy_policy(request):
-    return base_view(request, 'privacy-policy.html', {})
+    context = {'tab': 'home'}
+    return base_view(request, 'privacy-policy.html', context=context)
 
 
 def terms_of_service(request):
-    return base_view(request, 'terms-of-service.html', {})
+    context = {'tab': 'home'}
+    return base_view(request, 'terms-of-service.html', context)
 
 def manifest(request):
     """Render the app manifest for a PWA app that can install to homescreen

--- a/python/cac_tripplanner/destinations/views.py
+++ b/python/cac_tripplanner/destinations/views.py
@@ -79,6 +79,12 @@ def explore(request):
     context = {'tab': 'map-explore'}
     return base_view(request, 'home.html', context=context)
 
+def privacy_policy(request):
+    return base_view(request, 'privacy-policy.html', {})
+
+
+def terms_of_service(request):
+    return base_view(request, 'terms-of-service.html', {})
 
 def manifest(request):
     """Render the app manifest for a PWA app that can install to homescreen

--- a/python/cac_tripplanner/templates/privacy-policy.html
+++ b/python/cac_tripplanner/templates/privacy-policy.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% load cropping %}
+{% load staticfiles %}
+
+{% block pagetitle %}
+<title>{% block title %}GoPhillyGo | Privacy Policy{% endblock %}</title>
+
+<meta property="og:title" content="Privacy Policy" />
+<meta name="twitter:title" content="Privacy Policy" />
+<meta name="apple-mobile-web-app-title" content="{{ event.name }}">
+{% endblock %}
+
+{% block extrametatags %}
+<meta property="fb:app_id" content="{{ fb_app_id }}" />
+<meta property="fb:pages" content="299797223477237" />
+<meta property="fb:profile_id" content="gophillygo" />
+<meta property="og:url"
+    content="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}/" />
+<meta property="og:site_name" content="GoPhillyGo" />
+<meta property="og:locale" content="en_US" />
+{% endblock %}
+
+{% block content %}
+    {% include "partials/header.html" %}
+    <div class="main">
+        <h1><a href="{% url 'home' %}">Privacy Policy</a></h1>
+    </div>
+    {% include "partials/footer.html" %}
+{% endblock %}

--- a/python/cac_tripplanner/templates/privacy-policy.html
+++ b/python/cac_tripplanner/templates/privacy-policy.html
@@ -22,8 +22,67 @@
 
 {% block content %}
     {% include "partials/header.html" %}
-    <div class="main">
-        <h1><a href="{% url 'home' %}">Privacy Policy</a></h1>
+    <div class="main terms">
+        <h1>GoPhillyGo Privacy Policy</h1>
+        <p>Last updated: July 2018</p>
+        <p><em>Our privacy policy applies to information we collect when you use or access our website, application, or just interact with us. We may change this privacy policy from time to time. Whenever we make changes to this privacy policy, the changes are effective immediately after we post the revised privacy policy (as indicated by revising the date at the top of our privacy policy). We encourage you to review our privacy policy whenever you access our services to stay informed about our information practices and the ways you can help protect your privacy.</em></p>
+        <p>Clean Air Council ("us", "we", or "our") operates <a target="_blank" href="https://gophillygo.org/">https://gophillygo.org/</a> (the "Site") and the companion GoPhillyGo mobile application for Android (the “Application”, together with the Site, collectively referred to as the “Services”). This page informs you of our policies regarding the collection, use and disclosure of Personal Information we receive from users of the Services.</p>
+        <p>We use your the information you provide to us anonymously (i.e., we do not collect any personal information) and only for providing and improving the Services. By using the Services, you agree to the collection and use of information in accordance with this policy.</p>
+        <p>In the mobile application, you can choose to disable our collection of certain pieces of information (e.g., your selections regarding destinations/events of interest, usage and crash logs, etc.,) by accessing the Settings page. See the “Your Information Choices” section below for more information.</p>
+        <h2>Collection of Information</h2>
+        <h3>Information You Provide to Us</h3>
+        <p>We collect information you provide directly to us. For example, we collect information when you participate in any interactive features of our Services, request customer support, provide any contact or identifying information or otherwise communicate with us.</p>
+        <h3>Information We Collect Automatically When You Use the Services</h3>
+        <p>When you access or use our services, we automatically collect information about you, including:</p>
+        <ul>
+            <li>Log Information: We log information about your use of our services, including the type of browser you use, access times, pages viewed, the geographic location of your IP address and the page you visited before navigating to our Services.</li>
+            <li>Device Information: We collect information about the computer or mobile device you use to access our Services, including the hardware model, and operating system and version.</li>
+            <li>Location Information: We may collect (but do not store) information about the location of your device each time you access or use the Application.</li>
+            <li>Information Collected by Cookies and Other Tracking Technologies: We use various technologies to collect information, and this may include sending cookies to your computer or mobile device. Cookies are small data files stored on your hard drive or in your device memory that helps us to improve our services and your experience, see which areas and features of our services are popular and count visits.</li>
+        </ul>
+        <p>For more details about how we collect information, including details how to disable/enable the collection of certain data, please see "Your Information Choices" below.</p>
+        <h2>Use of Information</h2>
+        <p>We use information about you for various purposes, including to:</p>
+        <ul>
+            <li>Provide, maintain and improve our Services;</li>
+            <li>Provide services you request and to send you related information;</li>
+            <li>Send you technical notices, updates, security alerts and support and administrative messages;</li>
+            <li>Respond to your comments, questions and requests and provide customer service;</li>
+            <li>Communicate with you about news and information related to our service;</li>
+            <li>Monitor and analyze trends, usage and activities in connection with our services; and</li>
+            <li>Improve our services.</li>
+        </ul>
+        <p>By accessing and using our services, you consent to the processing and transfer of your information in and to the United States and other countries.</p>
+        <h2>Sharing of Information</h2>
+        <p>We may share personal information about you as follows:</p>
+        <ul>
+            <li>If we believe disclosure is reasonably necessary to comply with any applicable law, regulation, legal process or governmental request;</li>
+            <li>To enforce applicable user agreements or policies, including our Terms of Service; and to protect us, our users or the public from harm or illegal activities;</li>
+            <li>In connection with any merger, sale of Clean Air Council assets, financing or acquisition of all or a portion of our business to another company; and</li>
+            <li>If we notify you through our services (or in our privacy policy) that the information you provide will be shared in a particular manner and you provide such information.</li>
+        </ul>
+        <p>We may also share aggregated or anonymized information that does not directly identify you.</p>
+        <h2>Third Party Analytics</h2>
+        <p>We may allow third parties to provide analytics services. These third parties may use cookies, web beacons and other technologies to collect information about your use of the services and other websites, including the location of your IP address, web browser, pages viewed, time spent on pages, links clicked and conversion information. This information may be used by us and third parties to, among other things, analyze and track data, determine the popularity of certain content and other websites and better understand your online activity. Our privacy policy does not apply to, and we are not responsible for, third party cookies, web beacons or other tracking technologies and we encourage you to check the privacy policies of these third parties to learn more about their privacy practices.</p>
+        <p>Currently, analytics for the mobile Application are provided by Fabric Crashlytics. Data collected by Crashlytics may include identifiers for mobile devices, cookies and similar technologies. By default, Crashlytics collects all user triggered events listed <a target="_blank" href="https://support.google.com/firebase/answer/6317485?authuser=0">here</a>, which includes, but is not limited to, when the mobile Application crashes, when a user deletes the mobile Application, and when a user has a user session of a certain period of time. The Fabric Terms of Service can be found <a target="_blank" href="https://fabric.io/terms">here</a>.</p>
+        <p>For the website, analytics are provided by Google Analytics. Data collected by Google Analytics is listed <a target="_blank" href="https://support.google.com/analytics/answer/6318039?hl=en">here</a>, and may include, but is not limited to, the location of your IP address, the duration of your web session, and your device type and browser. The Google Analytics Terms of Service can be found <a target="_blank" href="https://www.google.com/analytics/terms/us.html">here</a>.</p>
+        <h2>Security</h2>
+        <p>We take reasonable measures to help protect personal information from loss, theft, misuse and unauthorized access, disclosure, alteration and destruction.</p>
+        <h2>Your Information Choices</h2>
+        <h3>Location Information (mobile Application only)</h3>
+        <p>When you first launch the mobile Application, you will be asked to consent to the application's collection of this information. Note that the mobile Application only uses the device’s location temporarily (i.e., to show distances to a destination and to provide directions) and this information is not saved. If you initially consent to our collection of location information, you can subsequently stop the collection of this information at any time by changing the preferences on your mobile device. If you do so, the mobile Application, or certain features thereof, will no longer function. You may also stop our collection of location information by following the standard uninstall process to remove the mobile Application from your device.</p>
+        <h3>User Settings (mobile Application only)</h3>
+        <p>You can opt out of sharing your settings by deselecting “Share selections” on the Settings page of the mobile Application.</p>
+        <h3>Third Party Analytics (mobile Application only)</h3>
+        <p>You can opt out of sharing analytics by deselecting “Share crash and usage data” on the Settings page of the mobile Application.</p>
+        <h3>Cookies (Site only)</h3>
+        <p>Most web browsers are set to accept cookies by default. If you prefer, you can usually choose to set your browser to remove or reject browser cookies. Please note that if you choose to remove or reject cookies, this could affect the availability and functionality of our services.</p>
+        <h2>Changes To This Privacy Policy</h2>
+        <p>This Privacy Policy is effective as of June 2018 and will remain in effect except with respect to any changes in its provisions in the future, which will be in effect immediately after being posted on this page.</p>
+        <p>We reserve the right to update or change our Privacy Policy at any time and you should check this Privacy Policy periodically. Your continued use of the Service after we post any modifications to the Privacy Policy on this page will constitute your acknowledgment of the modifications and your consent to abide and be bound by the modified Privacy Policy.</p>
+        <p>If we make any material changes to this Privacy Policy, we will notify you either through the email address you have provided us, or by placing a prominent notice on our website.</p>
+        <h2>Contact Us</h2>
+        <p>If you have any questions about this privacy policy, please contact us at: <a target="_blank" href="mailto:info@gophillygo.org">info@gophillygo.org</a>.</p>
     </div>
     {% include "partials/footer.html" %}
 {% endblock %}

--- a/python/cac_tripplanner/templates/terms-of-service.html
+++ b/python/cac_tripplanner/templates/terms-of-service.html
@@ -23,8 +23,66 @@
 {% block content %}
     {% include "partials/header.html" %}
     <div class="main terms">
-        <h1>Terms of Service</h1>
-        <p></p>
+        <h1>GoPhillyGo Terms and Conditions ("Terms")</h1>
+        <p>Last updated: July 2018</p>
+        <p>Please read these Terms and Conditions ("Terms", "Terms and Conditions") carefully before using the GoPhillyGo website and/or mobile application (collectively, the "Service" or “Application”) operated by the <a target="_blank" href="https://cleanair.org/">Clean Air Council</a> ("us", "we", or "our").</p>
+        <p>Your access to and use of the Service is conditioned on your acceptance of and compliance with these Terms. These Terms apply to all users of the Service.</p>
+        <p><strong>By accessing or using the Service you agree to be bound by these Terms. If you disagree with any part of the terms then you may not access the Service.</strong></p>
+        <h2>Links To Other Websites</h2>
+        <p>Our Service may contain links to third-party web sites or services that are not owned or controlled by the Clean Air Council.</p>
+        <p>Clean Air Council has no control over, and assumes no responsibility for, the content, privacy policies, or practices of any third party web sites or services. You further acknowledge and agree that Clean Air Council shall not be responsible or liable, directly or indirectly, for any damage or loss caused or alleged to be caused by or in connection with use of or reliance on any such content, goods or services available on or through any such websites or services.</p>
+        <h2>Changes</h2>
+        <p>We reserve the right, at our sole discretion, to modify or replace these Terms at any time. For instance, we may need to change these Terms if we come out with a new feature or for some other reason.</p>
+        <p>Whenever we make changes to these Terms, the changes are effective immediately after we post such revised Terms (indicated by revising the date at the top of these Terms) or upon your acceptance if we provide a mechanism for your immediate acceptance of the revised Terms (such as a click-through confirmation or acceptance button). It is your responsibility to check the GoPhillyGo mobile application for changes to these Terms.</p>
+        <p>If you continue to use the Service after the revised Terms go into effect, then you have accepted the changes to these Terms.</p>
+        <h2>Privacy Policy</h2>
+        <p>For information about how we collect and use information about users of the Service, please check out our <a target="_blank" href="/privacy_policy">Privacy Policy</a>.</p>
+        <h2>End User License</h2>
+        <p>Clean Air Council grants you a revocable, non-exclusive, non-transferable, limited license to download, install and/or use the Application solely for your personal, non-commercial purposes strictly in accordance with the terms of this Agreement.</p>
+        <h2>Restrictions</h2>
+        <p>You agree not to, and you will not permit others to license, sell, rent, lease, assign, distribute, transmit, host, outsource, disclose or otherwise commercially exploit the Application or make the Application available to any third party.</p>
+        <h2>Modifications to Application</h2>
+        <p>Clean Air Council reserves the right to modify, suspend or discontinue, temporarily or permanently, the Application or any service to which it connects, with or without notice and without liability to you.</p>
+        <h2>Your Use of the Application</h2>
+        <p>Our Service allows you to do the following: </p>
+        <ul>
+            <li>The website allows you and others to plan multi-modal trips, set preferences for travel modes, and search for/browse destinations reachable within a certain amount of time. (Any data you input is saved only in your browser’s storage and can be deleted by clearing your browser’s cache.)</li>
+            <li>The mobile application allows you and others to tag content made available through the Application according to your preferences. All tagging information is collected anonymously and tied only to the user’s anonymous identifier.</li>
+        </ul>
+        <p>When you enable sharing of your selections (on the Settings page), you grant us the right and license to use, reproduce, and display those selections (“Want to go”, “Liked”, “Been”, and “Not Interested”) to you on or through the Service. You can reset your preferences and/or opt out of sharing your selections by following the instructions outlined in the Settings page of the mobile Application. For more information, see the <a target="_blank" href="/privacy_policy">Privacy Policy</a>.</p>
+        <p>You agree that you will not do any of the following in connection with the Service or other users:</p>
+        <ul>
+            <li>Use the Service in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Service or that could damage, disable, overburden or impair the functioning of the Service; and</li>
+            <li>Circumvent or attempt to circumvent any filtering, security measures, rate limits or other features designed to protect the Service, users of the Service, or third parties.</li>
+        </ul>
+        <h2>Clean Air Council Materials</h2>
+        <p>We put a lot of effort into creating the Service including, the logo and all designs, text, graphics, pictures, information and other content. This property is owned by us or our licensors and it is protected by U.S. and international copyright laws. We grant you the right to use it.</p>
+        <p>However, unless we expressly state otherwise, your rights do not include: (i) publicly performing or publicly displaying the Service; (ii) modifying or otherwise making any derivative uses of the Service or any portion thereof; (iii) using any data mining, robots or similar data gathering or extraction methods; (iv) downloading (other than page caching) of any portion of the Service or any information contained therein; (v) reverse engineering or accessing the Service in order to build a competitive product or service; or (vi) using the Service other than for its intended purposes. If you do any of this stuff, we may terminate your use of the Service.</p>
+        <h2>Hyperlinks and Third Party Content</h2>
+        <p>You may create a hyperlink to the Service. But, you may not use, frame or utilize framing techniques to enclose any of our trademarks, logos or other proprietary information without our express written consent, which will not be unreasonably withheld.</p>
+        <p>Clean Air Council makes no claim or representation regarding, and accepts no responsibility for third party websites accessible by hyperlink from the Service or websites linking to the Service. When you leave the Service, you should be aware that these Terms and our policies no longer govern.</p>
+        <p>If there is any content on the Service from you and others, we don't review, verify or authenticate it, and it may include inaccuracies or false information. We make no representations, warranties, or guarantees relating to the quality, suitability, truth, accuracy or completeness of any content contained in the Service. You acknowledge sole responsibility for and assume all risk arising from your use of or reliance on any content.</p>
+        <h2>Miscellaneous</h2>
+        <p>THE SERVICE AND ANY OTHER SERVICE AND CONTENT INCLUDED ON OR OTHERWISE MADE AVAILABLE TO YOU THROUGH THE SERVICE ARE PROVIDED TO YOU ON AN AS IS OR AS AVAILABLE BASIS WITHOUT ANY REPRESENTATIONS OR WARRANTIES OF ANY KIND. WE DISCLAIM ANY AND ALL WARRANTIES AND REPRESENTATIONS (EXPRESS OR IMPLIED, ORAL OR WRITTEN) WITH RESPECT TO THE SERVICE AND CONTENT INCLUDED ON OR OTHERWISE MADE AVAILABLE TO YOU THROUGH THE SERVICE WHETHER ALLEGED TO ARISE BY OPERATION OF LAW, BY REASON OF CUSTOM OR USAGE IN THE TRADE, BY COURSE OF DEALING OR OTHERWISE.</p>
+        <p>IN NO EVENT WILL CLEAN AIR COUNCIL BE LIABLE TO YOU OR ANY THIRD PARTY FOR ANY SPECIAL, INDIRECT, INCIDENTAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES OF ANY KIND ARISING OUT OF OR IN CONNECTION WITH THE SERVICE OR ANY OTHER SERVICE AND/OR CONTENT INCLUDED ON OR OTHERWISE MADE AVAILABLE TO YOU THROUGH THE SERVICE, REGARDLESS OF THE FORM OF ACTION, WHETHER IN CONTRACT, TORT, STRICT LIABILITY OR OTHERWISE, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES OR ARE AWARE OF THE POSSIBILITY OF SUCH DAMAGES. OUR TOTAL LIABILITY FOR ALL CAUSES OF ACTION AND UNDER ALL THEORIES OF LIABILITY WILL BE LIMITED TO THE AMOUNT YOU PAID TO CLEAN AIR COUNCIL. THIS SECTION WILL BE GIVEN FULL EFFECT EVEN IF ANY REMEDY SPECIFIED IN THIS AGREEMENT IS DEEMED TO HAVE FAILED OF ITS ESSENTIAL PURPOSE.</p>
+        <p>You agree to defend, indemnify and hold us harmless from and against any and all costs, damages, liabilities, and expenses (including attorneys' fees, costs, penalties, interest and disbursements) we incur in relation to, arising from, or for the purpose of avoiding, any claim or demand from a third party relating to your use of the Service or the use of the Service by any person using your account, including any claim that your use of the Service violates any applicable law or regulation, or the rights of any third party, and/or your violation of these Terms.</p>
+        <h2>Governing Law</h2>
+        <p>The validity of these Terms and the rights, obligations, and relations of the parties under these Terms will be construed and determined under and in accordance with the laws of the Commonwealth of Pennsylvania, without regard to conflicts of law principles.</p>
+        <h2>Jurisdiction</h2>
+        <p>You expressly agree that exclusive jurisdiction for any dispute with the Service or relating to your use of it, resides in the courts of the Commonwealth of Pennsylvania and you further agree and expressly consent to the exercise of personal jurisdiction in the courts of the Commonwealth of Pennsylvania in connection with any such dispute including any claim involving Service. You further agree that you and Service will not commence against the other a class action, class arbitration or other representative action or proceeding.</p>
+        <h2>Term and Termination</h2>
+        <p>This Agreement shall remain in effect until terminated by you or Clean Air Council.</p>
+        <p>Clean Air Council may, in its sole discretion, at any time and for any or no reason, suspend or terminate this Agreement with or without prior notice.</p>
+        <p>This Agreement will terminate immediately, without prior notice from Clean Air Council, in the event that you fail to comply with any provision of this Agreement. You may also terminate this Agreement by deleting the Application and all copies thereof from your mobile device or from your desktop.</p>
+        <p>Upon termination of this Agreement, you shall cease all use of the Application and delete all copies of the Application from your mobile device or from your desktop.</p>
+        <h2>Entire Agreement</h2>
+        <p>These Terms constitute the entire agreement between you and Clean Air Council regarding the use of the Service, superseding any prior agreements between you and Clean Air Council relating to your use of the Service.</p>
+        <h2>Severability</h2>
+        <p>If any provision of this Agreement is held to be unenforceable or invalid, such provision will be changed and interpreted to accomplish the objectives of such provision to the greatest extent possible under applicable law and the remaining provisions will continue in full force and effect.</p>
+        <h2>Feedback</h2>
+        <p>Please let us know what you think of the Service, these Terms and, in general, the GoPhillyGo mobile application. When you provide us with any feedback, comments or suggestions about the Service, these Terms and, in general, the GoPhillyGo mobile application, you irrevocably assign to us all of your right, title and interest in and to your feedback, comments and suggestions.</p>
+        <h2>Contact Us</h2>
+        <p>If you have any questions about these Terms, please contact us at <a target="_blank" href="mailto:info@gophillygo.org">info@gophillygo.org</a>.</p>
     </div>
     {% include "partials/footer.html" %}
 {% endblock %}

--- a/python/cac_tripplanner/templates/terms-of-service.html
+++ b/python/cac_tripplanner/templates/terms-of-service.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% load cropping %}
+{% load staticfiles %}
+
+{% block pagetitle %}
+<title>{% block title %}GoPhillyGo | Terms of Service{% endblock %}</title>
+
+<meta property="og:title" content="Terms of Service" />
+<meta name="twitter:title" content="Terms of Service" />
+<meta name="apple-mobile-web-app-title" content="{{ event.name }}">
+{% endblock %}
+
+{% block extrametatags %}
+<meta property="fb:app_id" content="{{ fb_app_id }}" />
+<meta property="fb:pages" content="299797223477237" />
+<meta property="fb:profile_id" content="gophillygo" />
+<meta property="og:url"
+    content="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}/" />
+<meta property="og:site_name" content="GoPhillyGo" />
+<meta property="og:locale" content="en_US" />
+{% endblock %}
+
+{% block content %}
+    {% include "partials/header.html" %}
+    <div class="main">
+        <h1><a href="{% url 'home' %}">Terms of Service</a></h1>
+    </div>
+    {% include "partials/footer.html" %}
+{% endblock %}

--- a/python/cac_tripplanner/templates/terms-of-service.html
+++ b/python/cac_tripplanner/templates/terms-of-service.html
@@ -22,8 +22,9 @@
 
 {% block content %}
     {% include "partials/header.html" %}
-    <div class="main">
-        <h1><a href="{% url 'home' %}">Terms of Service</a></h1>
+    <div class="main terms">
+        <h1>Terms of Service</h1>
+        <p></p>
     </div>
     {% include "partials/footer.html" %}
 {% endblock %}

--- a/src/app/styles/components/_privacy-tos.scss
+++ b/src/app/styles/components/_privacy-tos.scss
@@ -1,0 +1,6 @@
+.terms {
+    h1, h2, h3, h4 {
+        text-align: center;
+    }
+    margin: 50px;
+}

--- a/src/app/styles/main.scss
+++ b/src/app/styles/main.scss
@@ -38,7 +38,8 @@
 'components/sidebar-banner',
 'components/modal',
 'components/spinner',
-'components/slick-dots';
+'components/slick-dots',
+'components/privacy-tos';
 
 
 // Layouts


### PR DESCRIPTION
## Overview

Add static pages for the privacy policy and terms of service, to link to from the mobile application.


### Demo

![image](https://user-images.githubusercontent.com/960264/42889788-3b033468-8a79-11e8-9ea2-3e4b9455e760.png)\

## Notes

Converting from Google Docs to HTML was a very tedious and manual process that may have resulted in error. The text should be checked to make sure it matches.

## Testing Instructions

 * Visit http://localhost:8024/privacy_policy and http://localhost:8024/terms_of_service
 * Verify text matches that [here](https://github.com/azavea/cac-tripplanner-android/issues/60#issuecomment-398543049)
 * Verify section headers and subheaders match and are the right levels
 * Test links work and open in new tab


Closes #1055 