### PR TITLE
Upgrade to Django 3.2.13

### DIFF
--- a/python/cac_tripplanner/requirements.txt
+++ b/python/cac_tripplanner/requirements.txt
@@ -1,6 +1,6 @@
 base58==2.0.1
 boto3==1.15.9
-Django==3.2.12
+Django==3.2.13
 django-ckeditor==6.0.0
 django-image-cropping==1.5.0
 django-extensions==3.1.5

--- a/python/cac_tripplanner/shortlinks/test/urls.py
+++ b/python/cac_tripplanner/shortlinks/test/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.conf.urls import re_path
 from django.urls import include, path
 from shortlinks.test.views import stub_view
 
@@ -6,5 +6,5 @@ app_name = 'shortlinks'
 
 urlpatterns = [
     path('link/', include('shortlinks.urls')),
-    url(r'^$', stub_view, name='test-home'),
+    re_path(r'^$', stub_view, name='test-home'),
 ]


### PR DESCRIPTION
## Overview

Upgrades to Django 3.2.13 following the release of a [point release to fix a security vulnerability](https://docs.djangoproject.com/en/4.0/releases/3.2.13/). 


### Notes

When running test and runserver, the following deprecation warning appears in the console:

```
/usr/local/lib/python3.6/dist-packages/boto/plugin.py:40: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
```

This seems to be an issue with dependency `boto` that has still not been addressed in their latest release.

While testing, I ran into some issues with my instance of OTP. As they're occurring on both `develop` and this branch, it seems unlikely to be caused by this upgrade; however, these errors mean my tests are failing so it would be worth testing this theory on another machine.


## Testing Instructions

_Note: These testing instructions have largely been copied from [PR 1320](https://github.com/azavea/cac-tripplanner/pull/1320)._

 * Provision your app VM to update Django vagrant provision app
 * Next, run tests and the dev server to make sure that you don't see any deprecation warnings from Django (other than the ones mentioned above from `boto`):
    * `vagrant ssh app`
    * `cd /opt/app/python/cac_tripplanner`
    * `python3 -Wall manage.py test`
    * `sudo systemctl stop cac-tripplanner-app` (This stops the server process that comes up by default when you start the VM; you need to do this before starting up the Django dev server manually because you'll get a port conflict if you don't)
    * `python3 -Wall manage.py runserver`
* Last, click around the app and make sure everything works as it used to.


## Checklist
- [X] No gulp lint warnings
- [X] No python lint warnings
- [x] Python tests pass


Connects #1330 
