### PR TITLE
Feature/kak/tour end marker#1205

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -264,7 +264,9 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             }
 
             if (currentItinerary.tourMode) {
-                itineraryControl.tourItinerary(currentItinerary, tour.destinations);
+                itineraryControl.tourItinerary(currentItinerary,
+                                               tour.destinations,
+                                               useInitialWaypoint);
             }
 
             // snap start and end points to where first itinerary starts and ends

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -1,4 +1,4 @@
-CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
+CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _, Utils) {
     'use strict';
 
     var defaults = {
@@ -263,11 +263,7 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         if (geocodeMarker) {
             geocodeMarker.setLatLng(latLng);
         } else {
-            var icon = L.AwesomeMarkers.icon({
-                icon: 'marker-origin',
-                prefix: 'icon',
-                markerColor: 'green'
-            });
+            var icon = L.AwesomeMarkers.icon(Utils.originIconConfig);
             geocodeMarker = new cartodb.L.marker(latLng, { icon: icon, draggable: true });
             geocodeMarker.addTo(map);
             geocodeMarker.on('dragend', markerDrag);
@@ -297,20 +293,8 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
             events.trigger(trigger, position);
         }
 
-        // Due to time constraints, these two icon definitions were copied to cac-pages-directions.js
-        // for use on the static map page there. If you change them here, change them there as well
-        // Remove comment if icon definitions are abstracted elsewhere
-        var originIcon = L.AwesomeMarkers.icon({
-            icon: 'marker-origin',
-            prefix: 'icon',
-            markerColor: 'green'
-        });
-
-        var destIcon = L.AwesomeMarkers.icon({
-            icon: 'marker-destination',
-            prefix: 'icon',
-            markerColor: 'red'
-        });
+        var originIcon = L.AwesomeMarkers.icon(Utils.originIconConfig);
+        var destIcon = L.AwesomeMarkers.icon(Utils.destinationIconConfig);
 
         if (originCoords) {
             var origin = cartodb.L.latLng(originCoords[0], originCoords[1]);
@@ -470,4 +454,4 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _) {
         });
     }
 
-})(jQuery, Handlebars, cartodb, L, turf, _);
+})(jQuery, Handlebars, cartodb, L, turf, _, CAC.Utils);

--- a/src/app/scripts/cac/map/cac-map-isochrone.js
+++ b/src/app/scripts/cac/map/cac-map-isochrone.js
@@ -1,4 +1,4 @@
-CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
+CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _, Utils) {
     'use strict';
 
     var defaults = {
@@ -22,35 +22,9 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
     var lastHighlightedMarkers = null;
     var lastHighlightedEventMarker = null;
     var options = null;
-    var destinationIcon = L.AwesomeMarkers.icon({
-        icon: 'default',
-        prefix: 'icon',
-        markerColor: 'lightgray'
-    });
-    var destinationOutsideTravelshedIcon = L.AwesomeMarkers.icon({
-        icon: 'default',
-        prefix: 'icon',
-        // modified by styles to actually be lightgray, with reduced opacity
-        markerColor: 'darkred',
-        extraClasses: 'outside'
-    });
-    var highlightIcon = L.AwesomeMarkers.icon({
-        icon: 'default',
-        prefix: 'icon',
-        markerColor: 'darkblue',
-    });
-    // Event marker styling
-   var eventHighlightIcon = L.AwesomeMarkers.icon({
-        icon: 'default',
-        prefix: 'icon',
-        markerColor: 'darkblue'
-    });
-   var eventIcon = L.AwesomeMarkers.icon({
-        icon: 'default',
-        prefix: 'icon',
-        markerColor: 'lightgray'
-    });
-
+    var placeIcon = L.AwesomeMarkers.icon(Utils.placeIconConfig);
+    var outsideTravelshedIcon = L.AwesomeMarkers.icon(Utils.outsideTravelshedIconConfig);
+    var highlightIcon = L.AwesomeMarkers.icon(Utils.highlightIconConfig);
 
     /**
      * Variables used for limiting to one isochrone request at a time.
@@ -289,11 +263,11 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
                 var popupContent = template({geojson: geojson});
                 var markerId = geojson.properties.id;
 
-                // use a different icon for places outside of the travel than those within it
-                var useIcon = geojson.properties.matched ? destinationIcon:
-                    destinationOutsideTravelshedIcon;
+                // use a different icon for places outside of the travelshed than those within it
+                var useIcon = geojson.properties.matched ? placeIcon:
+                    outsideTravelshedIcon;
                 if (isEvent) {
-                    useIcon = eventIcon;
+                    useIcon = placeIcon;
                 }
                 var marker = new cartodb.L.marker(latLng, {icon: useIcon})
                         .bindPopup(popupContent, {className: options.selectors.poiPopupClassName});
@@ -332,13 +306,13 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
     function highlightEventMarker(markerId) {
         unhighlightEventMarker();
         lastHighlightedEventMarker = destinationMarkers[markerId];
-        lastHighlightedEventMarker.marker.setIcon(eventHighlightIcon);
+        lastHighlightedEventMarker.marker.setIcon(highlightIcon);
 
     }
 
     function unhighlightEventMarker() {
         if (lastHighlightedEventMarker) {
-            lastHighlightedEventMarker.marker.setIcon(eventIcon);
+            lastHighlightedEventMarker.marker.setIcon(placeIcon);
             lastHighlightedEventMarker = null;
         }
     }
@@ -353,8 +327,8 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
         // If passed no destinations to highlight, un-highlight instead
         if ((!destinationIds || !destinationIds.length) && lastHighlightedMarkers) {
             _.each(lastHighlightedMarkers, function(marker) {
-                var icon = marker.matched ? destinationIcon:
-                    destinationOutsideTravelshedIcon;
+                var icon = marker.matched ? placeIcon:
+                    outsideTravelshedIcon;
                 marker.setIcon(icon);
             });
             lastHighlightedMarkers = null;
@@ -388,4 +362,4 @@ CAC.Map.IsochroneControl = (function ($, Handlebars, cartodb, L, turf, _) {
         }
     }
 
-})(jQuery, Handlebars, cartodb, L, turf, _);
+})(jQuery, Handlebars, cartodb, L, turf, _, CAC.Utils);

--- a/src/app/scripts/cac/map/cac-map-itinerary.js
+++ b/src/app/scripts/cac/map/cac-map-itinerary.js
@@ -1,4 +1,4 @@
-CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
+CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _, Utils) {
     'use strict';
 
     var defaults = {
@@ -44,7 +44,8 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
     } );
 
    // Tour itinerary styling
-   var tourHighlightWaypointIcon = L.AwesomeMarkers.icon(Utils.hightlightIconConfig);
+   var destinationIcon = L.AwesomeMarkers.icon(Utils.destinationIconConfig);
+   var tourHighlightWaypointIcon = L.AwesomeMarkers.icon(Utils.highlightIconConfig);
    var tourWaypointIcon = L.AwesomeMarkers.icon(Utils.placeIconConfig);
 
     function ItineraryControl(opts) {
@@ -90,7 +91,7 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
         // add a layer of non-draggable markers for tour waypoints (destinations)
         var waypoints = itinerary.waypoints ? _.cloneDeep(itinerary.waypoints) : [];
 
-        // Add the last tour destination as a marker styled like the waypoints
+        // Add the last tour destination
         if (tourDestinations && tourDestinations.length > 0) {
             var idx = tourDestinations.length - 1;
             var destination = tourDestinations[idx];
@@ -103,9 +104,11 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
             var dragging = false;
             var popupTimeout;
             var i = 0;
+            var lastIdx = tourDestinations.length - 1;
             waypointsLayer = cartodb.L.geoJson(turf.featureCollection(waypoints), {
                 pointToLayer: function(geojson, latlng) {
-                    var marker = new cartodb.L.marker(latlng, {icon: tourWaypointIcon,
+                    var icon = (i < lastIdx) ? tourWaypointIcon : destinationIcon;
+                    var marker = new cartodb.L.marker(latlng, {icon: icon,
                                                                draggable: false});
                     var place = tourDestinations[i];
                     i += 1;
@@ -141,7 +144,11 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
      */
     function highlightTourMarker(index) {
         unhighlightTourMarker();
-        lastItineraryHoverMarker = waypointsLayer.getLayers()[index];
+        var waypointMarkers = waypointsLayer.getLayers();
+        if (index === (waypointMarkers.length - 1)) {
+            return; // do not highlight destination marker
+        }
+        lastItineraryHoverMarker = waypointMarkers[index];
         if (lastItineraryHoverMarker) {
             lastItineraryHoverMarker.setIcon(tourHighlightWaypointIcon);
         }
@@ -518,4 +525,4 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
         });
     }
 
-})(jQuery, Handlebars, cartodb, L, turf, _);
+})(jQuery, Handlebars, cartodb, L, turf, _, CAC.Utils);

--- a/src/app/scripts/cac/map/cac-map-itinerary.js
+++ b/src/app/scripts/cac/map/cac-map-itinerary.js
@@ -44,16 +44,8 @@ CAC.Map.ItineraryControl = (function ($, Handlebars, cartodb, L, turf, _) {
     } );
 
    // Tour itinerary styling
-   var tourHighlightWaypointIcon = L.AwesomeMarkers.icon({
-        icon: 'default',
-        prefix: 'icon',
-        markerColor: 'darkblue'
-    });
-   var tourWaypointIcon = L.AwesomeMarkers.icon({
-        icon: 'default',
-        prefix: 'icon',
-        markerColor: 'lightgray'
-    });
+   var tourHighlightWaypointIcon = L.AwesomeMarkers.icon(Utils.hightlightIconConfig);
+   var tourWaypointIcon = L.AwesomeMarkers.icon(Utils.placeIconConfig);
 
     function ItineraryControl(opts) {
         this.events = events;

--- a/src/app/scripts/cac/map/cac-map-overlays.js
+++ b/src/app/scripts/cac/map/cac-map-overlays.js
@@ -85,11 +85,7 @@ CAC.Map.OverlaysControl = (function ($, cartodb, L, Utils) {
 
     function getFeedEventMarker(event) {
         var latLng = cartodb.L.latLng(event.point.coordinates[1], event.point.coordinates[0]);
-        var icon = L.AwesomeMarkers.icon({
-            icon: 'calendar',
-            markerColor: 'orange',
-            prefix: 'fa'
-        });
+        var icon = L.AwesomeMarkers.icon(Utils.feedEventIconConfig);
         var marker = new cartodb.L.marker(latLng, { icon: icon });
         marker.bindPopup(CAC.Map.Templates.eventPopup(event),
                          {className: options.selectors.eventPopupClassName});

--- a/src/app/scripts/cac/pages/cac-pages-directions.js
+++ b/src/app/scripts/cac/pages/cac-pages-directions.js
@@ -141,17 +141,8 @@ CAC.Pages.Directions = (function ($, _, DirectionsList, Itinerary, Settings, Uti
             });
             itinerary.geojson.addTo(map);
 
-            var originIcon = L.AwesomeMarkers.icon({
-                icon: 'home',
-                prefix: 'fa',
-                markerColor: 'purple'
-            });
-
-            var destIcon = L.AwesomeMarkers.icon({
-                icon: 'flag-o',
-                prefix: 'fa',
-                markerColor: 'red'
-            });
+            var originIcon = L.AwesomeMarkers.icon(Utils.originIconConfig);
+            var destIcon = L.AwesomeMarkers.icon(Utils.destinationIconConfig);
 
             var origin = [itinerary.from.lat, itinerary.from.lon];
             var destination = [itinerary.to.lat, itinerary.to.lon];

--- a/src/app/scripts/cac/utils.js
+++ b/src/app/scripts/cac/utils.js
@@ -1,6 +1,47 @@
 CAC.Utils = (function (_, moment) {
     'use strict';
 
+    // Map icon settings
+    var destinationIconConfig = {
+        icon: 'marker-destination',
+        prefix: 'icon',
+        markerColor: 'red'
+    };
+
+    // Note: feed events no longer display on the map
+    var feedEventIconConfig = {
+        icon: 'calendar',
+        markerColor: 'orange',
+        prefix: 'fa'
+    };
+
+    var highlightIconConfig = {
+        icon: 'default',
+        prefix: 'icon',
+        markerColor: 'darkblue',
+    };
+
+    var originIconConfig = {
+        icon: 'marker-origin',
+        prefix: 'icon',
+        markerColor: 'green'
+    };
+
+    var outsideTravelshedIconConfig = {
+        icon: 'default',
+        prefix: 'icon',
+        // modified by styles to actually be lightgray, with reduced opacity
+        markerColor: 'darkred',
+        extraClasses: 'outside'
+    };
+
+    var placeIconConfig = {
+        icon: 'default',
+        prefix: 'icon',
+        markerColor: 'lightgray'
+    };
+
+    // Direction string mappings
     var directions = {
         north: 'N',
         northeast: 'NE',
@@ -95,20 +136,26 @@ CAC.Utils = (function (_, moment) {
     };
 
     var module = {
-        convertReverseGeocodeToLocation: convertReverseGeocodeToLocation,
-        defaultBackgroundLineColor: defaultBackgroundLineColor,
-        defaultModeColor: defaultModeColor,
-        getImageUrl: getImageUrl,
-        getFormattedDistance: getFormattedDistance,
         abbrevStreetName: abbrevStreetName,
-        getBikeOptimizeLabel: getBikeOptimizeLabel,
-        getUrlParams: getUrlParams,
-        encodeUrlParams: encodeUrlParams,
-        getModeColor: getModeColor,
-        modeStringHelper: modeStringHelper,
-        initializeMoment: initializeMoment,
-        defaultCarouselOptions: defaultCarouselOptions,
+        convertReverseGeocodeToLocation: convertReverseGeocodeToLocation,
         dashArray: dashArray,
+        defaultBackgroundLineColor: defaultBackgroundLineColor,
+        defaultCarouselOptions: defaultCarouselOptions,
+        defaultModeColor: defaultModeColor,
+        destinationIconConfig: destinationIconConfig,
+        encodeUrlParams: encodeUrlParams,
+        feedEventIconConfig: feedEventIconConfig,
+        getBikeOptimizeLabel: getBikeOptimizeLabel,
+        getFormattedDistance: getFormattedDistance,
+        getImageUrl: getImageUrl,
+        getModeColor: getModeColor,
+        getUrlParams: getUrlParams,
+        highlightIconConfig: highlightIconConfig,
+        initializeMoment: initializeMoment,
+        modeStringHelper: modeStringHelper,
+        originIconConfig: originIconConfig,
+        outsideTravelshedIconConfig: outsideTravelshedIconConfig,
+        placeIconConfig: placeIconConfig,
         tourHighlightColor: tourHighlightColor
     };
 


### PR DESCRIPTION
## Overview

Styles tour place markers like origin or destination markers when they are at the start or end of the planned tour.

Also refactors all marker styling configurations into the `Utils` file, with the other app constants.


### Demo

![image](https://user-images.githubusercontent.com/960264/69175223-5c3a7900-0ad1-11ea-8856-640417ed1c34.png)


### Notes

As a result of this, place markers that are the origin or destination no longer change to blue with their preceding segment on segment/place card hover.


## Testing Instructions

 * Go to a tour without an origin set
 * Last tour place marker should be styled as a red destination marker
 * First tour place marker should be styled as a green origin marker
 * Set an origin in the sidebar form
 * First tour place marker should now be grey and and the user origin should have a green marker
 * Other map markers should still look as expected (not be broken by the refactor)

Closes #1205 
