### PR TITLE
Fix image sharing URLs

### DIFF
--- a/python/cac_tripplanner/templates/event-detail.html
+++ b/python/cac_tripplanner/templates/event-detail.html
@@ -23,8 +23,8 @@
 <meta name="twitter:site" content="@go_philly_go" />
 <meta property="og:description" content="{{ event.description|striptags }}" />
 <meta name="twitter:description" content="{{ event.description|striptags }}" />
-<meta property="og:image" content="{{ request.build_absolute_uri }}{% cropped_thumbnail event 'wide_image' %}" />
-<meta name="twitter:image" content="{{ request.build_absolute_uri }}{% cropped_thumbnail event 'wide_image' %}" />
+<meta property="og:image" content="https://gophillygo.org{% cropped_thumbnail event 'wide_image' %}" />
+<meta name="twitter:image" content="https://gophillygo.org{% cropped_thumbnail event 'wide_image' %}" />
 <meta name="og:image:alt" content="{{ event.description|striptags }}" />
 <meta name="twitter:image:alt" content="{{ event.description|striptags }}" />
 <meta property="og:image:width" content="680" />

--- a/python/cac_tripplanner/templates/learn-detail.html
+++ b/python/cac_tripplanner/templates/learn-detail.html
@@ -27,8 +27,8 @@
 <meta name="twitter:site" content="@go_philly_go" />
 <meta property="og:description" content="{{ article.teaser|striptags }}" />
 <meta name="twitter:description" content="{{ article.teaser|striptags }}" />
-<meta property="og:image" content="{{ request.build_absolute_uri }}{% cropped_thumbnail article 'wide_image' %}" />
-<meta name="twitter:image" content="{{ request.build_absolute_uri }}{% cropped_thumbnail article 'wide_image' %}" />
+<meta property="og:image" content="https://gophillygo.org{% cropped_thumbnail article 'wide_image' %}" />
+<meta name="twitter:image" content="https://gophillygo.org{% cropped_thumbnail article 'wide_image' %}" />
 <meta name="og:image:alt" content="{{ article.teaser|striptags }}" />
 <meta name="twitter:image:alt" content="{{ article.teaser|striptags }}" />
 <meta property="og:image:width" content="680" />

--- a/python/cac_tripplanner/templates/place-detail.html
+++ b/python/cac_tripplanner/templates/place-detail.html
@@ -23,8 +23,8 @@
 <meta name="twitter:site" content="@go_philly_go" />
 <meta name="twitter:description" content="{{ destination.description|striptags }}" />
 <meta property="og:description" content="{{ destination.description|striptags }}" />
-<meta property="og:image" content="{{ request.build_absolute_uri }}{% cropped_thumbnail destination 'wide_image' %}" />
-<meta name="twitter:image" content="{{ request.build_absolute_uri }}{% cropped_thumbnail destination 'wide_image' %}" />
+<meta property="og:image" content="https://gophillygo.org{% cropped_thumbnail destination 'wide_image' %}" />
+<meta name="twitter:image" content="https://gophillygo.org{% cropped_thumbnail destination 'wide_image' %}" />
 <meta name="og:image:alt" content="{{ destination.description|striptags }}" />
 <meta name="twitter:image:alt" content="{{ destination.description|striptags }}" />
 <meta property="og:image:width" content="680" />

--- a/python/cac_tripplanner/templates/service-worker.js
+++ b/python/cac_tripplanner/templates/service-worker.js
@@ -1,7 +1,7 @@
 // Service Worker to support functioning as a PWA
 // https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
 
-var CACHE_NAME = 'cac_tripplanner_v13';
+var CACHE_NAME = 'cac_tripplanner_v14';
 
 var cacheFiles = {{ cache_files | safe }};
 


### PR DESCRIPTION
Build absolute path using production domain.
(Sharing will not work in development anyways.)

Fixes an issue with #1062 where the sub-path to the detail page was also included in the image URL.