### PR TITLE
Ensure mobile route teasers are full-width

### DIFF
--- a/src/app/scripts/cac/control/cac-control-itinerary-list.js
+++ b/src/app/scripts/cac/control/cac-control-itinerary-list.js
@@ -26,7 +26,7 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates) {
             dots: true,
             infinite: false,
             mobileFirst: true,
-            variableWidth: true,
+            variableWidth: false,
             adaptiveHeight: true,
             responsive : [
                 {


### PR DESCRIPTION
## Overview

Fix https://github.com/azavea/cac-tripplanner/issues/1094 wherein mobile route teaser panels aren't spanning the full width of the viewport in mobile browsers.


### Demo

![image](https://user-images.githubusercontent.com/128699/52144376-1ab50c00-262c-11e9-92ff-c08b523d9abf.png)


## Testing Instructions

 * Get directions in mobile browsers
 * Ensure route teasers at bottom of viewport are full-width


## Checklist
- [ ] No gulp lint warnings
- [ ] No python lint warnings
- [ ] Python tests pass


Connects #1094 
