### PR TITLE
Fix homepage origin clear

### DIFF
--- a/src/app/scripts/cac/pages/cac-pages-home.js
+++ b/src/app/scripts/cac/pages/cac-pages-home.js
@@ -129,6 +129,9 @@ CAC.Pages.Home = (function ($, FilterOptions, ModeOptions,  MapControl, TripOpti
 
         modeOptionsControl.events.on(modeOptionsControl.eventNames.toggle, toggledMode);
 
+        directionsFormControl.events.on(directionsFormControl.eventNames.cleared,
+                                        $.proxy(onTypeaheadCleared, this));
+
         directionsFormControl.events.on(directionsFormControl.eventNames.selected,
                                         $.proxy(onTypeaheadSelected, this));
 
@@ -286,6 +289,14 @@ CAC.Pages.Home = (function ($, FilterOptions, ModeOptions,  MapControl, TripOpti
         if (tabId === tabControl.TABS.HOME) {
             UserPreferences.setPreference('method', undefined);
             clearUserSettings();
+        }
+    }
+
+    function onTypeaheadCleared(event, key) {
+        if (key === 'origin') {
+            // reload places list to clear distances from origin
+            exploreControl.showSpinner();
+            exploreControl.getNearbyPlaces();
         }
     }
 


### PR DESCRIPTION
## Overview

Fix loader displaying indefinitely when the origin field is cleared on the homepage.


## Testing Instructions

 * Set, then clear origin on home page
 * Places list should still load with distances when origin set
 * On origin clear, places list should reload without distances set
 * Origin set and clear should still work as expected on map page tabs


Fixes #1183.
