### PR TITLE
Upgrade development database to PostgreSQL 9.6

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -10,7 +10,7 @@ postgres_password: "cac_tripplanner"
 postgres_host: "192.168.8.25"
 
 postgresql_support_psycopg2_version: "2.8.*"
-'postgis_version': [2, 1, 8]
+'postgis_version': [2, 5, 2]
 
 packer_version: "1.4.4"
 

--- a/deployment/ansible/group_vars/development_template
+++ b/deployment/ansible/group_vars/development_template
@@ -27,7 +27,7 @@ default_admin_password: 'admin'
 default_admin_email: 'systems+cac@azavea.com'
 
 postgresql_version: "9.6"
-postgresql_package_version: "9.6.*.pgdg18.04+1"
+postgresql_package_version: "9.6.*"
 postgresql_support_libpq_version: "*"
 
 postgresql_listen_addresses: "*"

--- a/deployment/ansible/group_vars/development_template
+++ b/deployment/ansible/group_vars/development_template
@@ -9,7 +9,7 @@ otp_process_mem: 5G
 # for cac_secrets
 allowed_hosts: ['127.0.0.1', 'localhost']
 internal_ips: ['0.0.0.0', '127.0.0.1']
-postgis_version: [2, 1, 8]
+postgis_version: [2, 5, 2]
 aws_access_key_id: ''
 aws_secret_access_key: ''
 aws_storage_bucket_name: ''
@@ -26,8 +26,8 @@ default_admin_username: 'admin'
 default_admin_password: 'admin'
 default_admin_email: 'systems+cac@azavea.com'
 
-postgresql_version: "9.5"
-postgresql_package_version: "9.5.*"
+postgresql_version: "9.6"
+postgresql_package_version: "9.6.*.pgdg18.04+1"
 postgresql_support_libpq_version: "*"
 
 postgresql_listen_addresses: "*"

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -3,10 +3,10 @@ test: true
 develop: false
 production: false
 
-postgis_version: [2, 1, 8]
+postgis_version: [2, 5, 2]
 
-postgresql_version: "9.5"
-postgresql_package_version: "9.5.*"
+postgresql_version: "9.6"
+postgresql_package_version: "9.6.*.pgdg18.04+1"
 postgresql_support_libpq_version: "*"
 
 postgresql_listen_addresses: "*"

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -6,7 +6,7 @@ production: false
 postgis_version: [2, 5, 2]
 
 postgresql_version: "9.6"
-postgresql_package_version: "9.6.*.pgdg18.04+1"
+postgresql_package_version: "9.6.*"
 postgresql_support_libpq_version: "*"
 
 postgresql_listen_addresses: "*"

--- a/python/cac_tripplanner/cac_tripplanner/settings.py
+++ b/python/cac_tripplanner/cac_tripplanner/settings.py
@@ -47,7 +47,7 @@ except (IOError, NameError):
         # to the host machine's DNS here, because this code runs in a VM.
         'otp_url': 'http://192.168.8.26/otp/routers/{router}/',
         'internal_ips': ['0.0.0.0', '127.0.0.1'],
-        'postgis_version': [2, 1, 8],
+        'postgis_version': [2, 5, 2],
         'build_dir': '/opt/app/src',
         'production': False,
 


### PR DESCRIPTION
## Overview

Update PostgreSQL to version 9.6 and PostGIS to version 2.5.2 (matches Amazon RDS for PostgreSQL) for the local development environment.

In addition, this will update the PostgreSQL client libraries used by the application servers (across all environments) to connect to the database.

## Testing Instructions

- Destroy the `database` virtual machine and re-create it using the changes in this branch

```console
$ vagrant destroy database -f
$ vagrant up database
```

- SSH into the newly provisioned `database` virtual machine and ensure that the versions of PostgreSQL and PostGIS are as expected

```
$ vagrant ssh database
vagrant@database:~$ sudo su postgres
postgres@database:/home/vagrant$ psql
psql (9.6.16)
Type "help" for help.

postgres=# \c cac_tripplanner
You are now connected to database "cac_tripplanner" as user "postgres".
cac_tripplanner=# select version();
                                                                version
---------------------------------------------------------------------------------------------------------------------------------------
 PostgreSQL 9.6.16 on x86_64-pc-linux-gnu (Ubuntu 9.6.16-1.pgdg18.04+1), compiled by gcc (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0, 64-bit
(1 row)

cac_tripplanner=# select postgis_version();
            postgis_version
---------------------------------------
 2.5 USE_GEOS=1 USE_PROJ=1 USE_STATS=1
(1 row)
```

- Ensure the application works using its existing PostgreSQL client libraries to talk to a PostgreSQL 9.6 database

## Checklist

~- [ ] No gulp lint warnings~
~- [ ] No python lint warnings~
- [x] Python tests pass

Connects #1239 