### PR TITLE
Update django-wpadmin install location

### DIFF
--- a/python/cac_tripplanner/requirements.txt
+++ b/python/cac_tripplanner/requirements.txt
@@ -12,5 +12,5 @@ psycopg2-binary==2.8.3
 pytz==2019.2
 PyYAML==5.1.2
 requests==2.22.0
-git+https://github.com/flibbertigibbet/django-wpadmin.git@feature/kak/django-2x#egg=django-wpadmin
+git+https://github.com/azavea/django-wpadmin@v2.2#egg=django-wpadmin
 virtualenv==16.7.4


### PR DESCRIPTION
Follow up to #1139 to correct the `django-wpadmin` library install version.