### PR TITLE
Limit location card width on tour detail page

### DIFF
--- a/src/app/styles/components/_place-card.scss
+++ b/src/app/styles/components/_place-card.scss
@@ -272,6 +272,7 @@
     }
 
     .place-card-badges {
+        margin-top: auto;
     }
 
     .place-card-actions {

--- a/src/app/styles/components/_tour-place-card.scss
+++ b/src/app/styles/components/_tour-place-card.scss
@@ -81,16 +81,3 @@
         background-color: transparent;
     }
 }
-
-.tour-place-card-badges {
-    display: flex;
-    flex-flow: row nowrap;
-    align-items: center;
-    justify-content: flex-end;
-    font-size: 1.8rem;
-    line-height: 1;
-
-    .badge {
-        margin-left: .8rem;
-    }
-}

--- a/src/app/styles/layouts/_info.scss
+++ b/src/app/styles/layouts/_info.scss
@@ -474,7 +474,7 @@
 
     .tour-locations-list {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
         grid-gap: 2.4rem;
         justify-items: stretch;
         align-items: stretch;


### PR DESCRIPTION
## Overview

Fix the case where long locations names cause location cards to overflow their grid on the tour detail page.

### Before

![image](https://user-images.githubusercontent.com/128699/70648300-cbab1080-1c18-11ea-9a60-e451875549bd.png)

### After

![image](https://user-images.githubusercontent.com/128699/70648341-dd8cb380-1c18-11ea-8b93-3a014d4b9892.png)
