### PR TITLE
Fix card offsets in MS Edge

### DIFF
--- a/src/app/styles/components/_directions-results.scss
+++ b/src/app/styles/components/_directions-results.scss
@@ -323,4 +323,11 @@
             }
         }
     }
+
+    // WORKAROUND for tiny slider bug in MS Edge
+    @include respond-to('xxs-up') {
+        .tns-item {
+            margin-left: 0 !important;
+        }
+    }
 }


### PR DESCRIPTION
## Overview

Itinerary and tour list cards in MS Edge are incorrectly offset in MS Edge. This is a CSS workaround to fix it.

## Testing Instructions

 * Open a tour map in MS Edge (browserstack)
 * Confirm cards are left-aligned properly
 * Repeat for itinerary list

Connects #1196 
