### PR TITLE
Workaround for extra tour list

### DIFF
--- a/python/cac_tripplanner/templates/home.html
+++ b/python/cac_tripplanner/templates/home.html
@@ -217,7 +217,7 @@
     <div class="directions-results">
         {% include "partials/spinner.html" %}
         <div class="directions-list"></div>
-        <div class="tours"></div>
+        <div class="tour-places"></div>
     </div>
 
     <div class="directions-step-by-step"></div>

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -15,7 +15,7 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
         showShareButton: false,
         selectors: {
             alert: '.alert',
-            container: '.tours',
+            container: '.tour-places',
             dataPlaceIndex: 'data-tour-place-index',
             hiddenClass: 'hidden',
             destinationList: '.tour-list',
@@ -96,12 +96,6 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
         $(options.selectors.undoButton).on('click', onUndoButtonClick);
 
         var $destinationList = $(options.selectors.destinationList);
-
-        // workaround for #1201
-        // remove second destination list if there are two
-        if ($destinationList.length > 1) {
-            $destinationList.first().remove();
-        }
 
         // First remove sortable if already initialized
         if ($destinationList.sortable('widget')) {

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -97,6 +97,12 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
 
         var $destinationList = $(options.selectors.destinationList);
 
+        // workaround for #1201
+        // remove second destination list if there are two
+        if ($destinationList.length > 1) {
+            $destinationList.first().remove();
+        }
+
         // First remove sortable if already initialized
         if ($destinationList.sortable('widget')) {
             $destinationList.sortable('destroy');

--- a/src/app/scripts/cac/map/cac-map-control.js
+++ b/src/app/scripts/cac/map/cac-map-control.js
@@ -347,6 +347,8 @@ CAC.Map.Control = (function ($, Handlebars, cartodb, L, turf, _, Utils) {
                 map.setView(markers[0].getLatLng());
             }
         }
+        // Deal with Chrome mobile not always fully loading tiles
+        map.invalidateSize();
     }
 
     function clearDirectionsMarker(type) {

--- a/src/app/styles/components/_directions-results.scss
+++ b/src/app/styles/components/_directions-results.scss
@@ -61,7 +61,7 @@
         }
     }
 
-    .tours {
+    .tour-places {
         .body-map & {
             @include sidebar-main-inner-scroll;
         }


### PR DESCRIPTION
Work around having two tour lists in the DOM in the production build when the page is loaded directly by removing the first.

Connects #1201.
