### PR TITLE
Change directions link to "Map" on tour cards

### DIFF
--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -167,7 +167,9 @@
                             <a class="place-card-action place-action-go"
                                 data-destination-id="{{ directions_id }}"
                                 data-destination-places="{{ place_ids }}"
-                                href="#">Directions</a>
+                                href="#">
+                                {% if destination.is_tour %}Map{% else %}Directions{% endif %}
+                                </a>
                             {% endif %}
                             <a class="place-card-action place-action-details"
                                {% if destination.is_event %}

--- a/src/app/scripts/cac/home/cac-home-templates.js
+++ b/src/app/scripts/cac/home/cac-home-templates.js
@@ -198,7 +198,7 @@ CAC.Home.Templates = (function (Handlebars, moment) {
                             '<a class="place-card-action place-action-go" ',
                                 'data-destination-id="{{ cardId this.is_event this.is_tour this.id }}" ',
                                 'data-destination-places="{{ placeIds this.destinations this.id }}" ',
-                                'href="#">Directions</a>',
+                                'href="#">{{#if this.is_tour }}Map{{else}}Directions{{/if}}</a>',
                             '{{/if}}',
                             '<a class="place-card-action place-action-details" href=',
                             '"/{{#if this.is_event }}event{{else if this.is_tour}}tour{{else}}place{{/if}}/{{ this.id }}/"',


### PR DESCRIPTION
## Overview

Changes the text of the link on Tour cards from "Directions" to "Map".

Per discussion on issue #1152, I left this out of PR #1150 because I thought the logic to recreate the URL that's happening on the back-end for the Tour detail page needed to be reproduced on the front-end.  Turns out that's already handled by the existing directions controller logic, so only the name change is needed.

### Demo

![image](https://user-images.githubusercontent.com/6598836/66221160-6e389780-e69c-11e9-9c12-fe5a08a9a25a.png)

## Testing Instructions

- Go to [the home page](http://localhost:8024/). Tour cards should say "Map", everything else should still say "Directions".
- Click the "Tours" tab to filter to only tours, which also replaces the Django-rendered card with a Javascript-rendered one.  It should look the same.

## Checklist
- [x] No gulp lint warnings
- [x] No python lint warnings
~- [ ] Python tests pass~ (no changes, didn't check)

Resolves #1152