### PR TITLE
Fix missing Indego stations on map

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -14,7 +14,7 @@ packer_version: "1.0.2"
 python_version: "2.7.*"
 
 nodejs_version: 10.16.0
-nodejs_npm_version: 6.9.0
+nodejs_npm_version: 6.10.2
 
 pip_version: 19.1.*
 virtualenv_version: 16.5.0

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -16,7 +16,7 @@ python_version: "2.7.*"
 nodejs_version: 10.16.0
 nodejs_npm_version: 6.10.2
 
-pip_version: 19.1.*
+pip_version: 19.2.*
 virtualenv_version: 16.5.0
 
 otp_router: "default"

--- a/src/app/scripts/cac/map/cac-map-overlays.js
+++ b/src/app/scripts/cac/map/cac-map-overlays.js
@@ -26,7 +26,7 @@ CAC.Map.OverlaysControl = (function ($, cartodb, L, Utils) {
         bikeShareFeatureGroup = cartodb.L.featureGroup([]);
         $.ajax({
             contentType: 'application/json',
-            url: 'https://www.rideindego.com/stations/json/',
+            url: 'https://api.phila.gov/bike-share-stations/v1',
             success: function (data) {
                 $.each(data.features, function (i, share) {
                     bikeShareFeatureGroup.addLayer(getBikeShareMarker(share));


### PR DESCRIPTION
## Overview

Note that this branch is based on the Xenial upgrade PR branch.

Fix the Indego stations not showing on the map by changing the endpoint to the one maintained by the city, instead of the Indego-maintained endpoint.

### Demo

![image](https://user-images.githubusercontent.com/960264/61952821-e2f7a300-af82-11e9-9c51-c836717c86ab.png)


### Notes

Both endpoints resolve to the same CloudFront endpoint. However, the Indego proxy no longer adds CORS headers, while the city endpoint does.

The city endpoint results in a CORB warning on Chrome, but loads without error:
![image](https://user-images.githubusercontent.com/960264/61952794-d2dfc380-af82-11e9-8a80-186edf26e13e.png)


## Testing Instructions

 * Go to map page
 * Open the layer switcher and check 'Bike Share Locations'
 * Blue map markers with the Indego logo should appear where the stations are
 * Map marker popups should contain the expected station address and availability information

Fixes #1120.
