### PR TITLE
Enable tours mobile carousel

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -311,7 +311,9 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
         }
         itineraryControl.clearItineraries();
         mapControl.setDirectionsMarkers(null, null);
-        mapControl.isochroneControl.clearDestinations();
+        if (mapControl.isochroneControl) {
+            mapControl.isochroneControl.clearDestinations();
+        }
         itineraryListControl.hide();
         directionsListControl.hide();
     }

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -104,7 +104,6 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
 
         tourListControl.events.on(tourListControl.eventNames.destinationClicked,
             function(e, placeId, address, x, y) {
-                showSpinner();
                 // push tour map page into browser history first
                 urlRouter.pushDirectionsUrlHistory();
                 UserPreferences.setPreference('placeId', placeId);

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -2,7 +2,7 @@
  *  View control for the tour overview destinations list
  *
  */
-CAC.Control.TourList = (function (_, $, MapTemplates) {
+CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
 
     'use strict';
 
@@ -54,7 +54,7 @@ CAC.Control.TourList = (function (_, $, MapTemplates) {
     return TourListControl;
 
     function setTourDestinations(tour) {
-        if (tour.id !== tourId) {
+        if (tour && tour.id !== tourId) {
             tourId = tour.id;
             destinations = tour.destinations;
         } else {
@@ -91,6 +91,8 @@ CAC.Control.TourList = (function (_, $, MapTemplates) {
                 onUpdate: onDestinationListReordered
             });
         }
+
+        enableCarousel();
     }
 
     // Called when Sortable list of destinations gets updated
@@ -106,6 +108,34 @@ CAC.Control.TourList = (function (_, $, MapTemplates) {
 
         destinations = _.sortBy(destinations, 'userOrder');
         events.trigger(eventNames.destinationsReordered, [destinations]);
+    }
+
+    /**
+     * Enable carousel for swiping tour destinations on mobile
+     */
+    function enableCarousel() {
+        if (!destinations || destinations.length < 2) {
+            return;
+        }
+
+        var slider = tns(Object.assign({
+            container: options.selectors.destinationList,
+        }, Utils.defaultCarouselOptions, {
+            autoplay: false,
+            autoHeight: true,
+            responsive: {
+                320: {disable: false, controls: false, nav: true, autoHeight: true},
+                481: {disable: true}
+            }
+        }));
+
+        // Highlight place on map on destinations carousel swipe
+        slider.events.on('indexChanged', function(info) {
+            var items = $(options.selectors.destinationItem);
+            if (items && items.length > info.displayIndex) {
+                items.eq(info.displayIndex).triggerHandler('mouseenter');
+            }
+        });
     }
 
     /**
@@ -191,4 +221,4 @@ CAC.Control.TourList = (function (_, $, MapTemplates) {
             hide();
         }
     }
-})(_, jQuery, CAC.Map.Templates);
+})(_, jQuery, CAC.Map.Templates, CAC.Utils);


### PR DESCRIPTION
## Overview

Enable tours mobile carousel. ~~Do not merge: needs styling fixes.~~ Merging for styling afterwards.


### Demo

![image](https://user-images.githubusercontent.com/960264/66493471-217e0380-ea84-11e9-9580-d1af95c99980.png)


### Notes

Carousel appears and responds to swipe gestures, but destination cards mostly do not appear, likely due to styling issues.

~~This PR is based on #1157. I will rebase it on `tours` after #1157 has been merged.~~


## Testing Instructions

 * Go to an event or tour map view with a mobile-sized screen
 * Destinations should appear in swipe-able carousel at bottom of screen


Closes #1147 
