### PR TITLE
Explicitly install gcc on database VM

### DIFF
--- a/deployment/ansible/roles/cac-tripplanner.database/tasks/install-postgis-from-source.yml
+++ b/deployment/ansible/roles/cac-tripplanner.database/tasks/install-postgis-from-source.yml
@@ -4,6 +4,7 @@
     state: present
     pkg:
       - build-essential
+      - gcc
       - libgeos-dev
       - libgdal-dev
       - libproj-dev


### PR DESCRIPTION
## Overview

Explicitly install `gcc` on database VM.

Same as #1160, but PR is against `tours` branch, which should make CI less grumpy.

Connects #1155.
