### PR TITLE
Resolve issues transferring built graph to host

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
@@ -43,8 +43,10 @@
   when: test or (develop and not graph.stat.exists)
 
 - name: Copy Built OTP Graph to Host (develop)
-  fetch: src={{ otp_data_dir }}/Graph.obj dest=../../otp_data/ fail_on_missing=yes flat=yes
-  when: develop and graph_build|changed
+  synchronize:
+    mode: pull
+    src: "{{ otp_data_dir }}/Graph.obj"
+    dest: "../../otp_data/"
 
 - name: Create Graph Directory
   file: path="{{ otp_data_dir}}/{{ otp_router }}" state=directory

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
@@ -47,6 +47,7 @@
     mode: pull
     src: "{{ otp_data_dir }}/Graph.obj"
     dest: "../../otp_data/"
+    use_ssh_args: yes
 
 - name: Create Graph Directory
   file: path="{{ otp_data_dir}}/{{ otp_router }}" state=directory


### PR DESCRIPTION
## Overview

* Switch from using `fetch` to `synchronize`

Fixes #1083 

## Notes

I was able to get the graph transfer to be successful, even using the `fetch` Ansible module. With the larger graph from production, I did notice some slowdown on my machine during the transfer. After switching to using `synchronize`, transfers are faster and the slowdown is gone.

 I think that https://github.com/ansible/ansible/issues/31194 supports a theory that this is related to excessive memory consumption. It's possible that hardware differences allowed transfers to succeed on my machine.

## Testing Instructions

First, I downloaded the `Graph.obj` from the production EC2 instance running in the Clean Air Council AWS account. 

Then, I executed `./scripts/vagrant-up.sh`.

Next, I placed the `Graph.obj` file in the `otp` VM:

```bash
$ scp Graph.obj vagrant@192.168.8.26:/tmp/Graph.obj
$ vagrant ssh otp
vagrant@otp:~$ cd /var/otp
vagrant@otp:/var/otp$ sudo cp /tmp/Graph.obj .
vagrant@otp:/var/otp$ sudo chown root:root Graph.obj
vagrant@otp:/var/otp$ sudo cp Graph.obj default/Graph.obj
```

I removed the `Graph.obj` file created earlier and reprovisioned the `otp` VM to allow the copy task to execute again:

```bash
$ rm otp_data/Graph.obj
$ time vagrant up --provision otp
...
TASK [cac-tripplanner.otp-data : Create Directory for OSM and GTFS] ************
ok: [otp]

TASK [cac-tripplanner.otp-data : Copy Feed Validator] **************************
ok: [otp]

TASK [cac-tripplanner.otp-data : Install AuthBind (for serving OTP on port 80)] ***
ok: [otp]

TASK [cac-tripplanner.otp-data : Touch AuthBind file if it does not exist] *****
changed: [otp]

TASK [cac-tripplanner.otp-data : Change owner and mode of byport file] *********
ok: [otp]

TASK [cac-tripplanner.otp-data : Overwrite upstart service] ********************
changed: [otp]

TASK [cac-tripplanner.otp-data : Create data directory (test)] *****************
ok: [otp]

TASK [cac-tripplanner.otp-data : Download OTP Data (test)] *********************
skipping: [otp]

TASK [cac-tripplanner.otp-data : Copy OTP Data (test/develop)] *****************
ok: [otp]

TASK [cac-tripplanner.otp-data : Check for Existing Graph (develop)] ***********
ok: [otp]

TASK [cac-tripplanner.otp-data : Build OTP Graph (test/develop)] ***************
skipping: [otp]

TASK [cac-tripplanner.otp-data : Copy Built OTP Graph to Host (develop)] *******
changed: [otp]

TASK [cac-tripplanner.otp-data : Create Graph Directory] ***********************
ok: [otp]

TASK [cac-tripplanner.otp-data : Copy Router Configuration to Graph Directory] ***
ok: [otp]

TASK [cac-tripplanner.otp-data : Move Graph to Graph Directory (test/develop)] ***
changed: [otp]

TASK [cac-tripplanner.otp-data : Copy Local Graph to Graph Directory (production)] ***
skipping: [otp]

RUNNING HANDLER [azavea.opentripplanner : Restart OpenTripPlanner] *************
changed: [otp]

PLAY RECAP *********************************************************************
otp                        : ok=34   changed=8    unreachable=0    failed=0


real	1m20.561s
user	0m22.032s
sys	0m7.508s
```

Finally, ensure the transfer was successful:

```bash
$ shasum Graph.obj && ls -lh Graph.obj
a96c7286a23f2c57c6b3195991a160fe140dc20f  Graph.obj
-rw-r--r--  1 rbreslow  AZVA-INT\Domain Users   890M Sep 24 11:22 Graph.obj
```

```bash
vagrant@otp:/var/otp/default$ shasum Graph.obj && ls -lh Graph.obj
a96c7286a23f2c57c6b3195991a160fe140dc20f  Graph.obj
-rw-r--r-- 1 root root 890M Sep 24 15:22 Graph.obj
```