### PR TITLE
Fix trip duration show

### DIFF
--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -296,6 +296,10 @@ CAC.Pages.Home = (function ($, FilterOptions, ModeOptions,  MapControl, TripOpti
 
             if (origin && destination) {
                 tabControl.setTab(tabControl.TABS.DIRECTIONS);
+            } else if (origin) {
+                // reload places list to get new distances from origin
+                exploreControl.showSpinner();
+                exploreControl.getNearbyPlaces();
             }
         }
     }


### PR DESCRIPTION
## Overview

Fix distances to places not updating on origin change.


## Testing Instructions

 * Set origin on home page
 * Places should reload with distances set on the cards

Fixes #1167 