### PR TITLE
Preserve tour edits on returning to tour

### DIFF
--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -377,6 +377,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             showPlaces(false);
             planTrip();
         } else {
+            clearItineraries();
             showPlaces(true);
             exploreControl.getNearbyPlaces();
         }
@@ -618,6 +619,8 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             }
         } else {
             $(options.selectors.reverseButton).show();
+            tour = null;
+            tourListControl.resetTour();
         }
 
         clearItineraries();
@@ -634,6 +637,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             mapControl.clearDirectionsMarker(key);
             // only load destinations list in directions mode when destination field empty
             if (key === 'destination') {
+                clearItineraries();
                 showPlaces(true);
                 exploreControl.getNearbyPlaces();
             }
@@ -703,6 +707,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             return;
         } else {
             tour = null;
+            tourListControl.resetTour();
             // Cannot set a tour or multi-location event as origin, so hide reverse button
             $(options.selectors.reverseButton).hide();
         }
@@ -847,13 +852,14 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
                             tour.id = 'tour_' + tour.id;
                         }
                         // Reset the tour to update map with user edits to the destinations/order
-                        tourListControl.resetTour();
+                        tourListControl.resetTour(tour.id);
                     } else if (tourMode === 'event' && data.events && data.events.length) {
                         tour = data.events[0];
                         // Go directly to route for single-destination events
                         if (tour.destinations && tour.destinations.length === 1) {
                             UserPreferences.setPreference('tourMode', false);
                             tour = null;
+                            tourListControl.resetTour();
                             onTypeaheadSelectDone('destination', [data.events[0]]);
                             return;
                         }
@@ -877,6 +883,7 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
             }
         } else {
             // explore tab visible
+            clearItineraries();
             showPlaces(true);
         }
     }

--- a/src/app/scripts/cac/control/cac-control-directions.js
+++ b/src/app/scripts/cac/control/cac-control-directions.js
@@ -846,8 +846,8 @@ CAC.Control.Directions = (function (_, $, moment, Control, Places, Routing, User
                             // Match format of Typeahead response
                             tour.id = 'tour_' + tour.id;
                         }
-                        // Reset the tour to clear changes to order or removed destinations
-                        tourListControl.clearTour();
+                        // Reset the tour to update map with user edits to the destinations/order
+                        tourListControl.resetTour();
                     } else if (tourMode === 'event' && data.events && data.events.length) {
                         tour = data.events[0];
                         // Go directly to route for single-destination events

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -58,10 +58,14 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
 
     return TourListControl;
 
-    function resetTour() {
-        // Trigger event to let map know about any user edits to the tour destinations
-        if (tourId && destinations && destinations.length) {
+    // Clear the current tour if the IDs don't match, or tell the map to reflect the last user
+    // edits if the IDs do match, or if no ID is passed in.
+    function resetTour(forId) {
+        if (forId && tourId === forId && destinations && destinations.length) {
             reorderDestinations();
+        } else {
+            tourId = null;
+            destinations = [];
         }
     }
 

--- a/src/app/scripts/cac/control/cac-control-tour-list.js
+++ b/src/app/scripts/cac/control/cac-control-tour-list.js
@@ -45,7 +45,7 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
     }
 
     TourListControl.prototype = {
-        clearTour: clearTour,
+        resetTour: resetTour,
         events: events,
         eventNames: eventNames,
         setTourDestinations: setTourDestinations,
@@ -58,9 +58,11 @@ CAC.Control.TourList = (function (_, $, MapTemplates, Utils) {
 
     return TourListControl;
 
-    function clearTour() {
-        tourId = null;
-        destinations = [];
+    function resetTour() {
+        // Trigger event to let map know about any user edits to the tour destinations
+        if (tourId && destinations && destinations.length) {
+            reorderDestinations();
+        }
     }
 
     // Helper to check if a given tour place has been reordered or removed by the user


### PR DESCRIPTION
## Overview

On clicking to go back to the tour places list after viewing place-to-place directions,
preserve any user changes to place order or removed places.


### Notes

Supersedes #1235 by fixing edits appearing in the sidebar but not on the map.


## Testing Instructions

 * Go to the map page for a tour
 * Reorder the tour and/or remove one or more places from it
 * Click on a place card 'directions' button
 * Click either browser back or the back button at the head of the directions list
 * Tour edits made above should be preserved on both map and in sidebar
 * Page refresh should load tour with no edits

Closes #1241.
