### PR TITLE
Feature/kak/hide back to tour button#1195

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -31,7 +31,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
 
     var currentDestination = null;
     var currentItinerary = null;
-    var fromTour = null;
+    var showBackToTourButton = false;
     var tour = null;
 
     var directions = {
@@ -112,7 +112,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
                 // push tour map page into browser history first
                 urlRouter.pushDirectionsUrlHistory();
                 // locally track that directions navigated to from a tour, to show back button
-                fromTour = !isEvent;
+                showBackToTourButton = !isEvent;
                 UserPreferences.setPreference('placeId', destinationPlaceId);
                 var originLocation = {
                     id: originPlaceId,
@@ -193,10 +193,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
             itineraryListControl.setItineraries(null);
             itineraryListControl.show();
-            if (fromTour) {
-                itineraryListControl.showBackButton();
-            }
-            fromTour = false;
+            showBackToTourButton = false;
             return;
         }
 
@@ -295,14 +292,14 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
                 itineraryListControl.setItineraries(itineraries);
                 $(options.selectors.spinner).addClass(options.selectors.hiddenClass);
                 itineraryListControl.show();
-                if (fromTour) {
+                if (showBackToTourButton && itineraries && itineraries.length > 0) {
                     itineraryListControl.showBackButton();
                 }
                 // highlight first itinerary in sidebar as well as on map
                 findItineraryBlock(currentItinerary.id)
                     .addClass(options.selectors.selectedClass);
             }
-            fromTour = false;
+            showBackToTourButton = false;
         }, function (error) {
             // Cancelled requests are expected; do not display an error message to user.
             // Just keep showing the loading animation until a subsequent request completes.

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -107,12 +107,12 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
 
         tourListControl.events.on(tourListControl.eventNames.destinationClicked,
             function(e,
-                     originPlaceId, originAddress, originX, originY,
+                     isEvent, originPlaceId, originAddress, originX, originY,
                      destinationPlaceId, destinationAddress, destinationX, destinationY) {
                 // push tour map page into browser history first
                 urlRouter.pushDirectionsUrlHistory();
                 // locally track that directions navigated to from a tour, to show back button
-                fromTour = true;
+                fromTour = !isEvent;
                 UserPreferences.setPreference('placeId', destinationPlaceId);
                 var originLocation = {
                     id: originPlaceId,

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -216,7 +216,8 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
             originX = origin.location.x;
             originY = origin.location.y;
         }
-        events.trigger(eventNames.destinationClicked, [originPlaceId,
+        events.trigger(eventNames.destinationClicked, [isEvent,
+                                                       originPlaceId,
                                                        originAddress,
                                                        originX,
                                                        originY,


### PR DESCRIPTION
## Overview

Hide the back button from an itinerary when coming from an event, or when there are no itinerary results (only show when coming from a tour and there are directions results).


Closes #1195 