### PR TITLE
Do not sent preflight request for Indego stations JSON

### DIFF
--- a/src/app/scripts/cac/map/cac-map-overlays.js
+++ b/src/app/scripts/cac/map/cac-map-overlays.js
@@ -25,8 +25,9 @@ CAC.Map.OverlaysControl = (function ($, cartodb, L, Utils) {
     function bikeShareOverlay() {
         bikeShareFeatureGroup = cartodb.L.featureGroup([]);
         $.ajax({
-            contentType: 'application/json',
-            url: 'https://api.phila.gov/bike-share-stations/v1',
+            cache: false,
+            dataType: 'json',
+            url: 'https://kiosks.bicycletransit.workers.dev/phl',
             success: function (data) {
                 $.each(data.features, function (i, share) {
                     bikeShareFeatureGroup.addLayer(getBikeShareMarker(share));


### PR DESCRIPTION
## Overview

Fixes station map not loading.
Fixes #1253.

### Demo

![cac_bike_share_locations](https://user-images.githubusercontent.com/960264/77768721-3ee66000-7019-11ea-8657-230da3648b34.png)


## Testing Instructions

 * Go to map
 * Toggle on the bike share station overlay in the map overlay picker
 * Station icons should show
