### PR TITLE
Switch to Google Analytics 4

### DIFF
--- a/python/cac_tripplanner/templates/base.html
+++ b/python/cac_tripplanner/templates/base.html
@@ -57,24 +57,19 @@
     {% block extracss %}
     {% endblock %}
 
-    <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-EE36F23XEW"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-EE36F23XEW');
+    </script>
+
   </head>
 
   <body>
-
-    <!-- Google Tag Manager -->
-    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KNZ9R2"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-KNZ9R2');</script>
-    <!-- End Google Tag Manager -->
-
     {% block body %}
     <div id="body-div" class="body-{{ tab|default:'home' }}
         {% if 'map' in tab %}body-map{% endif %}">


### PR DESCRIPTION
The previous version of Google Analytics is going way.

Also drop IE6-8 workaround that appears to have expired.

Resolves: #1329

## Testing Instructions

 *  Tested by running locally and confirming user was reported in Google analytics.

## Checklist
- [no change ] No gulp lint warnings
- [no change ] No python lint warnings
- [no change ] Python tests pass

