### PR TITLE
Reset user order on tour load

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -840,6 +840,8 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
                             // Match format of Typeahead response
                             tour.id = 'tour_' + tour.id;
                         }
+                        // Reset the tour to clear changes to order or removed destinations
+                        tourListControl.clearTour();
                     } else if (tourMode === 'event' && data.events && data.events.length) {
                         tour = data.events[0];
                         // Go directly to route for single-destination events

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -45,6 +45,7 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
     }
 
     TourListControl.prototype = {
+        clearTour: clearTour,
         events: events,
         eventNames: eventNames,
         setTourDestinations: setTourDestinations,
@@ -56,6 +57,11 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
     };
 
     return TourListControl;
+
+    function clearTour() {
+        tourId = null;
+        destinations = [];
+    }
 
     // Helper to check if a given tour place has been reordered or removed by the user
     function destinationIsDirty(destination) {


### PR DESCRIPTION
## Overview

Fixes issue where user reorder or removal of tour places would persist in sidebar after returning to tour via browser back, but tour would be reset on map. Clears user edits to tour on page changes.


## Testing Instructions

 * Go to the map view of a tour
 * Change the tour (reorder or remove places)
 * Changes should persist across multiple changes (i.e., can remove multiple places)
 * Click to go to directions in a place card
 * Click browser back button to return to tour places list
 * Tour should be reset to clear the changes made above, both in sidebar and on map


Fixes #1235 
