### PR TITLE
Feature/kak/tour map no origin#1164

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -144,8 +144,8 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
         showSpinner();
         showPlaces(false);
         var tourMode = UserPreferences.getPreference('tourMode');
-        if (tourMode === 'event') {
-            // Show event destinations and their markers but do not route
+        if (tourMode === 'event' || (tourMode === 'tour' && !directions.origin)) {
+            // Show destinations and their markers but do not route
             tourListControl.setTourDestinations(tour);
             $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
             tourListControl.show();

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -144,7 +144,9 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
         showSpinner();
         showPlaces(false);
         var tourMode = UserPreferences.getPreference('tourMode');
-        if (tourMode === 'event' || (tourMode === 'tour' && !directions.origin)) {
+        var useInitialWaypoint = false;
+        var origin = directions.origin;
+        if (tourMode === 'event') {
             // Show destinations and their markers but do not route
             tourListControl.setTourDestinations(tour);
             $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
@@ -155,13 +157,22 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
                 _.flatMap(tour.destinations, 'id'), true);
             updateUrl();
             return;
-        } else if (!(directions.origin && directions.destination)) {
+        } else if (tourMode === 'tour' && !origin &&
+                   tour.destinations && tour.destinations.length) {
+            // Viewing a tour with no origin set, implicitly use first destination
+            // without displaying it in the form.
+            origin = tour.destinations[0];
+            origin = [origin.location.y, origin.location.x];
+            useInitialWaypoint = true;
+        }
+
+        if (!(origin && directions.destination)) {
             directionsFormControl.setError('origin');
             directionsFormControl.setError('destination');
 
             // Still update the URL and show marker if they request one-sided directions
             updateUrl();
-            mapControl.setDirectionsMarkers(directions.origin, directions.destination, true);
+            mapControl.setDirectionsMarkers(origin, directions.destination, true);
             $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
             return;
         }
@@ -179,6 +190,12 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
         // Most changes trigger this function, so doing this here keeps the URL mostly in sync
         updateUrl();
 
+        // If using first tour destination as implicit origin,
+        // remove it from waypoints *after* upating URL.
+        if (useInitialWaypoint) {
+            otpOptions.waypoints.shift();
+        }
+
         tabControl.setTab(tabControl.TABS.DIRECTIONS);
 
         // If a previous request is in progress, cancel it before issuing the new one.
@@ -187,7 +204,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             planTripRequest.reject(Error(OUTDATED_REQUEST_ERROR));
         }
 
-        planTripRequest = Routing.planTrip(directions.origin,
+        planTripRequest = Routing.planTrip(origin,
                                            directions.destination,
                                            date,
                                            otpOptions,
@@ -222,12 +239,16 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
 
             // snap start and end points to where first itinerary starts and ends
             // (in case one or both markers is someplace unroutable, like in a river)
-            directions.origin = [currentItinerary.from.lat, currentItinerary.from.lon];
             directions.destination = [currentItinerary.to.lat, currentItinerary.to.lon];
-            updateLocationPreferenceWithDirections('origin');
             updateLocationPreferenceWithDirections('destination');
+            if (!useInitialWaypoint) {
+                // Only update origin if it isn't the first destination of a tour
+                directions.origin = [currentItinerary.from.lat, currentItinerary.from.lon];
+                updateLocationPreferenceWithDirections('origin');
+                origin = directions.origin;
+            }
             // put markers at start and end
-            mapControl.setDirectionsMarkers(directions.origin, directions.destination);
+            mapControl.setDirectionsMarkers(origin, directions.destination);
             if (currentItinerary.tourMode) {
                 tourListControl.setTourDestinations(tour);
                 $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
@@ -333,7 +354,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             tourMode: UserPreferences.getPreference('tourMode')
         };
 
-        // add intermediatePlaces if user edited route
+        // add intermediatePlaces if user edited route or in tour mode
         var waypoints = UserPreferences.getPreference('waypoints');
         if (waypoints && waypoints.length && !arriveBy) {
             otpOptions.waypoints = waypoints;
@@ -685,7 +706,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
         }
 
         if (destination && destination.location) {
-            directions.destination = [destination.location.y, destination.location.x ];
+            directions.destination = [destination.location.y, destination.location.x];
         }
 
         if (tabControl.isTabShowing(tabControl.TABS.DIRECTIONS)) {

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -173,6 +173,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             // Still update the URL and show marker if they request one-sided directions
             updateUrl();
             mapControl.setDirectionsMarkers(origin, directions.destination, true);
+
             $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
             return;
         }
@@ -512,15 +513,24 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
     }
 
     function onTypeaheadCleared(event, key) {
-        // Only clear map when origin cleared in tour mode
-        if (key === 'origin' && UserPreferences.getPreference('tourMode')) {
-            itineraryControl.clearItineraries();
-            mapControl.setDirectionsMarkers(null, null);
-            directions[key] = null;
-            return;
+        if (key === 'origin') {
+            var tourMode = UserPreferences.getPreference('tourMode');
+
+            if (tourMode === 'event') {
+                itineraryControl.clearItineraries();
+                mapControl.setDirectionsMarkers(null, null);
+                directions[key] = null;
+                return;
+            }
         }
+
         clearItineraries();
         directions[key] = null;
+
+        // Plan tour trip with first destination as implicit origin
+        if (tourMode === 'tour' && tour && tour.destinations && tour.destinations.length) {
+            planTripOrShowPlaces();
+        }
 
         if (tabControl.isTabShowing(tabControl.TABS.DIRECTIONS)) {
             mapControl.clearDirectionsMarker(key);

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -276,8 +276,14 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
             enableSlider(false);
             mapControl.clearDirectionsMarker('origin');
             clearIsochrone();
-            // get all places in sidebar when no origin set
-            getNearbyPlaces();
+            // Get all places in sidebar when no origin set.
+            // Check for tour mode to prevent hiding spinner while reloading with
+            // implicit origin.
+            if (tabControl.isTabShowing(tabControl.TABS.DIRECTIONS) &&
+                !UserPreferences.getPreference('tourMode') === 'tour') {
+
+                getNearbyPlaces();
+            }
         }
     }
 

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -277,11 +277,7 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
             mapControl.clearDirectionsMarker('origin');
             clearIsochrone();
             // Get all places in sidebar when no origin set.
-            // Check for tour mode to prevent hiding spinner while reloading with
-            // implicit origin.
-            if (tabControl.isTabShowing(tabControl.TABS.DIRECTIONS) &&
-                !UserPreferences.getPreference('tourMode') === 'tour') {
-
+            if (tabControl.isTabShowing(tabControl.TABS.EXPLORE)) {
                 getNearbyPlaces();
             }
         }


### PR DESCRIPTION
## Overview

Changes the initial tour map page to load directions from the first tour destination when there is no origin set in the directions form.


### Demo

![image](https://user-images.githubusercontent.com/960264/66679889-4e294b00-ec3d-11e9-8f99-c97faba3d949.png)


### Notes

~~This branch is based on #1157. I'll rebase it on `tours` when #1157 has merged.~~


## Testing Instructions

 * Go to the map page for a tour without an origin set
 * Markers for tour destinations should load on map
 * Directions should display on map, starting at the first destination in the tour
 * Origin field in the sidebar form should remain blank
 * Set the origin in the form
 * Directions should update to route from user set origin to tour destinations


Closes #1164 