### PR TITLE
Feature/kak/undo tour order#1180

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -10,7 +10,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
     var DIRECTION_THROTTLE_MILLIS = 750;
 
     // Number of milliseconds to wait on destination list reorder before requerying directions
-    var REORDER_TOUR_THROTTLE_MILLIS = 1000;
+    var REORDER_TOUR_THROTTLE_MILLIS = 500;
 
     var defaults = {
         selectors: {

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -66,7 +66,14 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
         }
 
         // Show the directions div and populate with tour destinations
-        var html = MapTemplates.tourDestinationList(tour);
+
+        // Only show button to remove a place from the list if it is in a reorderable tour
+        // still containing at least three destinations.
+        var canRemove = tour && tour.is_tour && _.reduce(tour.destinations, function(ct, dest) {
+            // only count destinations the user has not removed
+            return dest.removed ? ct : ct + 1;
+        }, 0) > 2;
+        var html = MapTemplates.tourDestinationList(tour, canRemove);
         $container.html(html);
 
         $(options.selectors.destinationDirectionsButton).on('click', onTourDestinationClicked);

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -19,7 +19,8 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
             hiddenClass: 'hidden',
             destinationList: '.tour-list',
             destinationItem: '.place-card',
-            destinationDirectionsButton: '.place-card-action-directions'
+            destinationDirectionsButton: '.place-card-action-directions',
+            undoButton: '.tour-heading i'
         }
     };
     var options = {};
@@ -69,6 +70,7 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
         $(options.selectors.destinationDirectionsButton).on('click', onTourDestinationClicked);
         $(options.selectors.destinationItem).on('mouseenter', onTourDestinationHovered);
         $(options.selectors.destinationItem).on('mouseleave', onTourDestinationHoveredOut);
+        $(options.selectors.undoButton).on('click', onUndoButtonClick);
 
         var $destinationList = $(options.selectors.destinationList);
 
@@ -194,6 +196,25 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
     function onTourDestinationHoveredOut(e) {
         events.trigger(eventNames.destinationHovered, null);
         e.stopPropagation();
+    }
+
+    /**
+     * Handle undo icon button click by resetting destination order to default (admin-assigned).
+     */
+     function onUndoButtonClick(e) {
+         var needsReordering = false;
+        _.each(destinations, function(destination) {
+            if (!_.isUndefined(destination.userOrder) &&
+                destination.userOrder !== destination.order) {
+                needsReordering = true;
+            }
+            destination.userOrder = destination.order;
+        });
+
+        if (needsReordering) {
+            destinations = _.sortBy(destinations, 'order');
+            events.trigger(eventNames.destinationsReordered, [destinations]);
+        }
     }
 
     function show() {

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -369,13 +369,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
         '</div>'].join('');
 
         var template = Handlebars.compile(source);
-        // Only show button to remove a place from the list if it is in a reorderable tour
-        // still containing at least three destinations.
-        var canRemove = tour && tour.is_tour && _.reduce(tour.destinations, function(ct, dest) {
-            // only count destinations the user has not removed
-            return dest.removed ? ct : ct + 1;
-        }, 0) > 2;
-        var html = template({tour: tour, canRemoveDestinations: canRemove});
+        var html = template({tour: tour, canRemoveDestinations: canRemoveDestinations});
         return html;
     }
 

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -275,16 +275,23 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
         return html;
     }
 
-    // Template for tour destinations
-    // Note that the date/time helpers used here were registered in the home templates
-    function tourDestinationList(tour, canRemoveDestinations) {
+    /**
+     * Build an HTML snippet for tour destination sidebar list.
+     * Note that the date/time helpers used here were registered in the home templates
+     *
+     * @param {Object} tour The tour object that has a list of destinations to display
+     * @param {Boolean} canRemoveDestinations If true, show the button for removing places
+     * @param {Boolean} isDirty If true, show the undo button
+     * @returns {String} Compiled HTML snippet
+     */
+    function tourDestinationList(tour, canRemoveDestinations, isDirty) {
         var source = [
         '<div class="tour-list">',
             '<div class="tour-heading">',
                 '<div class="tour-label">',
                     '{{#if tour.is_event}}Event{{else}}Tour{{/if}}',
                 '</div>',
-                '{{#if tour.is_tour}}<i class="icon-counterclockwise"></i>{{/if}}',
+                '{{#if isDirty}}<i class="icon-counterclockwise"></i>{{/if}}',
                 '<h1 class="tour-name">',
                     '<a class="tour-name-link" href=',
                         '"/{{#if tour.is_event}}event{{else}}tour{{/if}}/{{ tour.id }}/">',
@@ -369,7 +376,11 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
         '</div>'].join('');
 
         var template = Handlebars.compile(source);
-        var html = template({tour: tour, canRemoveDestinations: canRemoveDestinations});
+        var html = template({
+            tour: tour,
+            canRemoveDestinations: canRemoveDestinations,
+            isDirty: isDirty
+        });
         return html;
     }
 

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -277,7 +277,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
 
     // Template for tour destinations
     // Note that the date/time helpers used here were registered in the home templates
-    function tourDestinationList(tour) {
+    function tourDestinationList(tour, canRemoveDestinations) {
         var source = [
         '<div class="tour-list">',
             '<div class="tour-heading">',
@@ -311,6 +311,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                 '<div class="swipe-hint">Swipe to see locations</div>',
             '</div>',
             '{{#each tour.destinations}}',
+                '{{#unless this.removed}}',
                 '<div class="place-card place-card-compact no-origin ',
                     '{{#if ../tour.is_tour}}place-card-sortable{{/if}}" ',
                     'data-tour-place-index="{{ @index }}" ',
@@ -327,6 +328,9 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                                 'alt="{{ this.name }}" />',
                         '</div>',
                         '<div class="place-card-info">',
+                            '{{#if ../canRemoveDestinations}}',
+                                '<div class="place-card-remove">X</div>',
+                            '{{/if}}',
                             '<div class="place-card-name oneline">{{ this.name }}</div>',
                             '<div class="event-date-time">',
                                 '{{#if this.start_date }}',
@@ -360,11 +364,18 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                         '{{/if}}',
                     '</div>',
                 '</div>',
+                '{{/unless}}',
             '{{/each}}',
         '</div>'].join('');
 
         var template = Handlebars.compile(source);
-        var html = template({tour: tour});
+        // Only show button to remove a place from the list if it is in a reorderable tour
+        // still containing at least three destinations.
+        var canRemove = tour && tour.is_tour && _.reduce(tour.destinations, function(ct, dest) {
+            // only count destinations the user has not removed
+            return dest.removed ? ct : ct + 1;
+        }, 0) > 2;
+        var html = template({tour: tour, canRemoveDestinations: canRemove});
         return html;
     }
 

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -284,6 +284,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                 '<div class="tour-label">',
                     '{{#if tour.is_event}}Event{{else}}Tour{{/if}}',
                 '</div>',
+                '<i class="icon-counterclockwise"></i>',
                 '<h1 class="tour-name">',
                     '<a class="tour-name-link" href=',
                         '"/{{#if tour.is_event}}event{{else}}tour{{/if}}/{{ tour.id }}/">',

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -284,7 +284,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                 '<div class="tour-label">',
                     '{{#if tour.is_event}}Event{{else}}Tour{{/if}}',
                 '</div>',
-                '<i class="icon-counterclockwise"></i>',
+                '{{#if tour.is_tour}}<i class="icon-counterclockwise"></i>{{/if}}',
                 '<h1 class="tour-name">',
                     '<a class="tour-name-link" href=',
                         '"/{{#if tour.is_event}}event{{else}}tour{{/if}}/{{ tour.id }}/">',

--- a/src/app/styles/components/_directions-results.scss
+++ b/src/app/styles/components/_directions-results.scss
@@ -106,6 +106,12 @@
         .place-card {
             width: 100%;
 
+            .place-card-remove {
+                cursor: pointer;
+                text-align: end;
+                margin-top: -10px;
+            }
+
             &.selected {
                 background-color: $white;
 

--- a/src/app/styles/components/_directions-results.scss
+++ b/src/app/styles/components/_directions-results.scss
@@ -69,6 +69,11 @@
                 background-color: $white;
             }
 
+            i {
+                float: right;
+                cursor: pointer;
+            }
+
             .tour-label {
                 color: $gophillygo-green;
                 font-size: 1.2rem;


### PR DESCRIPTION
## Overview

Add and implement undo and remove buttons for user-ordered tours.

If there are at least three tour destinations remaining in a tour, show an 'X' button for the user to remove a place from the tour and requery for the itinerary.

The undo button resets the order to the admin-assigned default order and adds back any removed destinations to the waypoints.


### Demo

![image](https://user-images.githubusercontent.com/960264/67339094-827fef80-f4f8-11e9-9100-d0364854de5b.png)


## Testing Instructions

 * Go to the map page for a tour
 * Reordering the list by drag-and-drop should still function as expected
 * Clicking the 'X' to remove a destination should remove it from itinerary on map and sidebar list
 * 'X' should be hidden for events and tours with less than three destinations
 * Undo button at top of list should reset to initial state


Closes #1180 
