### PR TITLE
Feature/kak/separate tour markers style#1149

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions-form.js
+++ b/src/app/scripts/cac/control/cac-control-directions-form.js
@@ -50,6 +50,7 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
         clearFocus: clearFocus,
         clearAll: clearAll,
         setLocation: setLocation,
+        setStoredLocation: setStoredLocation,
         setError: setError,
         setFromUserPreferences: setFromUserPreferences
     };
@@ -110,10 +111,20 @@ CAC.Control.DirectionsFormControl = (function ($, Typeahead, Geocoder, UserPrefe
         events.trigger(eventNames.selected, [key, location]);
     }
 
+    // Set the origin or destination without triggering trip recalculation
+    function setStoredLocation(key, location) {
+        if (location) {
+            typeaheads[key].setValue(location.address);
+            UserPreferences.setLocation(key, location);
+        } else {
+            typeaheads[key].setValue('');
+            UserPreferences.clearLocation(key);
+        }
+    }
+
     // For setting origin or destination from code, e.g. directions links
     function setLocation(key, location) {
-        typeaheads[key].setValue(location.address);
-        UserPreferences.setLocation(key, location);
+        setStoredLocation(key, location);
         events.trigger(eventNames.selected, [key, location]);
     }
 

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -31,6 +31,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
 
     var currentDestination = null;
     var currentItinerary = null;
+    var fromTour = null;
     var tour = null;
 
     var directions = {
@@ -110,6 +111,8 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
                      destinationPlaceId, destinationAddress, destinationX, destinationY) {
                 // push tour map page into browser history first
                 urlRouter.pushDirectionsUrlHistory();
+                // locally track that directions navigated to from a tour, to show back button
+                fromTour = true;
                 UserPreferences.setPreference('placeId', destinationPlaceId);
                 var originLocation = {
                     id: originPlaceId,
@@ -190,6 +193,10 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
             itineraryListControl.setItineraries(null);
             itineraryListControl.show();
+            if (fromTour) {
+                itineraryListControl.showBackButton();
+            }
+            fromTour = false;
             return;
         }
 
@@ -288,10 +295,14 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
                 itineraryListControl.setItineraries(itineraries);
                 $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
                 itineraryListControl.show();
+                if (fromTour) {
+                    itineraryListControl.showBackButton();
+                }
                 // highlight first itinerary in sidebar as well as on map
                 findItineraryBlock(currentItinerary.id)
                     .addClass(options.selectors.selectedClass);
             }
+            fromTour = false;
         }, function (error) {
             // Cancelled requests are expected; do not display an error message to user.
             // Just keep showing the loading animation until a subsequent request completes.

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -155,7 +155,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             itineraryControl.clearItineraries();
             mapControl.setDirectionsMarkers(null, null, true);
             mapControl.isochroneControl.drawDestinations(tour.destinations,
-                _.flatMap(tour.destinations, 'id'), true);
+                _.flatMap(tour.destinations, 'id'), true, true);
             updateUrl();
             return;
         } else if (tourMode === 'tour' && !origin &&
@@ -481,7 +481,11 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
         if (destination) {
             var order = destination.userOrder ? destination.userOrder : destination.order;
             // Highlight marker
-            itineraryControl.highlightTourMarker(order - 1);
+            if (tourMode === 'tour') {
+                itineraryControl.highlightTourMarker(order - 1);
+            } else if (tourMode === 'event') {
+                mapControl.isochroneControl.highlightEventMarker(destination.id);
+            }
             // If first waypoint is used as origin, do not highlight a segment for it.
             if (!directions.origin) {
                 order -= 1;
@@ -512,10 +516,12 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             findTourDestinationBlock(currentDestination.id)
                     .removeClass(options.selectors.selectedClass);
             currentDestination = null;
-            itineraryControl.unhighlightTourMarker();
             if (tourMode === 'tour') {
                 currentItinerary.geojson.setStyle({color: Utils.defaultBackgroundLineColor,
                                                    dashArray: Utils.dashArray});
+                itineraryControl.unhighlightTourMarker();
+            } else if (tourMode === 'event') {
+                mapControl.isochroneControl.unhighlightEventMarker();
             }
         }
     }

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -2,7 +2,7 @@
  *  View control for the directions form
  *
  */
-CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, UserPreferences) {
+CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, UserPreferences, Utils) {
 
     'use strict';
 
@@ -220,7 +220,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             if (tourMode && itineraries.length) {
                 currentItinerary = itineraries[0];
                 itineraryControl.plotItinerary(currentItinerary, true);
-                currentItinerary.showTour();
+                currentItinerary.show(true);
             } else if (!tourMode) {
                 // Add the itineraries to the map, highlighting the first one
                 var isFirst = true;
@@ -480,6 +480,8 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
         var tourMode = UserPreferences.getPreference('tourMode');
         if (destination) {
             var order = destination.userOrder ? destination.userOrder : destination.order;
+            // Highlight marker
+            itineraryControl.highlightTourMarker(order - 1);
             // If first waypoint is used as origin, do not highlight a segment for it.
             if (!directions.origin) {
                 order -= 1;
@@ -488,8 +490,11 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             if (tourMode === 'tour') {
                 currentItinerary.geojson.eachLayer(function(layer) {
                     var highlight = layer.feature.properties.nextWaypoint === order;
-                    layer.setStyle({color: highlight ?
-                        'green' : 'black'
+                    layer.setStyle({
+                        color: highlight ?
+                            Utils.tourHighlightColor : Utils.defaultBackgroundLineColor,
+                        dashArray: highlight ?
+                            null : Utils.dashArray
                     });
                     if (highlight) {
                         layer.bringToFront();
@@ -507,8 +512,10 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             findTourDestinationBlock(currentDestination.id)
                     .removeClass(options.selectors.selectedClass);
             currentDestination = null;
+            itineraryControl.unhighlightTourMarker();
             if (tourMode === 'tour') {
-                currentItinerary.geojson.setStyle({color: 'black'});
+                currentItinerary.geojson.setStyle({color: Utils.defaultBackgroundLineColor,
+                                                   dashArray: Utils.dashArray});
             }
         }
     }
@@ -810,4 +817,4 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
         }
     }
 
-})(_, jQuery, moment, CAC.Control, CAC.Places.Places, CAC.Routing.Plans, CAC.User.Preferences);
+})(_, jQuery, moment, CAC.Control, CAC.Places.Places, CAC.Routing.Plans, CAC.User.Preferences, CAC.Utils);

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -171,6 +171,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
 
             // Still update the URL and show marker if they request one-sided directions
             updateUrl();
+
             mapControl.setDirectionsMarkers(origin, directions.destination, true);
 
             $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
@@ -229,12 +230,14 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             // Only one itinerary is returned if there are waypoints, so this
             // lets the user to continue to add or modify waypoints without
             // having to select it in the list.
-            if (itineraries.length === 1 && !UserPreferences.getPreference('arriveBy')) {
-                if (currentItinerary.tourMode) {
-                    itineraryControl.tourItinerary(currentItinerary, tour.destinations);
-                } else {
-                    itineraryControl.draggableItinerary(currentItinerary);
-                }
+            if (!currentItinerary.tourMode && itineraries.length === 1 &&
+                !UserPreferences.getPreference('arriveBy')) {
+
+                itineraryControl.draggableItinerary(currentItinerary);
+            }
+
+            if (currentItinerary.tourMode) {
+                itineraryControl.tourItinerary(currentItinerary, tour.destinations);
             }
 
             // snap start and end points to where first itinerary starts and ends
@@ -247,8 +250,13 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
                 updateLocationPreferenceWithDirections('origin');
                 origin = directions.origin;
             }
-            // put markers at start and end
-            mapControl.setDirectionsMarkers(origin, directions.destination);
+            // put markers at start and end, if set by user
+            if (!currentItinerary.tourMode) {
+                mapControl.setDirectionsMarkers(directions.origin, directions.destination);
+            } else if (directions.origin) {
+                mapControl.setDirectionsMarkers(directions.origin, null);
+            }
+
             if (currentItinerary.tourMode) {
                 tourListControl.setTourDestinations(tour);
                 $(options.selectors.spinner).addClass(options.selectors.hiddenClass);

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -158,7 +158,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
                 _.flatMap(tour.destinations, 'id'), true, true);
             updateUrl();
             return;
-        } else if (tourMode === 'tour' && !origin &&
+        } else if (tourMode === 'tour' && !origin && tour &&
                    tour.destinations && tour.destinations.length) {
             // Viewing a tour with no origin set, implicitly use first destination
             // without displaying it in the form.
@@ -793,7 +793,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
                     tour = null;
                     if (tourMode === 'tour' && data.tours && data.tours.length) {
                         tour = _.find(data.tours, function(tour) {
-                            return 'tour_' + tour.id === destination.id;
+                            return tour.name === destination.address;
                         });
                         if (tour) {
                             // Match format of Typeahead response

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -187,8 +187,9 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             updateUrl();
 
             mapControl.setDirectionsMarkers(origin, directions.destination, true);
-
             $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
+            itineraryListControl.setItineraries(null);
+            itineraryListControl.show();
             return;
         }
 

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -213,17 +213,25 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
 
 
         planTripRequest.then(function (itineraries) {
-            // Add the itineraries to the map, highlighting the first one
-            var isFirst = true;
             itineraryControl.clearItineraries();
-            _.forEach(itineraries, function (itinerary) {
-                itineraryControl.plotItinerary(itinerary, isFirst);
-                itinerary.highlight(isFirst);
-                if (isFirst) {
-                    currentItinerary = itinerary;
-                    isFirst = false;
-                }
-            });
+            // Only use first itinerary in tour mode
+            if (tourMode && itineraries.length) {
+                currentItinerary = itineraries[0];
+                itineraryControl.plotItinerary(currentItinerary, true);
+                currentItinerary.showTour();
+            } else if (!tourMode) {
+                // Add the itineraries to the map, highlighting the first one
+                var isFirst = true;
+                _.forEach(itineraries, function (itinerary) {
+                    itineraryControl.plotItinerary(itinerary, isFirst);
+                    itinerary.highlight(isFirst);
+                    if (isFirst) {
+                        currentItinerary = itinerary;
+                        isFirst = false;
+                    }
+                });
+            }
+
             currentItinerary.geojson.bringToFront();
 
             // If there is only one itinerary, make it draggable.

--- a/src/app/scripts/cac/control/cac-control-explore.js
+++ b/src/app/scripts/cac/control/cac-control-explore.js
@@ -411,7 +411,7 @@ CAC.Control.Explore = (function (_, $, MapTemplates, HomeTemplates, Places, Rout
             var filterPlaces = _.isNull(isochroneDestinationIds) ?
                 _.flatMap(allDestinations, 'id') : isochroneDestinationIds;
             mapControl.isochroneControl.drawDestinations(filterPlacesCategory(allDestinations),
-                                                         filterPlaces, false);
+                                                         filterPlaces, false, false);
         }
         showPlacesContent();
     }

--- a/src/app/scripts/cac/control/cac-control-itinerary-list.js
+++ b/src/app/scripts/cac/control/cac-control-itinerary-list.js
@@ -39,6 +39,7 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates, Utils) {
         eventNames: eventNames,
         setItineraries: setItineraries,
         setItinerariesError: setItinerariesError,
+        showBackButton: showBackButton,
         showItineraries: showItineraries,
         show: show,
         hide: hide,
@@ -62,9 +63,11 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates, Utils) {
 
         $(options.selectors.itineraryItem).on('click', onItineraryClicked);
         $(options.selectors.itineraryItem).hover(onItineraryHover);
-        $(options.selectors.backButton).on('click', function() {
-            window.history.back();
-        });
+        if (options.showBackButton) {
+            $(options.selectors.backButton).on('click', function() {
+                window.history.back();
+            });
+        }
     }
 
     /**
@@ -149,6 +152,10 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates, Utils) {
 
     function show() {
         $container.removeClass(options.selectors.hiddenClass);
+    }
+
+    function showBackButton() {
+        $(options.selectors.backButton).removeClass(options.selectors.hiddenClass);
     }
 
     /**

--- a/src/app/scripts/cac/control/cac-control-itinerary-list.js
+++ b/src/app/scripts/cac/control/cac-control-itinerary-list.js
@@ -8,13 +8,10 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates, Utils) {
 
     var defaults = {
         // Should the back button be shown in the control
-        //  this is weird, ideally we would handle the back button in the wrapper view, but we
-        //  need to switch out the sidebar div as a whole
-        showBackButton: false,
-        // Should the share button be shown in the control
-        showShareButton: false,
+        showBackButton: true,
         selectors: {
             alert: '.alert',
+            backButton: '.back-to-itinerary',
             container: '.directions-list',
             hiddenClass: 'hidden',
             itineraryList: '.routes-list',
@@ -65,6 +62,9 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates, Utils) {
 
         $(options.selectors.itineraryItem).on('click', onItineraryClicked);
         $(options.selectors.itineraryItem).hover(onItineraryHover);
+        $(options.selectors.backButton).on('click', function() {
+            window.history.back();
+        });
     }
 
     /**
@@ -100,7 +100,7 @@ CAC.Control.ItineraryList = (function (_, $, MapTemplates, Utils) {
      * @param {[object]} itineraries An open trip planner itinerary object, as returned from the plan endpoint
      */
     function enableCarousel(itineraries) {
-        if (itineraries.length < 2) {
+        if (!itineraries || itineraries.length < 2) {
             return;
         }
 

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -121,16 +121,16 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
     // Called when Sortable list of destinations gets updated
     function onDestinationListReordered(e) {
         var kids = e.to.children;
-        for (var i = 0; i < kids.length; i++) {
-            var k = kids[i];
-            var originalIndex = k.getAttribute('data-tour-place-index');
-
-            if (!originalIndex) {
-                continue; // skip header list element
+        var indexOrder = 0;
+        _.each(kids, function(kid) {
+            var originalIndex = kid.getAttribute('data-tour-place-index');
+            // If attribute is missing, it is the header element; skip
+            if (originalIndex) {
+                // assign property with new order
+                destinations[originalIndex].userOrder = indexOrder;
+                indexOrder++;
             }
-            // assign property with new order
-            destinations[originalIndex].userOrder = i;
-        }
+        });
 
         destinations = _.sortBy(destinations, 'userOrder');
         reorderDestinations();

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -36,6 +36,7 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
 
     var $container = null;
     var destinations = [];
+    var isEvent = false;
     var tourId = null;
 
     function TourListControl(params) {
@@ -65,6 +66,7 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
     function setTourDestinations(tour) {
         if (tour && tour.id !== tourId) {
             tourId = tour.id;
+            isEvent = tour.is_event;
             destinations = tour.destinations;
         } else {
             // tour unchanged; preserve user assigned destination order
@@ -201,7 +203,24 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
         var index = this.getAttribute(options.selectors.dataPlaceIndex);
         var destination = destinations[index];
         var placeId = 'place_' + destination.id;
-        events.trigger(eventNames.destinationClicked, [placeId,
+
+        // For tours, use preceding tour destination as origin, unless this is the first
+        var originPlaceId = null;
+        var originAddress = null;
+        var originX = null;
+        var originY = null;
+        if (!isEvent && index > 0) {
+            var origin = destinations[index-1];
+            originPlaceId = 'place_' + origin.id;
+            originAddress = origin.address;
+            originX = origin.location.x;
+            originY = origin.location.y;
+        }
+        events.trigger(eventNames.destinationClicked, [originPlaceId,
+                                                       originAddress,
+                                                       originX,
+                                                       originY,
+                                                       placeId,
                                                        destination.address,
                                                        destination.location.x,
                                                        destination.location.y]);

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -121,10 +121,13 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
     // Called when Sortable list of destinations gets updated
     function onDestinationListReordered(e) {
         var kids = e.to.children;
-        // First list item is the header; skip it
-        for (var i = 1; i < kids.length; i++) {
+        for (var i = 0; i < kids.length; i++) {
             var k = kids[i];
-            var originalIndex = k.getAttribute(options.selectors.dataPlaceIndex);
+            var originalIndex = k.getAttribute('data-tour-place-index');
+
+            if (!originalIndex) {
+                continue; // skip header list element
+            }
             // assign property with new order
             destinations[originalIndex].userOrder = i;
         }

--- a/src/app/scripts/cac/map/cac-map-isochrone.js
+++ b/src/app/scripts/cac/map/cac-map-isochrone.js
@@ -20,6 +20,7 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
     var destinationMarkers = {};
     var destinationsLayer = null;
     var lastHighlightedMarkers = null;
+    var lastHighlightedEventMarker = null;
     var options = null;
     var destinationIcon = L.AwesomeMarkers.icon({
         icon: 'default',
@@ -37,6 +38,17 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
         icon: 'default',
         prefix: 'icon',
         markerColor: 'blue',
+    });
+    // Event marker styling
+   var eventHighlightIcon = L.AwesomeMarkers.icon({
+        icon: 'default',
+        prefix: 'icon',
+        markerColor: 'darkpurple'
+    });
+   var eventIcon = L.AwesomeMarkers.icon({
+        icon: 'default',
+        prefix: 'icon',
+        markerColor: 'black'
     });
 
 
@@ -65,6 +77,8 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
     IsochroneControl.prototype.drawDestinations = drawDestinations;
     IsochroneControl.prototype.clearDestinations = clearDestinations;
     IsochroneControl.prototype.highlightDestinations = highlightDestinations;
+    IsochroneControl.prototype.highlightEventMarker = highlightEventMarker;
+    IsochroneControl.prototype.unhighlightEventMarker = unhighlightEventMarker;
 
     return IsochroneControl;
 
@@ -216,8 +230,9 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
      * @param {Array} all All destinations to draw
      * @param {Array} matched IDs of matched Destinations witin the travelshed
      * @param {Boolean} zoomToFit If true, zoom map to fit all markers
+     * @param {Boolean} isEvent If true, style for event map page display
      */
-    function drawDestinations(all, matched, zoomToFit) {
+    function drawDestinations(all, matched, zoomToFit, isEvent) {
         // put destination details onto point geojson object's properties
         // build map of unconverted destination objects
         var destinations = {};
@@ -277,6 +292,9 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
                 // use a different icon for places outside of the travel than those within it
                 var useIcon = geojson.properties.matched ? destinationIcon:
                     destinationOutsideTravelshedIcon;
+                if (isEvent) {
+                    useIcon = eventIcon;
+                }
                 var marker = new cartodb.L.marker(latLng, {icon: useIcon})
                         .bindPopup(popupContent, {className: options.selectors.poiPopupClassName});
                 marker.matched = geojson.properties.matched;
@@ -308,6 +326,20 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
                     map.setView(markers[0].getLatLng());
                 }
             }
+        }
+    }
+
+    function highlightEventMarker(markerId) {
+        unhighlightEventMarker();
+        lastHighlightedEventMarker = destinationMarkers[markerId];
+        lastHighlightedEventMarker.marker.setIcon(eventHighlightIcon);
+
+    }
+
+    function unhighlightEventMarker() {
+        if (lastHighlightedEventMarker) {
+            lastHighlightedEventMarker.marker.setIcon(eventIcon);
+            lastHighlightedEventMarker = null;
         }
     }
 

--- a/src/app/scripts/cac/map/cac-map-itinerary.js
+++ b/src/app/scripts/cac/map/cac-map-itinerary.js
@@ -150,7 +150,9 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
     function highlightTourMarker(index) {
         unhighlightTourMarker();
         lastItineraryHoverMarker = waypointsLayer.getLayers()[index];
-        lastItineraryHoverMarker.setIcon(tourHighlightWaypointIcon);
+        if (lastItineraryHoverMarker) {
+            lastItineraryHoverMarker.setIcon(tourHighlightWaypointIcon);
+        }
     }
 
 

--- a/src/app/scripts/cac/map/cac-map-itinerary.js
+++ b/src/app/scripts/cac/map/cac-map-itinerary.js
@@ -44,6 +44,11 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
     } );
 
    // Tour itinerary styling
+   var tourHighlightWaypointIcon = L.AwesomeMarkers.icon({
+        icon: 'default',
+        prefix: 'icon',
+        markerColor: 'darkpurple'
+    });
    var tourWaypointIcon = L.AwesomeMarkers.icon({
         icon: 'default',
         prefix: 'icon',
@@ -61,6 +66,8 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
     ItineraryControl.prototype.clearItineraries = clearItineraries;
     ItineraryControl.prototype.clearWaypointInteractivity = clearWaypointInteractivity;
     ItineraryControl.prototype.draggableItinerary = draggableItinerary;
+    ItineraryControl.prototype.highlightTourMarker = highlightTourMarker;
+    ItineraryControl.prototype.unhighlightTourMarker = unhighlightTourMarker;
     ItineraryControl.prototype.tourItinerary = tourItinerary;
     ItineraryControl.prototype.updateItineraryLayer = updateItineraryLayer;
     ItineraryControl.prototype.errorLiveUpdatingLayer = errorLiveUpdatingLayer;
@@ -108,17 +115,15 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
                 pointToLayer: function(geojson, latlng) {
                     var marker = new cartodb.L.marker(latlng, {icon: tourWaypointIcon,
                                                                draggable: false});
-
-            var place = tourDestinations[i];
-            i += 1;
-
-            marker.bindPopup(place.name,
-                             {closeButton: false, className: options.selectors.routeTooltipClassName})
-                    .on('mouseover', function () {
-                        this.openPopup();
-                    }).on('mouseout', function () {
-                        marker.closePopup();
-                    });
+                    var place = tourDestinations[i];
+                    i += 1;
+                    marker.bindPopup(place.name, {closeButton: false,
+                                     className: options.selectors.routeTooltipClassName})
+                            .on('mouseover', function () {
+                                this.openPopup();
+                            }).on('mouseout', function () {
+                                marker.closePopup();
+                            });
                     return marker;
                 }
             }).addTo(map);
@@ -135,6 +140,26 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
         };
         itinerary.geojson.on('mouseover', itineraryHoverListener);
         itinerary.geojson.on('mouseout', itineraryHoverOutListener);
+    }
+
+    /**
+     * Change which one of the tour place markers to highlight.
+     *
+     * @param {Number} index Offset of marker in marker layer to highlight
+     */
+    function highlightTourMarker(index) {
+        unhighlightTourMarker();
+        lastItineraryHoverMarker = waypointsLayer.getLayers()[index];
+        lastItineraryHoverMarker.setIcon(tourHighlightWaypointIcon);
+    }
+
+
+    // Un-highlight the last highlighted tour marker (if any).
+    function unhighlightTourMarker() {
+        if (lastItineraryHoverMarker) {
+            lastItineraryHoverMarker.setIcon(tourWaypointIcon);
+            lastItineraryHoverMarker = null;
+        }
     }
 
     /**

--- a/src/app/scripts/cac/map/cac-map-itinerary.js
+++ b/src/app/scripts/cac/map/cac-map-itinerary.js
@@ -22,6 +22,7 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
 
     var options = null;
 
+    // Draggable itinerary styling
     var waypointRadius = 6;
     var waypointFillColor = 'white';
     var waypointStrokeColor = '#d02d2d';
@@ -39,6 +40,13 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
         iconSize: [(waypointRadius + waypointStrokeWidth) * 2, (waypointRadius + waypointStrokeWidth) * 2],
         popupAnchor: [60, 40]
     } );
+
+   // Tour itinerary styling
+   var tourWaypointIcon = L.AwesomeMarkers.icon({
+        icon: 'default',
+        prefix: 'icon',
+        markerColor: 'black'
+    });
 
     function ItineraryControl(opts) {
         this.events = events;
@@ -85,7 +93,7 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
             var idx = 0;
             waypointsLayer = cartodb.L.geoJson(turf.featureCollection(itinerary.waypoints), {
                 pointToLayer: function(geojson, latlng) {
-                    var marker = new cartodb.L.marker(latlng, {icon: waypointIcon,
+                    var marker = new cartodb.L.marker(latlng, {icon: tourWaypointIcon,
                                                                draggable: false});
 
             var place = tourDestinations[idx];

--- a/src/app/scripts/cac/map/cac-map-itinerary.js
+++ b/src/app/scripts/cac/map/cac-map-itinerary.js
@@ -87,11 +87,22 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
 
     function tourItinerary(itinerary, tourDestinations) {
         // add a layer of non-draggable markers for tour waypoints (destinations)
-        if (itinerary.waypoints) {
+        var waypoints = itinerary.waypoints ? _.cloneDeep(itinerary.waypoints) : [];
+
+        // Add the last tour destination as a marker styled like the waypoints
+        if (tourDestinations && tourDestinations.length > 0) {
+            var idx = tourDestinations.length - 1;
+            var destination = tourDestinations[idx];
+            var coords = [destination.location.x, destination.location.y];
+            var lastPoint = turf.point(coords, {index: idx});
+            waypoints.push(lastPoint);
+        }
+
+        if (waypoints) {
             var dragging = false;
             var popupTimeout;
             var idx = 0;
-            waypointsLayer = cartodb.L.geoJson(turf.featureCollection(itinerary.waypoints), {
+            waypointsLayer = cartodb.L.geoJson(turf.featureCollection(waypoints), {
                 pointToLayer: function(geojson, latlng) {
                     var marker = new cartodb.L.marker(latlng, {icon: tourWaypointIcon,
                                                                draggable: false});

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -150,7 +150,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
     function itineraryList(itineraries, showBackButton) {
         var source = [
         '{{#if showBackButton}}',
-            '<button name="back-to-itinerary" class="back-to-itinerary" title="Back">',
+            '<button name="back-to-itinerary" class="back-to-itinerary hidden" title="Back">',
             '<i class="icon-left-big"></i></button>',
         '{{/if}}',
         '<div class="routes-list">',

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -147,9 +147,14 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
     }
 
     // Template for itinerary summaries
-    function itineraryList(itineraries) {
+    function itineraryList(itineraries, showBackButton) {
         var source = [
-        '<h1>Choose a route</h1><div class="routes-list">',
+        '{{#if showBackButton}}',
+            '<button name="back-to-itinerary" class="back-to-itinerary" title="Back">',
+            '<i class="icon-left-big"></i></button>',
+        '{{/if}}',
+        '<div class="routes-list">',
+        '{{#if itineraries}}<h1>Choose a route</h1>{{/if}}',
         '{{#each itineraries}}',
             '<div class="route-summary" data-itinerary="{{this.id}}">',
                 '<div class="route-name">via {{this.via}}</div>',
@@ -179,7 +184,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
         '</div>'].join('');
 
         var template = Handlebars.compile(source);
-        var html = template({itineraries: itineraries});
+        var html = template({itineraries: itineraries, showBackButton: true});
         return html;
     }
 

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -63,15 +63,11 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
     }
 
     Itinerary.prototype.highlight = function(isHighlighted) {
-        this.setLineColors(true, isHighlighted, false);
+        this.setLineColors(true, isHighlighted);
     };
 
     Itinerary.prototype.show = function(isShown) {
-        this.setLineColors(isShown, false, false);
-    };
-
-    Itinerary.prototype.showTour = function() {
-        this.setLineColors(true, false, true);
+        this.setLineColors(isShown, false);
     };
 
     /**
@@ -383,9 +379,8 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
      *
      * @param {Boolean} shown Should this itinerary be shown (if false, make transparent)
      * @param {Boolean} highlighted Should this itinerary be highlighted on the map
-     * @param {Boolean} tour Should this itinerary be styled as a tour
      */
-    function setLineColors(shown, highlighted, tour) {
+    function setLineColors(shown, highlighted) {
 
         if (!shown) {
             this.geojson.setStyle({opacity: 0});
@@ -411,14 +406,10 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
                 var modeColor = Utils.getModeColor(layer.feature.properties.mode);
                 layer.setStyle({color: modeColor});
             });
-        } else if (tour) {
-            defaultStyle.color = 'black';
-            defaultStyle.opacity = 1;
-            this.geojson.setStyle(defaultStyle);
         } else {
             // in background
             defaultStyle.color = Utils.defaultBackgroundLineColor;
-            defaultStyle.dashArray = [5, 8];
+            defaultStyle.dashArray = Utils.dashArray;
             this.geojson.setStyle(defaultStyle);
         }
     }

--- a/src/app/scripts/cac/routing/cac-routing-itinerary.js
+++ b/src/app/scripts/cac/routing/cac-routing-itinerary.js
@@ -42,7 +42,7 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
         this.setLineColors = setLineColors;
 
         // default to visible, backgrounded linestring styling
-        this.setLineColors(true, false);
+        this.setLineColors(true, false, false);
 
         // set by CAC.Routing.Plans with the arguments sent to planTrip:
         // coordsFrom, coordsTo, when, extraOptions
@@ -63,12 +63,16 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
     }
 
     Itinerary.prototype.highlight = function(isHighlighted) {
-        this.setLineColors(true, isHighlighted);
+        this.setLineColors(true, isHighlighted, false);
     };
 
     Itinerary.prototype.show = function(isShown) {
-        this.setLineColors(isShown, false);
+        this.setLineColors(isShown, false, false);
     };
+
+    Itinerary.prototype.showTour = function() {
+        this.setLineColors(true, false, true);
+    }
 
     /**
      * Get geoJSON for an itinerary. Also updates `from` and `to` points while building geoJSON.
@@ -362,20 +366,23 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
      *
      * @param {Boolean} shown Should this itinerary be shown (if false, make transparent)
      * @param {Boolean} highlighted Should this itinerary be highlighted on the map
+     * @param {Boolean} tour Should this itinerary be styled as a tour
      */
-    function setLineColors(shown, highlighted) {
+    function setLineColors(shown, highlighted, tour) {
 
         if (!shown) {
             this.geojson.setStyle({opacity: 0});
             return;
         }
 
-        var defaultStyle = {clickable: true, // to get mouse events (listen to hover)
-                        color: Utils.defaultModeColor,
-                        dashArray: null,
-                        lineCap: 'round',
-                        lineJoin: 'round',
-                        opacity: 0.75};
+        var defaultStyle = {
+            clickable: true, // to get mouse events (listen to hover)
+            color: Utils.defaultModeColor,
+            dashArray: null,
+            lineCap: 'round',
+            lineJoin: 'round',
+            opacity: 0.75
+        };
 
         if (highlighted) {
             defaultStyle.dashArray = null;
@@ -387,6 +394,10 @@ CAC.Routing.Itinerary = (function ($, cartodb, L, _, moment, Geocoder, Utils) {
                 var modeColor = Utils.getModeColor(layer.feature.properties.mode);
                 layer.setStyle({color: modeColor});
             });
+        } else if (tour) {
+            defaultStyle.color = 'black';
+            defaultStyle.opacity = 1;
+            this.geojson.setStyle(defaultStyle);
         } else {
             // in background
             defaultStyle.color = Utils.defaultBackgroundLineColor;

--- a/src/app/scripts/cac/routing/cac-routing-plans.js
+++ b/src/app/scripts/cac/routing/cac-routing-plans.js
@@ -106,7 +106,7 @@ CAC.Routing.Plans = (function($, moment, _, UserPreferences, Itinerary, Settings
 
                 itinerary.geojson = cartodb.L.geoJson({type: 'FeatureCollection',
                                           features: itinerary.getFeatures(otpItinerary.legs)});
-                itinerary.setLineColors(true, true);
+                itinerary.setLineColors(true, !itinerary.tourMode, itinerary.tourMode);
 
                 deferred.resolve(itinerary);
             } else {

--- a/src/app/scripts/cac/utils.js
+++ b/src/app/scripts/cac/utils.js
@@ -76,6 +76,10 @@ CAC.Utils = (function (_, moment) {
         FERRY: brandColors.YELLOW
     };
 
+    // Map styling for tours
+    var dashArray = [5, 8];
+    var tourHighlightColor = brandColors.PURPLE;
+
     var defaultCarouselOptions = {
         autoplayButton: false,
         autoplayButtonOutput: false,
@@ -102,7 +106,9 @@ CAC.Utils = (function (_, moment) {
         getModeColor: getModeColor,
         modeStringHelper: modeStringHelper,
         initializeMoment: initializeMoment,
-        defaultCarouselOptions: defaultCarouselOptions
+        defaultCarouselOptions: defaultCarouselOptions,
+        dashArray: dashArray,
+        tourHighlightColor: tourHighlightColor
     };
 
     return Object.freeze(module);


### PR DESCRIPTION
## Overview

Give tour itineraries different styling from user-draggable itineraries with waypoints. Also style markers for event map page and highlight place marker on sidebar card hover.

Style tour itineraries on map hover to highlight the segment between the preceding and next tour destinations, and interact with the sidebar to highlight the next waypoint card.


### Demo

Tour map page (no hover):
![image](https://user-images.githubusercontent.com/960264/67309309-a0822b80-f4c9-11e9-8be5-432f372ef945.png)


Tour place card hover:
![image](https://user-images.githubusercontent.com/960264/67309016-28b40100-f4c9-11e9-849e-3a5c0126ceda.png)


First tour place card hover, origin set:
![image](https://user-images.githubusercontent.com/960264/67309195-6ca70600-f4c9-11e9-8afc-6e1322e750f6.png)


Event page, sidebar hover (marker highlighted):
![image](https://user-images.githubusercontent.com/960264/67309460-e7702100-f4c9-11e9-9031-d1a828190d94.png)


## Notes

The [Leaflet awesome markers library](https://github.com/lvoogdt/Leaflet.awesome-markers) we're using for the map markers have a limited set of colors that can be used for the background for the default icon. One of the two purple colors available happens to be close to the app purple, so I went with that for the highlight marker color. The wireframes show the non-highlighted marker color to match the grey of non-highlighted route segments; for that I went with black instead. The contrast between the black and purple colors is pretty low.


## Testing Instructions

 * Go to the map page for a tour
 * Place card hover interactions should work as expected
 * Itinerary hover interactions should match place card hover interactions
 * Go to the map page for an event
 * Place card hover should highlight place map marker

Closes #1149 
