### PR TITLE
Add back condition to graph copy

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
@@ -43,6 +43,7 @@
   when: test or (develop and not graph.stat.exists)
 
 - name: Copy Built OTP Graph to Host (develop)
+  when: develop and graph_build|changed
   synchronize:
     mode: pull
     src: "{{ otp_data_dir }}/Graph.obj"


### PR DESCRIPTION
Do not attempt to copy back to host on production build.

Fixes #1086.
