### PR TITLE
Add android app link to desktop site

### DIFF
--- a/python/cac_tripplanner/templates/partials/header.html
+++ b/python/cac_tripplanner/templates/partials/header.html
@@ -13,5 +13,17 @@
         <a id="explore-header-link" class="nav-item {% if tab == 'explore'%} on {% endif %}"
             data-tab-id="EXPLORE" href="/explore">Explore</a>
         <a class="nav-item {% if tab == 'info'%} on {% endif %}" href="{% url 'learn-list' %}">Learn</a>
+        <a
+            class="android-link"
+            href="https://play.google.com/store/apps/details?id=org.gophillygo.app"
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            <img
+                class="image"
+                alt="Get it on Google Play"
+                src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png"
+            />
+        </a>
     </nav>
 </header>

--- a/src/app/styles/components/_app-header.scss
+++ b/src/app/styles/components/_app-header.scss
@@ -110,6 +110,7 @@
 }
 
 .primary-nav {
+    position: relative;
     display: flex;
     flex: 0 0 60px;
     flex-flow: row nowrap;
@@ -158,5 +159,28 @@
             border-bottom-color: $primary-nav-link-color;
             font-weight: $font-weight-bold;
         }
+    }
+
+    .android-link {
+        @include delinkify();
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        height: 60px;  // dimensions hard-coded bc otherwise some browsers
+        width: 155px;  // don't position it properly ¯\_(ツ)_/¯
+
+        @include respond-to('xxs') {
+            display: none;
+        }
+
+        .image {
+            height: 100%;
+            width: auto;
+        }
+    }
+
+    .slogan-start {
+        text-align: right;
     }
 }


### PR DESCRIPTION
## Overview

Add Google's official "Get it on Google Play" badge to the website. It only appears on desktop, when not in map view. Clicking opens the app's Google Play page in a new tab.

### Demo

![localhost_8024_](https://user-images.githubusercontent.com/128699/43969528-6fca048e-9c98-11e8-9382-97c662e19f41.png)


Connects #1070
