### PR TITLE
Limit up to two total events and tours in explore

### DIFF
--- a/python/cac_tripplanner/destinations/views.py
+++ b/python/cac_tripplanner/destinations/views.py
@@ -62,8 +62,13 @@ def home(request):
     article = Article.objects.random()
     # Show all destinations, events, and tours
     destinations = list(Destination.objects.published().order_by('priority'))
+    # Return one tour and one event each, unless there aren't any of one kind,
+    # then return two of the other.
     events = list(Event.objects.current().order_by('priority', 'start_date'))[:2]
     tours = list(Tour.objects.published().order_by('priority'))[:2]
+    if len(events) > 0 and len(tours) > 0:
+        events = events[0:1]
+        tours = tours[0:1]
     context = {
         'tab': 'home',
         'article': article,

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -484,7 +484,8 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
                     return _.indexOf(place.categories, 'Events') > -1 ||
                         _.indexOf(place.categories, 'Tours') > -1;
                 });
-                return twoEvents.concat(twoTours).concat(noEventsOrTours);
+                // Show one tour and one event each, or up to two of one kind if there aren't any
+                return twoEvents.concat(twoTours).slice(0, 2).concat(noEventsOrTours);
             }
         }
 

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -485,7 +485,11 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
                         _.indexOf(place.categories, 'Tours') > -1;
                 });
                 // Show one tour and one event each, or up to two of one kind if there aren't any
-                return twoEvents.concat(twoTours).slice(0, 2).concat(noEventsOrTours);
+                var eventsTours = twoEvents && twoTours &&
+                    twoEvents.length > 0 && twoTours.length > 0 ?
+                    [twoEvents[0], twoTours[0]] :
+                    twoEvents.concat(twoTours);
+                return eventsTours.concat(noEventsOrTours);
             }
         }
 


### PR DESCRIPTION
## Overview

Show one event and one tour at top, unless one type is missing, then show up to two of the other.


### Demo

![image](https://user-images.githubusercontent.com/960264/67029409-376e7280-f0db-11e9-9f21-1c727074ef12.png)


## Testing Instructions

 * Reload home page (uses Django template)
 * Should have expected number of events and tours
 * Toggle home page filter to another tab and back to all (uses JS template)
 * Should still have expected number of events and tours


Closes #1171
