### PR TITLE
Increase scale down threshold for web servers

### DIFF
--- a/deployment/cloudformation/app.py
+++ b/deployment/cloudformation/app.py
@@ -452,7 +452,7 @@ class AppServerStack(StackNode):
                 AlarmActions=[Ref(autoscaling_policy_remove)],
                 Statistic='Average',
                 Period=300,
-                Threshold='500000',
+                Threshold='2000000',
                 EvaluationPeriods=3,
                 ComparisonOperator='LessThanThreshold',
                 MetricName='NetworkOut',


### PR DESCRIPTION
## Overview

Based on ~5 days of historical data in CloudWatch, the scale down threshold for the web server ASG would have to be at least 2MB (as opposed to the previous .5MB) in order for it to trip. This increases the threshold to 2MB.

### Notes

**Before**

<img width="1402" alt="screen shot 2018-08-13 at 16 07 06" src="https://user-images.githubusercontent.com/43639/44057152-49c0bac6-9f18-11e8-932e-774b3ce9de8a.png">

**After**

<img width="1210" alt="screen shot 2018-08-13 at 16 49 57" src="https://user-images.githubusercontent.com/43639/44057365-fb3e0fb0-9f18-11e8-910a-8c0d1aa860fa.png">

## Testing Instructions

- Login to the AWS console and inspect the alarm thresholds for `WebServerStack-f88a45c81a4ffc6a3-alarmAppServerLowNetworkUsage-1A5ITXNRNZXM8`
- Ensure that is reports `NetworkOut < 2,000,000 for 3 datapoints within 15 minutes`

This change was applied via a CloudFormation stack update to [WebServerStack-f88a45c81a4ffc6a3](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stack/detail?stackId=arn:aws:cloudformation:us-east-1:204768116391:stack%2FWebServerStack-f88a45c81a4ffc6a3%2F20c31800-9b47-11e8-8615-500c2854b699).

## Checklist

- [x] No gulp lint warnings
- [x] No python lint warnings
- [x] Python tests pass

Fixes https://github.com/azavea/cac-tripplanner/issues/1063