### PR TITLE
Create otp_url check for deployment

### DIFF
--- a/scripts/check-deploy-otp-url.sh
+++ b/scripts/check-deploy-otp-url.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+echo "Fetching otp url used by latest WebServer instance..."
+
+WEBSERVER=$(AWS_PROFILE=gophillygo aws ec2 describe-instances \
+    --filters 'Name=tag:Name,Values=WebServer' \
+    --query 'Reservations[].Instances[].{ip:PrivateIpAddress,time:LaunchTime}' | \
+    jq -r 'sort_by(.time) | reverse | .[0].ip')
+
+#There is only one, but sort by latest in event of multiple instances
+BASTION=$(AWS_PROFILE=gophillygo aws ec2 describe-instances \
+    --filters 'Name=tag:Name,Values=BastionHost' \
+    --query 'Reservations[].Instances[].{dns:PublicDnsName,time:LaunchTime}' | \
+    jq -r 'sort_by(.time) | reverse | .[0].dns')
+
+ssh -o ProxyCommand="ssh -i ~/.ssh/cac.pem -W %h:%p ubuntu@$BASTION" -i ~/.ssh/cac.pem ubuntu@$WEBSERVER /bin/bash << PRINTURL
+    sed -n 14p /etc/cac_secrets
+    exit
+PRINTURL


### PR DESCRIPTION
## Overview

This script prints the `otp_url` used by the latest AWS `WebServerStack` so that a user can manually confirm it matches the color of the `OtpServerStack` before proceeding with deployment. This is intended as a stopgap until we can better automate the deployment process.

### Notes

- This script will connect to AWS EC2 instances through `ssh` and will need the appropriate identity file. Ensure file is within local `~/.ssh` folder and given 600 permissions.
- We will need to include an instruction to run this script in the deployment `README.md` after new stacks are up and before previous ones are deleted.
- I wasn't sure how far to take this script, but AWS cli _does_ have an `aws cloudformation describe-stacks` command that I can filter, grab a color tag, and potentially compare to the color contained in`otp_url`. I think it would be a reasonable enough addition and would allow us to print a more clear cut `TEST PASS` vs `FAIL`. However, in previous "hybrid" stacks (ie a color stack mismatch), the Cloudfront cache was used instead of the `otp_host` defined in the `group_vars/production` file. It's unclear whether this will be the case in future color stack mismatches, but I figured it might be worth having a user just manually confirm the url until we sort it out.

## Testing Instructions
 * Set up identity file
 * Run `./scripts/check-deploy-otp-url.sh`
 * Confirm `otp_url` prints and matches color expected for latest stack (at time of writing this PR it should be `blue`)

Connects #1316 
