### PR TITLE
Fix OSX build issue

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.database/tasks/install-postgis-from-source.yml
+++ b/deployment/ansible/roles/cac-tripplanner.database/tasks/install-postgis-from-source.yml
@@ -4,6 +4,7 @@
     state: present
     pkg:
       - build-essential
+      - gcc
       - libgeos-dev
       - libgdal-dev
       - libproj-dev


### PR DESCRIPTION
## Overview

Explicitly install `gcc` on database VM to fix running on OSX host.


### Notes

Fix missing `gcc` when building database VM on OSX hosts, ~~and address `npm install` failing occasionally. See discussion on npm/npm#992.~~

## Testing Instructions

 * Destroying and recreating database VM on OSX host should succeed
 * ~~Deleting `node_modules` and reprovisioning app VM should work on all hosts~~

Closes #1155.
