### PR TITLE
Hide extra carousel images while loading

### DIFF
--- a/python/cac_tripplanner/templates/event-detail.html
+++ b/python/cac_tripplanner/templates/event-detail.html
@@ -52,7 +52,7 @@
 
 {%block jspage %}
 <script type="text/javascript">
-jQuery(document).ready(function ($) {
+jQuery(document).ready(function () {
     tns({
         container: '.detail-image-carousel',
         autoplayButton: false,
@@ -66,6 +66,7 @@ jQuery(document).ready(function ($) {
         slideBy: 'page',
         autoplay: true
     });
+    jQuery('.detail-image-carousel-extra-image').removeClass('hidden');
 });
 </script>
 {% endblock %}

--- a/python/cac_tripplanner/templates/partials/destination-detail.html
+++ b/python/cac_tripplanner/templates/partials/destination-detail.html
@@ -7,7 +7,8 @@
             <div class="detail-image-carousel">
                 <img src="{% cropped_thumbnail destination 'wide_image' %}">
                 {% for extra_image in destination.extradestinationpicture_set.all %}
-                <img src="{% cropped_thumbnail extra_image 'wide_image' %}">
+                <img class="detail-image-carousel-extra-image hidden"
+                     src="{% cropped_thumbnail extra_image 'wide_image' %}">
                 {% endfor %}
             </div>
         </div>

--- a/python/cac_tripplanner/templates/partials/event-detail.html
+++ b/python/cac_tripplanner/templates/partials/event-detail.html
@@ -9,7 +9,8 @@
             <div class="detail-image-carousel">
                 <img src="{% cropped_thumbnail event "wide_image" %}">
                 {% for extra_image in event.extraeventpicture_set.all %}
-                <img src="{% cropped_thumbnail extra_image 'wide_image' %}">
+                <img class="detail-image-carousel-extra-image hidden"
+                     src="{% cropped_thumbnail extra_image 'wide_image' %}">
                 {% endfor %}
             </div>
         </div>

--- a/python/cac_tripplanner/templates/place-detail.html
+++ b/python/cac_tripplanner/templates/place-detail.html
@@ -52,7 +52,7 @@
 
 {%block jspage %}
 <script type="text/javascript">
-jQuery(document).ready(function ($) {
+jQuery(document).ready(function () {
     tns({
         container: '.detail-image-carousel',
         autoplayButton: false,
@@ -66,6 +66,7 @@ jQuery(document).ready(function ($) {
         slideBy: 'page',
         autoplay: true
     });
+    jQuery('.detail-image-carousel-extra-image').removeClass('hidden');
 });
 </script>
 {% endblock %}

--- a/src/app/styles/layouts/_info.scss
+++ b/src/app/styles/layouts/_info.scss
@@ -84,6 +84,12 @@
             margin-left: -4rem;
             margin-right: -4rem;
         }
+
+        .detail-image-carousel-extra-image {
+            &.hidden {
+                display: none;
+            }
+        }
     }
 
     .info-article-image-hero {


### PR DESCRIPTION
Fix flash below initial image on page load in place and event detail.

Hide images other than the first image until the carousel library has loaded.

Fixes #1105.
