### PR TITLE
Add Docker configuration to process OTP data files

### DIFF
--- a/deployment/dataproc/Dockerfile
+++ b/deployment/dataproc/Dockerfile
@@ -3,6 +3,6 @@ FROM ubuntu:20.04
 RUN mkdir -p /usr/local/src
 WORKDIR /usr/local/src
 
-RUN apt update && apt install -y osmctools
+RUN apt update && apt install -y curl osmctools
 
 COPY . /usr/local/src

--- a/deployment/dataproc/Dockerfile
+++ b/deployment/dataproc/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:20.04
+
+RUN mkdir -p /usr/local/src
+WORKDIR /usr/local/src
+
+RUN apt update && apt install -y osmctools
+
+COPY . /usr/local/src

--- a/deployment/dataproc/combine-and-clip.sh
+++ b/deployment/dataproc/combine-and-clip.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+BOUNDS=-76.209582,38.441753,-74.243725,40.725449
+
+declare -a STATES=("pennsylvania" "new-jersey" "delaware")
+
+for STATE in "${STATES[@]}"; do
+    echo "extracting OSM data for the region served by CAC for ${STATE}..."
+    osmconvert ${STATE}.pbf -b=${BOUNDS} \
+        --complete-ways --complex-ways --complete-boundaries --complete-multipolygons \
+        -o=${STATE}.o5m
+done
+
+echo "combining state region extracts..."
+
+INPUTS=$(printf "%s.o5m " "${STATES[@]}")
+
+osmconvert ${INPUTS} -o=cac.pbf
+
+echo "all done!"

--- a/deployment/dataproc/docker-compose.yml
+++ b/deployment/dataproc/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  osm:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./:/usr/local/src

--- a/deployment/dataproc/download-osm-data.sh
+++ b/deployment/dataproc/download-osm-data.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+declare -a STATES=("pennsylvania" "new-jersey" "delaware")
+
+for STATE in "${STATES[@]}"; do
+    echo "downloading OSM data for ${STATE}..."
+    curl https://download.geofabrik.de/north-america/us/${STATE}-latest.osm.pbf -o ${STATE}.pbf
+done


### PR DESCRIPTION
## Overview

Add a data processing subdirectory to the deployment directory that contains the scripts and container image definitions necessary to downloads state extracts, merge them, and clip them to the bounds of the DVRPC area.

## Testing Instructions

See updated testing instructions in https://github.com/azavea/geospatial-apps/pull/252.

## Checklist
- [x] No gulp lint warnings
- [x] No python lint warnings
- [x] Python tests pass