### PR TITLE
Feature/kak/drag tour destinations#1112

### DIFF
--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -100,6 +100,8 @@
     {% endif %}
     <script src="{% static 'scripts/vendor/index.js' %}"></script>
     <script src="{% static 'scripts/vendor/jquery.js' %}"></script>
+    <script src="{% static 'scripts/vendor/Sortable.js' %}"></script>
+    <script src="{% static 'scripts/vendor/jquery-sortable.js' %}"></script>
     <script src="{% static 'scripts/vendor/cartodb.uncompressed.js' %}"></script>
     <script src="{% static 'scripts/vendor/leaflet.awesome-markers.js' %}"></script>
     <script src="{% static 'scripts/vendor/js.storage.js' %}"></script>

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -102,6 +102,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
         tourListControl.events.on(tourListControl.eventNames.destinationClicked,
             function(e, placeId, address, x, y) {
                 showSpinner();
+                showPlaces(false);
                 // push tour map page into browser history first
                 urlRouter.pushDirectionsUrlHistory();
                 UserPreferences.setPreference('placeId', placeId);
@@ -611,6 +612,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
         } else {
             $(options.selectors.directions).show();
             $(options.selectors.places).hide();
+            exploreControl.showPlacesContent(); // hide spinner
         }
     }
 

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -105,7 +105,6 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
         tourListControl.events.on(tourListControl.eventNames.destinationClicked,
             function(e, placeId, address, x, y) {
                 showSpinner();
-                showPlaces(false);
                 // push tour map page into browser history first
                 urlRouter.pushDirectionsUrlHistory();
                 UserPreferences.setPreference('placeId', placeId);
@@ -631,7 +630,6 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
         } else {
             $(options.selectors.directions).show();
             $(options.selectors.places).hide();
-            exploreControl.showPlacesContent(); // hide spinner
         }
     }
 

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -83,6 +83,9 @@ CAC.Control.TourList = (function (_, $, MapTemplates) {
                 animation: 150,
                 direction: 'vertical',
                 draggable: '.tour-place-card',
+                // Allow scrolling while dragging by not using native HTML5
+                // See: https://github.com/SortableJS/Sortable/issues/935
+                forceFallback: true,
                 sort: true,
                 onUpdate: onDestinationListReordered
             });

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -82,7 +82,7 @@ CAC.Control.TourList = (function (_, $, MapTemplates) {
             var $sortableList = $destinationList.sortable({
                 animation: 150,
                 direction: 'vertical',
-                draggable: '.tour-place-card',
+                draggable: options.selectors.destinationItem,
                 // Allow scrolling while dragging by not using native HTML5
                 // See: https://github.com/SortableJS/Sortable/issues/935
                 forceFallback: true,
@@ -95,7 +95,8 @@ CAC.Control.TourList = (function (_, $, MapTemplates) {
     // Called when Sortable list of destinations gets updated
     function onDestinationListReordered(e) {
         var kids = e.to.children;
-        for (var i = 0; i < kids.length; i++) {
+        // First list item is the header; skip it
+        for (var i = 1; i < kids.length; i++) {
             var k = kids[i];
             var originalIndex = k.getAttribute('data-tour-place-index');
             // assign property with new order

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -60,8 +60,26 @@ CAC.Control.TourList = (function (_, $, MapTemplates) {
 
         $(options.selectors.destinationDirectionsButton).on('click', onTourDestinationClicked);
         $(options.selectors.destinationItem).on('mouseenter', onTourDestinationHovered);
-
         $(options.selectors.destinationItem).on('mouseleave', onTourDestinationHoveredOut);
+
+        var $destinationList = $(options.selectors.destinationList);
+
+        // First remove sortable if already initialized
+        if ($destinationList.sortable('widget')) {
+            $destinationList.sortable('destroy');
+        }
+
+        // Set up sortable list
+        var $sortableList = $destinationList.sortable({
+            animation: 150,
+            direction: 'vertical',
+            draggable: '.tour-place-card',
+            sort: true,
+            onUpdate: function(e) {
+                console.log('sortable updated');
+                console.log(e);
+            }
+        });
     }
 
     /**

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -67,11 +67,22 @@ var scriptOrder = [
     '**/*.js',
 ];
 
+// Load jQuery and Sortable dependencies before the plugin
+var vendorScriptOrder = [
+    '**/jquery.js',
+    '**/Sortable*.js',
+    '**/jquery-sortable*.js',
+    '**/*.js'
+];
+
 // Helper for copying over dependency files
 var copyNpmFiles = function() {
-    return gulp.src(mainNPM({
-        showWarnings: true
-    }), {allowEmpty: true, ignore: '**/*gulpfile*'});
+    return pump([
+        gulp.src(mainNPM({
+            showWarnings: true
+        }), {allowEmpty: true, ignore: '**/*gulpfile*'}),
+        order(vendorScriptOrder)
+    ]);
 };
 
 gulp.task('collectstatic', function (done) {

--- a/src/karma/karma-coverage.conf.js
+++ b/src/karma/karma-coverage.conf.js
@@ -18,6 +18,8 @@ module.exports = function(config) {
       // console polyfills
       '/srv/cac/scripts/vendor/index.js',
       '/srv/cac/scripts/vendor/jquery.js',
+      '/srv/cac/scripts/vendor/Sortable.js',
+      '/srv/cac/scripts/vendor/jquery-sortable.js',
       '/srv/cac/scripts/vendor/lodash.js',
       // load moment before other vendor scripts; is requirement for bootstrap datetime picker
       '/srv/cac/scripts/vendor/moment.js',

--- a/src/karma/karma-dev.conf.js
+++ b/src/karma/karma-dev.conf.js
@@ -18,6 +18,8 @@ module.exports = function(config) {
       // console polyfills
       '/srv/cac/scripts/vendor/index.js',
       '/srv/cac/scripts/vendor/jquery.js',
+      '/srv/cac/scripts/vendor/Sortable.js',
+      '/srv/cac/scripts/vendor/jquery-sortable.js',
       '/srv/cac/scripts/vendor/lodash.js',
       '/srv/cac/scripts/vendor/handlebars.js',
       // load moment before other vendor scripts; is requirement for bootstrap datetime picker

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -691,12 +691,6 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
-    "array-differ": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
-      "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
-      "dev": true
-    },
     "array-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
@@ -792,12 +786,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
-      "dev": true
-    },
-    "arrify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true
     },
     "asn1": {
@@ -1623,6 +1611,14 @@
         "caniuse-lite": "^1.0.30000989",
         "electron-to-chromium": "^1.3.247",
         "node-releases": "^1.1.29"
+      },
+      "dependencies": {
+        "electron-to-chromium": {
+          "version": "1.3.277",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.277.tgz",
+          "integrity": "sha512-Czmsrgng89DOgJlIknnw9bn5431QdtnUwGp5YYiPwU1DbZQUxCLF+rc1ZC09VNAdalOPcvH6AE8BaA0H5HjI/w==",
+          "dev": true
+        }
       }
     },
     "buffer": {
@@ -2283,12 +2279,6 @@
         "parseurl": "~1.3.3",
         "utils-merge": "1.0.1"
       }
-    },
-    "connect-livereload": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.6.1.tgz",
-      "integrity": "sha512-3R0kMOdL7CjJpU66fzAkCe6HNtd3AavCS4m+uW4KtJjrdGPT0SQEZieAYd+cm+lJoBznNQ4lqipYWkhBMgk00g==",
-      "dev": true
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -3174,12 +3164,6 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
-    "electron-to-chromium": {
-      "version": "1.3.237",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.237.tgz",
-      "integrity": "sha512-SPAFjDr/7iiVK2kgTluwxela6eaWjjFkS9rO/iYpB/KGXgccUom5YC7OIf19c8m8GGptWxLU0Em8xM64A/N7Fg==",
-      "dev": true
-    },
     "elliptic": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
@@ -3320,13 +3304,9 @@
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.0",
         "is-callable": "^1.1.4",
         "is-regex": "^1.0.4",
-        "object-inspect": "^1.6.0",
-        "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.0.0",
-        "string.prototype.trimright": "^2.0.0"
+        "object-keys": "^1.0.12"
       }
     },
     "es-to-primitive": {
@@ -5392,17 +5372,6 @@
         "tildify": "^1.1.2"
       }
     },
-    "gulp-filter": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-6.0.0.tgz",
-      "integrity": "sha512-veQFW93kf6jBdWdF/RxMEIlDK2mkjHyPftM381DID2C9ImTVngwYpyyThxm4/EpgcNOT37BLefzMOjEKbyYg0Q==",
-      "dev": true,
-      "requires": {
-        "multimatch": "^4.0.0",
-        "plugin-error": "^1.0.1",
-        "streamfilter": "^3.0.0"
-      }
-    },
     "gulp-flatten": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/gulp-flatten/-/gulp-flatten-0.4.0.tgz",
@@ -5947,9 +5916,9 @@
       }
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -7131,6 +7100,11 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
       "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+    },
+    "jquery-sortablejs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jquery-sortablejs/-/jquery-sortablejs-1.0.1.tgz",
+      "integrity": "sha512-tKSyPMC+VfepxfFngVDmOJeYEGakzGHYh+/FgqzqHYJa29cN8i6LN0xlCI8Oc0ShTBWqra+zOgQmlydAVaeWkg=="
     },
     "js-base64": {
       "version": "2.5.1",
@@ -8475,19 +8449,6 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "multimatch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
-      "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "^3.0.3",
-        "array-differ": "^3.0.0",
-        "array-union": "^2.1.0",
-        "arrify": "^2.0.1",
-        "minimatch": "^3.0.4"
-      }
-    },
     "mute-stdout": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
@@ -9069,12 +9030,6 @@
           }
         }
       }
-    },
-    "object-inspect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
-      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
@@ -10959,6 +10914,11 @@
         "sort-keys": "^1.0.0"
       }
     },
+    "sortablejs": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.1.tgz",
+      "integrity": "sha512-N6r7GrVmO8RW1rn0cTdvK3JR0BcqecAJ0PmYMCL3ZuqTH3pY+9QyqkmJSkkLyyDvd+AJnwaxTP22Ybr/83V9hQ=="
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11264,28 +11224,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "streamfilter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-3.0.0.tgz",
-      "integrity": "sha512-kvKNfXCmUyC8lAXSSHCIXBUlo/lhsLcCU/OmzACZYpRUdtKIH68xYhm/+HI15jFJYtNJGYtCgn2wmIiExY1VwA==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^3.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
     "streamqueue": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/streamqueue/-/streamqueue-0.1.3.tgz",
@@ -11371,26 +11309,6 @@
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
-      }
-    },
-    "string.prototype.trimleft": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz",
-      "integrity": "sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.0.2"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz",
-      "integrity": "sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {

--- a/src/package.json
+++ b/src/package.json
@@ -10,6 +10,7 @@
     "console-polyfill": "~0.3.0",
     "handlebars": "~4.4.0",
     "jquery": "~3.4.1",
+    "jquery-sortablejs": "~1.0.0",
     "js-storage": "~1.1.0",
     "leaflet": "~0.7.7",
     "leaflet.awesome-markers": "~2.0.5",
@@ -18,6 +19,7 @@
     "moment-duration-format": "~2.3.2",
     "polyline-encoded": "~0.0.8",
     "riot-route": "~3.1.4",
+    "sortablejs": "~1.10.1",
     "spinkit": "~1.2.5",
     "tiny-slider": "~2.9.2",
     "typeahead.js": "~0.10.5"


### PR DESCRIPTION
## Overview

Allow dragging tour destinations in sidebar to reorder them, which triggers refreshing the route to update the waypoint order and destination.


### Notes

I based this PR on #1126. I'll rebase on `tours` once #1126 has merged.


## Testing Instructions

 * Go to the map page for a tour
 * Destinations in sidebar should have expected drag-and-drop interactions
 * On destination reorder directions should update as expected
 * Event destinations should not be draggable (only tours)


Closes #1112
