### PR TITLE
Fix explore markers when no origin set

### DIFF
--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -407,8 +407,11 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
         // (not just those in the isochrone)
         if (tabControl.isTabShowing(tabControl.TABS.EXPLORE) && mapControl.isLoaded()) {
             // allDestinations has been loaded by now
+            // Only filter to isochrone if it is set.
+            var filterPlaces = _.isNull(isochroneDestinationIds) ?
+                _.flatMap(allDestinations, 'id') : isochroneDestinationIds;
             mapControl.isochroneControl.drawDestinations(filterPlacesCategory(allDestinations),
-                                                         isochroneDestinationIds, false);
+                                                         filterPlaces, false);
         }
         showPlacesContent();
     }


### PR DESCRIPTION
## Overview

Do not present markers as translucent (unmatched) in explore mode when no origin is set.


### Demo

Markers are orange when no origin is set:
![image](https://user-images.githubusercontent.com/960264/67032781-51f81a00-f0e2-11e9-960d-8de182d0d776.png)

Markers are still translucent when origin set, but no locations matched:
![image](https://user-images.githubusercontent.com/960264/67032836-6a683480-f0e2-11e9-8e09-f2684d8628f0.png)


## Testing Instructions

 * Go to explore map page with no origin set
 * Map markers should be solid orange

Fixes #1173
