### PR TITLE
Hide reverse button for tour/event destinations

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -18,6 +18,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             hiddenClass: 'hidden',
             itineraryBlock: '.route-summary',
             places: '.places',
+            reverseButton: '.btn-reverse',
             selectedClass: 'selected',
             spinner: '.directions-results > .sk-spinner',
             tourDestinationBlock: '.place-card',
@@ -615,6 +616,8 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
                 directions[key] = null;
                 return;
             }
+        } else {
+            $(options.selectors.reverseButton).show();
         }
 
         clearItineraries();
@@ -694,11 +697,14 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
         UserPreferences.setPreference('tourMode', tourModePreference);
 
         if (!tourModePreference) {
+            $(options.selectors.reverseButton).show();
             // Send the single destination.
             onTypeaheadSelectDone(key, [result]);
             return;
         } else {
             tour = null;
+            // Cannot set a tour or multi-location event as origin, so hide reverse button
+            $(options.selectors.reverseButton).hide();
         }
 
         if (result.destinations) {
@@ -851,6 +857,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
                         }
                     }
                     if (tour) {
+                        $(options.selectors.reverseButton).hide();
                         onTypeaheadSelectDone('destination', tour.destinations);
                     } else {
                         console.error('Failed to find destinations for tour ' + destination.address);
@@ -862,6 +869,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
                     planTripOrShowPlaces();
                 });
             } else {
+                $(options.selectors.reverseButton).show();
                 // Not a tour; go to plan route
                 planTripOrShowPlaces();
             }


### PR DESCRIPTION
## Overview

Hide the origin/destination reverse button if the destination cannot be an origin (a tour or multi-destination event.)


### Demo

No reverse button:
![image](https://user-images.githubusercontent.com/960264/70069904-91aa9080-15c0-11ea-9802-675d3c6f7b00.png)

Has reverse button:
![image](https://user-images.githubusercontent.com/960264/70069954-a8e97e00-15c0-11ea-8afb-993de8c8143f.png)


## Testing Instructions

 * Set and clear destination various ways: should have reverse button if a single destination
 * Go to destination from home page
 * Page refresh
 * Go to destination from details page
 * Go to destination from 'directions' button in places sidebar list
 * On browser back from directions to a single tour destination


Closes #1237 
