### PR TITLE
Expose the detail page for unpublished places/events/tours

### DIFF
--- a/python/cac_tripplanner/destinations/tests.py
+++ b/python/cac_tripplanner/destinations/tests.py
@@ -52,11 +52,11 @@ class EventTests(TestCase):
         response = self.client.get(url)
         self.assertContains(response, 'Current Event', status_code=200)
 
-        # cannot view detail for unpublished event
+        # can also view detail for unpublished event
         url = reverse('event-detail',
                       kwargs={'pk': self.event_2.pk})
-        response_404 = self.client.get(url)
-        self.assertEqual(response_404.status_code, 404)
+        response = self.client.get(url)
+        self.assertContains(response, 'Unpublished Past Event', status_code=200)
 
     def test_event_search(self):
         """Test that event shows in search results"""
@@ -256,10 +256,11 @@ class DestinationTests(TestCase):
         response = self.client.get(url)
         self.assertContains(response, 'place_one', status_code=200)
 
+        # unpublished place should also be viewable
         url = reverse('place-detail',
                       kwargs={'pk': self.place_3.pk})
-        response_404 = self.client.get(url)
-        self.assertEqual(response_404.status_code, 404)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
 
     def test_destination_search(self):
         """Test that destinations show in search results"""
@@ -355,11 +356,11 @@ class TourTests(TestCase):
         response = self.client.get(url)
         self.assertContains(response, 'tour_one', status_code=200)
 
-        # unpublished tour detail should not be available
+        # unpublished tour detail should also be available
         url = reverse('tour-detail',
                       kwargs={'pk': self.tour_2.pk})
-        response_404 = self.client.get(url)
-        self.assertEqual(response_404.status_code, 404)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
 
     def test_tour_search(self):
         """Test that tour shows in search results"""

--- a/python/cac_tripplanner/destinations/views.py
+++ b/python/cac_tripplanner/destinations/views.py
@@ -141,7 +141,7 @@ def service_worker(request):
 
 
 def place_detail(request, pk):
-    destination = get_object_or_404(Destination.objects.published(), pk=pk)
+    destination = get_object_or_404(Destination.objects.all(), pk=pk)
     more_destinations = Destination.objects.published().exclude(pk=destination.pk)[:3]
     context = dict(tab='explore', destination=destination, more_destinations=more_destinations,
                    **DEFAULT_CONTEXT)
@@ -149,7 +149,7 @@ def place_detail(request, pk):
 
 
 def event_detail(request, pk):
-    event = get_object_or_404(Event.objects.published(), pk=pk)
+    event = get_object_or_404(Event.objects.all(), pk=pk)
     more_events = Event.objects.current().exclude(pk=event.pk)[:3]
     context = dict(tab='explore', event=event, more_events=more_events,
                    **DEFAULT_CONTEXT)
@@ -157,7 +157,7 @@ def event_detail(request, pk):
 
 
 def tour_detail(request, pk):
-    tour = get_object_or_404(Tour.objects.published(), pk=pk)
+    tour = get_object_or_404(Tour.objects.all(), pk=pk)
     more_tours = Tour.objects.published().exclude(pk=tour.pk)[:3]
     context = dict(tab='explore', tour=tour, more_tours=more_tours,
                    **DEFAULT_CONTEXT)


### PR DESCRIPTION
## Overview

Expose the detail page for all things created in the admin site (places, events, and tours), whether or not they have been marked as 'published'. Unpublished things are still hidden from the main homepage list and explore page.


### Notes

The site administrators are aware that this means "unpublished" things will have their detail pages made available.


## Testing Instructions

 * Unpublish a place that is in a tour or event
 * Confirm place no longer shows on the homepage
 * Go to the detail page for its related tour or event
 * Click the card for the unpublished place
 * Should be able to view the detail page for the unpublished place

Closes #1209.