### PR TITLE
Upgrade Troposphere to version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,18 @@ Note that if there is an existing build Graph.obj in `otp_data`, vagrant provisi
 
 Building AMIs
 ------------------------
+1. Configure an AWS profile with `aws configure --profile gophillygo` if you haven't already
 1. Make a production group_vars file (similarly to how is described above with development). Make sure production is set to true, and also specify an app_username, which should be set to: ubuntu
 2. If building the `otp` machine, make sure the latest GTFS are in `otp_data`, then build a graph when them in the development environment provisioning.  This will result in a new `Graph.obj` file being written to `otp_data`.
-3. In the project directory within the app VM, run: `deployment/cac-stack.py create-ami --aws-access-key-id YOUR_ACCESS_KEY --aws-secret-access-key YOUR_SECRET_KEY --aws-role-arn YOUR_ASSUMED_ROLE_ARN`
+3. In the project directory within the app VM, run: `AWS_PROFILE=gophillygo deployment/cac-stack.py create-ami`
 4. The previous command builds all AMIs. To only build a single AMI, run the same command, but also specify the `--machine-type` parameter, which may be set to one of: `bastion`, `otp`, or `app`.
 
 
 Launching AWS Stacks
 ------------------------
 1. Copy `deployment/default_template.yaml` to `deployment/default.yaml` and edit variables
-2. In the project directory, for a set of `Blue` stacks in the `Production` environment, run: `deployment/cac-stack.py launch-stacks --stack-type prod --stack-color blue --aws-access-key-id YOUR_ACCESS_KEY --aws-secret-access-key YOUR_SECRET_KEY --aws-role-arn YOUR_ASSUMED_ROLE_ARN`
+1. Configure an AWS profile with `aws configure --profile gophillygo` if you haven't already
+2. In the project directory, for a set of `Blue` stacks in the `Production` environment, run: `AWS_PROFILE=gophillygo deployment/cac-stack.py launch-stacks --stack-color blue --stack-type prod`
 3. The previous command will do the following:
  * Ensure the `VPC` stack is up in Production -- it will be launched if it isn't already running
  * Ensure the `DataPlane` stack is up in Production -- it will be launched if it isn't already running

--- a/deployment/cloudformation/app.py
+++ b/deployment/cloudformation/app.py
@@ -54,10 +54,10 @@ class AppServerStack(StackNode):
         if not self.INPUTS or not self.STACK_NAME_PREFIX or not self.HEALTH_ENDPOINT:
             raise MKInputError('Must define INPUTS, STACK_NAME_PREFIX, and HEALTH_ENDPOINT')
 
-        super(AppServerStack, self).set_up_stack()
+        self.set_version()
 
         tags = self.get_input('Tags').copy()
-        self.add_description('{} App Server Stack for Cac'.format(self.STACK_NAME_PREFIX))
+        self.set_description('{} App Server Stack for Cac'.format(self.STACK_NAME_PREFIX))
 
         assert isinstance(tags, dict), 'tags must be a dictionary'
 

--- a/deployment/cloudformation/data.py
+++ b/deployment/cloudformation/data.py
@@ -241,8 +241,8 @@ class DataPlaneGenerator(StackNode):
 
     def set_up_stack(self):
         """Sets up the stack"""
-        super(DataPlaneGenerator, self).set_up_stack()
-        self.add_description('Data Plane Stack for Cac')
+        self.set_version()
+        self.set_description('Data Plane Stack for Cac')
         self.rds_stack = RDSFactory()
         self.rds_stack.populate_template(self)
         for key in self.parameters:

--- a/deployment/cloudformation/vpc.py
+++ b/deployment/cloudformation/vpc.py
@@ -81,7 +81,7 @@ class VPC(StackNode):
 
     def set_up_stack(self):
         """Sets up the stack"""
-        super(VPC, self).set_up_stack()
+        self.set_version()
 
         """Creates a VPC object. See Class docstring for description of class
 
@@ -92,7 +92,7 @@ class VPC(StackNode):
           tags (dict): Arbitrary tags to add to all resources that accept tags
         """
         tags = self.get_input('Tags').copy()
-        self.add_description('VPC Stack for Cac')
+        self.set_description('VPC Stack for Cac')
 
         assert isinstance(tags, dict), 'tags must be a dictionary'
 

--- a/python/cac_tripplanner/deployment_requirements.txt
+++ b/python/cac_tripplanner/deployment_requirements.txt
@@ -2,4 +2,4 @@ boto==2.49.0
 PyYAML==5.3.1
 majorkirby==1.0.0
 requests==2.24.0
-troposphere==2.6.2
+troposphere==3.2.2


### PR DESCRIPTION
## Overview

Upgrading Troposphere broke majorkirby because it uses `add_version` in its `set_up_stack()` method, which was changed to `set_version()` in Troposphere v3. To work around the issue without pushing a new release to majorkirby, this removes calls to `super()` so that the code using `add_version()` doesn't get called, and then calls `set_version()` in local project code so that functionality is preserved. If it turns out we have more majorkirby projects hidden in a closet somewhere then we should probably push this fix up to majorkirby, but for the time being this is the most time-efficient thing to do. Also CC @rajadain in case this pops up elsewhere. 

### Notes

- I had apparently encountered this once before and forgotten about it because there was already an issue open. Oops.
- This doesn't upgrade troposphere all the way because there are more breaking changes in v4 that affect us and they look substantial enough that I think they're better left alone for now.

## Testing Instructions

 * Follow the deployment instructions to launch a new stack. As long as you've done it at least once before, you shouldn't need to build AMIs because we're not actually going to do anything with the stack we launch. Double-check the [existing stack color in the Cloudformation console](https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks?filteringText=&filteringStatus=active&viewNested=true) and launch the other color (it doesn't matter whether it matches the color built into the AMI, but we don't want to clobber anything in the existing stack). If you haven't launched the app before you can [grab some AMI ids from the console](https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=owned-by-me;sort=desc:creationDate) to use.
 * Confirm that the stack launches successfully. You don't need to check that the stack is actually functional, although you can if you want.
 * Return to the [CloudFormation console](https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks?filteringText=&filteringStatus=active&viewNested=true) and (very carefully) delete the stacks you just launched (and not the existing production stacks).

## Checklist
- [x] ~No gulp lint warnings~
- [x] No python lint warnings
  - I actually did run this and there were some warnings, but not in any of the code that I touched, so I'm going to ignore them unless / until we actually need to touch that code again.
- [ ] ~Python tests pass~


Closes #1347 
