### PR TITLE
Stop using deprecated ansible_ssh_host

### DIFF
--- a/deployment/ansible/inventory/development
+++ b/deployment/ansible/inventory/development
@@ -1,4 +1,4 @@
 [development]
-app ansible_ssh_host=192.168.8.24
-database ansible_ssh_host=192.168.8.25
-otp ansible_ssh_host=192.168.8.26
+app ansible_host=192.168.8.24
+database ansible_host=192.168.8.25
+otp ansible_host=192.168.8.26


### PR DESCRIPTION
## Overview

Fixes an issue I had with copying the built Graph onto the host during deployment.

### Notes

The issue was due to newer versions of Ansible having deprecated the `ansible_ssh_host` parameter in favor of `ansible_host`. This caused the `synchronize` task to attempt to connect to `vagrant@otp` rather than `vagrant@192.168.8.26` when trying to use `rsync` to copy the Graph.obj file.


## Testing Instructions

 * If you've put in place any workarounds to resolve this issue (for example, changes to your `/etc/hosts` file), deactivate them and confirm that the error re-occurs on `develop` before testing this branch. The quickest way to test is to make the following temporary changes to your `Vagrantfile` and Ansible tasks:
```diff
index cc60b967..c1a3bb0a 100644
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -175,7 +175,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.compatibility_mode = "2.0"
       ansible.playbook = "deployment/ansible/otp.yml"
       ansible.inventory_path = ANSIBLE_INVENTORY_PATH
-      ansible.raw_arguments = ["--timeout=60"]
+      ansible.raw_arguments = ["--timeout=60", '--start-at-task=Copy Built OTP Graph to Host (develop)']
     end
 
     otp.vm.provider :virtualbox do |v|
```

```diff
index 966fd211..fbb59780 100644
--- a/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.otp-data/tasks/main.yml
@@ -51,7 +51,7 @@
   when: test or (develop and not graph.stat.exists)
 
 - name: Copy Built OTP Graph to Host (develop)
-  when: develop and graph_build is changed
+  when: develop #and graph_build is changed
   synchronize:
     mode: pull
     src: "{{ otp_data_dir }}/Graph.obj"

```

 * On `develop`, assuming you've correctly deactivated any workarounds, running `vagrant provision otp` should cause the task to immediately fail with a message like `"ssh: Could not resolve hostname otp: nodename nor servname provided, or not known\r\nrsync: connection unexpectedly closed"`
 * Once you've got it failing, check out this branch and re-run `vagrant provision otp` 
 * Everything should succeed

## Checklist
- [ ] ~No gulp lint warnings~
- [ ] ~No python lint warnings~
- [ ] ~Python tests pass~


Closes #1303 
