### PR TITLE
Style fixes

### DIFF
--- a/python/cac_tripplanner/templates/partials/tour-detail.html
+++ b/python/cac_tripplanner/templates/partials/tour-detail.html
@@ -20,7 +20,10 @@
         <div class="info-article-header-info">
             <div class="info-article-header-main">
                 <h2 class="info-article-title">{{ tour.name }}</h2>
-                <p class="info-tour">GoPhillyGo tours are curated collections of places that share a common theme. Customize your self-guided tour on the map page.</p>
+                <p class="info-tour">
+                    GoPhillyGo tours are curated collections of places that share a common theme.
+                    <span class="info-tour-desktop"> Customize your self-guided tour on the map page.</span>
+                </p>
                 <div class="info-place-actions">
                     {% if tour.first_destination %}
                     <a class="place-action-go"

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -113,7 +113,9 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
                 forceFallback: true,
                 handle: '.place-card-drag-handle',
                 sort: true,
-                onUpdate: onDestinationListReordered
+                onUpdate: onDestinationListReordered,
+                onStart: onDestinationListReorderStart,
+                onEnd: onDestinationListReorderEnd
             });
         }
 
@@ -136,6 +138,16 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
 
         destinations = _.sortBy(destinations, 'userOrder');
         reorderDestinations();
+    }
+
+    // Called when destinations list sorting begins
+    function onDestinationListReorderStart(e) {
+        $(options.selectors.destinationList).addClass('sorting');
+    }
+
+    // Called when destinations list sorting ends
+    function onDestinationListReorderEnd(e) {
+        $(options.selectors.destinationList).removeClass('sorting');
     }
 
     /**

--- a/src/app/scripts/cac/map/cac-map-templates.js
+++ b/src/app/scripts/cac/map/cac-map-templates.js
@@ -368,7 +368,7 @@ CAC.Map.Templates = (function (Handlebars, moment, Utils) {
                                     'data-tour-place-index="{{ @index }}" ',
                                     'href="#">Directions</a>',
                                 '<a class="place-card-action place-card-action-details" href=',
-                                '"/place/{{ this.id }}/">More info</a>',
+                                    '"/place/{{ this.id }}/">More info</a>',
                             '</div>',
                         '</div>',
                         '{{#if ../tour.is_tour}}',

--- a/src/app/styles/components/_directions-results.scss
+++ b/src/app/styles/components/_directions-results.scss
@@ -128,12 +128,6 @@
                     box-shadow: $place-card-drop-shadow;
                 }
 
-                .place-card-action-directions {
-                    color: $white;
-                    background-color: $gophillygo-blue;
-                    border-color: $gophillygo-blue;
-                }
-
                 .place-card-route-line path {
                     stroke: $gophillygo-blue;
                     stroke-dasharray: none;

--- a/src/app/styles/components/_place-card.scss
+++ b/src/app/styles/components/_place-card.scss
@@ -312,6 +312,10 @@
                 left: 4rem;
             }
         }
+
+        .tour-list.sorting & {
+            display: none;
+        }
     }
 }
 

--- a/src/app/styles/components/_place-card.scss
+++ b/src/app/styles/components/_place-card.scss
@@ -292,6 +292,12 @@
         &:last-of-type {
             margin-right: 0;
         }
+
+        &:hover {
+            color: $white;
+            background-color: $gophillygo-blue;
+            border-color: $gophillygo-blue;
+        }
     }
 
     .place-card-route-line {

--- a/src/app/styles/layouts/_info.scss
+++ b/src/app/styles/layouts/_info.scss
@@ -235,6 +235,12 @@
         line-height: 1.5;
     }
 
+    .info-tour-desktop {
+        @include respond-to('xxs') {
+            display: none;
+        }
+    }
+
     .info-event-destinations {
         display: flex;
         flex-flow: row nowrap;


### PR DESCRIPTION
## Overview

1. Hide sidebar route lines during drag-n-drop reordering.
2. Highlight tour location card More Info button on hover in tour map. We also no longer highlight the Direction button when hovering anywhere on the card. Each button now simply highlights on direct hover.
3. Hide "Customize your self-guided tour …" hint on tour detail page when on mobile.


### Notes

As a direction consequence of 2, this also fixes the problem where tapping on a tour location card on the mobile map highlights the directions button.

## Testing Instructions

 * Go to a tour map.
 * Reorder some locations. Confirm the route line "spine" in the sidebar disappears during reordering.
 * Hover on tour location cards. Confirm Directions button only highlights on direct hover, and More Info highlights on direct hover.
 * Narrow viewport to mobile width (refresh if necessary). Confirm that tapping location card at bottom of viewport does not highlight Directions button.
 * Go to a tour detail page.
 * Confirm that "Customize your self-guided tour …" hint is visible on desktop, but not mobile.

Connects #1210 
Connects #1211 
