### PR TITLE
Upgrade OS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,7 +71,7 @@ VAGRANT_PROXYCONF_ENDPOINT = ENV["VAGRANT_PROXYCONF_ENDPOINT"]
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "bento/ubuntu-18.04"
+  config.vm.box = "bento/ubuntu-20.04"
 
   # Wire up the proxy if:
   #

--- a/deployment/ansible/app.yml
+++ b/deployment/ansible/app.yml
@@ -6,5 +6,11 @@
     - name: Update APT cache
       apt: update_cache=yes
 
+    - name: Install ACL for ansible file permission controls
+      apt:
+        state: present
+        pkg:
+          - acl
+
   roles:
     - { role: "cac-tripplanner.app"}

--- a/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/defaults/main.yml
@@ -15,3 +15,5 @@ root_conf_dir: "/etc/cac_tripplanner.d"
 root_src_dir: "/opt/app/src"
 root_static_dir: "/srv/cac"
 root_media_dir: "/media/cac"
+
+nginx_delete_default_site: False

--- a/deployment/ansible/roles/cac-tripplanner.app/meta/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/meta/main.yml
@@ -1,7 +1,6 @@
 ---
   dependencies:
     - { role: "azavea.git" }
-    - { role: "azavea.nginx" }
     - { role: "azavea.nodejs" }
     - { role: "azavea.packer" }
     - { role: "cac-tripplanner.papertrail", when: production }

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -11,6 +11,7 @@
       - libpq-dev
       - libproj-dev
       - libjpeg-dev
+      - osmctools
 
 - name: Install pip packages for deployment
   pip: requirements={{ root_app_dir }}/deployment_requirements.txt executable=/usr/bin/pip3

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -1,9 +1,32 @@
 ---
+- name: Install nginx prerequisites
+  apt:
+    state: present
+    pkg:
+      - curl
+      - gnupg2
+      - ca-certificates
+      - lsb-release
+
+- name: Set up nginx apt repository
+  become: yes
+  command: echo "deb http://nginx.org/packages/ubuntu `lsb_release -cs` nginx" tee /etc/apt/sources.list.d/nginx.list
+  args:
+    creates: /etc/apt/sources.list.d/nginx.list
+
+- name: Add nginx signing key
+  apt_key:
+    url: https://nginx.org/keys/nginx_signing.key
+    state: present
+    id: ABF5BD827BD9BF62
+
+- name: Update APT cache
+  apt: update_cache=yes
+
 - name: Install packages
   apt:
     state: present
     pkg:
-      - acl
       - binutils
       - chromium-browser
       - dh-autoreconf
@@ -12,6 +35,7 @@
       - libpq-dev
       - libproj-dev
       - libjpeg-dev
+      - nginx-full
       - osmctools
 
 - name: Install pip packages for deployment
@@ -56,6 +80,30 @@
     name: "{{ gunicorn_app_name }}.service"
     enabled: yes
     daemon_reload: yes
+
+- name: Delete default site
+  file: path=/etc/nginx/sites-enabled/default state=absent
+  register: delete_default_site
+  when: nginx_delete_default_site | bool
+  notify:
+    - Restart nginx
+
+- name: Delete default web root
+  file: path=/var/www/html state=absent
+  when: nginx_delete_default_site | bool and delete_default_site is changed
+
+- name: Check Nginx Upstart service definition exists
+  stat: path=/etc/init/nginx.conf
+  register: nginx_upstart
+
+- name: Configure Nginx log rotation
+  template: src=logrotate_nginx.j2 dest=/etc/logrotate.d/nginx
+  when: nginx_upstart.stat.exists
+
+- name: Configure Nginx
+  template: src=nginx.conf.j2 dest=/etc/nginx/nginx.conf
+  notify:
+    - Restart nginx
 
 - name: Enable nginx service
   systemd:

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -3,6 +3,7 @@
   apt:
     state: present
     pkg:
+      - acl
       - binutils
       - chromium-browser
       - dh-autoreconf

--- a/deployment/ansible/roles/cac-tripplanner.app/templates/logrotate_nginx.j2
+++ b/deployment/ansible/roles/cac-tripplanner.app/templates/logrotate_nginx.j2
@@ -1,0 +1,18 @@
+/var/log/nginx/*.log {
+	weekly
+	missingok
+	rotate 52
+	compress
+	delaycompress
+	notifempty
+	create 0640 www-data adm
+	sharedscripts
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+			run-parts /etc/logrotate.d/httpd-prerotate; \
+		fi \
+	endscript
+	postrotate
+		service nginx rotate >/dev/null 2>&1
+	endscript
+}

--- a/deployment/ansible/roles/cac-tripplanner.app/templates/nginx.conf.j2
+++ b/deployment/ansible/roles/cac-tripplanner.app/templates/nginx.conf.j2
@@ -1,0 +1,34 @@
+user www-data;
+worker_processes {{ ansible_processor_count }};
+pid /run/nginx.pid;
+
+events {
+	worker_connections 768;
+}
+
+http {
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+
+	server_tokens off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
+
+	gzip on;
+	gzip_vary on;
+	gzip_proxied any;
+	gzip_comp_level 6;
+	gzip_buffers 16 8k;
+	gzip_http_version 1.1;
+	gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript;
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+}

--- a/deployment/ansible/roles/cac-tripplanner.database/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.database/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Install ACL for ansible file permission controls
+  apt:
+    state: present
+    pkg:
+      - acl
+
 - name: Configure the PostgreSQL APT key
   apt_key: url=https://www.postgresql.org/media/keys/ACCC4CF8.asc state=present
 

--- a/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Install ACL for ansible file permission controls
+  apt:
+    state: present
+    pkg:
+      - acl
+
 - name: Create Directory for OSM and GTFS
   file: path={{ otp_data_dir }} state=directory owner={{ otp_user }}
 

--- a/deployment/packer/cac_packer.py
+++ b/deployment/packer/cac_packer.py
@@ -21,7 +21,7 @@ def get_ubuntu_ami(region, creds):
       creds (Dict): Dictionary containing AWS credentials
     """
 
-    response = urllib.urlopen('http://cloud-images.ubuntu.com/query/bionic/'
+    response = urllib.urlopen('http://cloud-images.ubuntu.com/query/focal/'
                               'server/released.current.txt').readlines()
     response = [x.decode('utf-8') for x in response]
     fieldnames = ['version', 'version_type', 'release_status', 'date',


### PR DESCRIPTION
## Overview

This PR upgrades the Ubuntu version used in the VMs and deployment AMIs from `bionic` to `focal`. Both are long-term support releases. This PR also installs `osmctools` in the app VM, as a convenience for managing OSM data downloads.

This is not a necessary upgrade to make right now, but may be helpful to do because it enables installing a version of `osmconvert` (in `osmctools`) that can support the `complete-boundaries` parameter for merging and clipping OSM extracts; the version of `osmconvert` in `bionic` is not recent enough for that (> 0.7 needed).


### Demo

In the app VM:
![image](https://user-images.githubusercontent.com/960264/95893733-0fe5d080-0d56-11eb-94e3-9f3348b97d1f.png)


### Notes

Replacing the `nginx` role was necessary, because the unofficial Ubuntu `ppa` has not been updated to support `focal`. This installs the [official repository](http://nginx.org/en/linux_packages.html#Ubuntu), and copies the template files and configuration tasks from the `nginx` role.


## Testing Instructions

If this might be a useful upgrade to make at this time, it can be tested during VM and AMI building as part of paring to redeploy.
