### PR TITLE
Update README to add note to install npm modules on host machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Development Installation
 1. Make sure you have the development dependencies installed
 2. Place GTFS .zip files, OSM files, and elevation .tif files (optional) in the otp_data folder
 3. Copy `deployment/ansible/group_vars/development_template` to `deployment/ansible/group_vars/development`
-4. Run `vagrant up`
-5. See the app at http://localhost:8024! See OpenTripPlanner at http://localhost:9090.
-6. Running `./scripts/serve-js-dev.sh` on the host will rebuild the front-end app on file change (the browser must be reloaded manually to pick up the change). Alternatively, `cd /opt/app/src && npm run gulp-development` can be run manually in the VM to pick up changes to the static files.
+4. Change into the `src/` folder and run `npm install` to install the node modules on the host machine
+5. Run `vagrant up`
+6. See the app at http://localhost:8024! See OpenTripPlanner at http://localhost:9090.
+7. Running `./scripts/serve-js-dev.sh` on the host will rebuild the front-end app on file change (the browser must be reloaded manually to pick up the change). Alternatively, `cd /opt/app/src && npm run gulp-development` can be run manually in the VM to pick up changes to the static files.
 
 Note that if there is an existing build Graph.obj in `otp_data`, vagrant provisioning in development mode will not attempt to rebuild the graph, but will use the one already present.
 


### PR DESCRIPTION
## Overview

Update README with added step of installing npm modules locally before running `vagrant up`

### Notes

Are there additional steps that need to be added here?

## Testing Instructions

Follow instructions in README


## Checklist
- [ ] No gulp lint warnings
- [ ] No python lint warnings
- [ ] Python tests pass


Connects #XXX
