### PR TITLE
Don't install deployment dependencies in app VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,16 @@ Building AMIs
 1. Configure an AWS profile with `aws configure --profile gophillygo` if you haven't already
 1. Make a production group_vars file (similarly to how is described above with development). Make sure production is set to true, and also specify an app_username, which should be set to: ubuntu
 2. If building the `otp` machine, make sure the latest GTFS are in `otp_data`, then build a graph when them in the development environment provisioning.  This will result in a new `Graph.obj` file being written to `otp_data`.
-3. In the project directory within the app VM, run: `AWS_PROFILE=gophillygo deployment/cac-stack.py create-ami`
-4. The previous command builds all AMIs. To only build a single AMI, run the same command, but also specify the `--machine-type` parameter, which may be set to one of: `bastion`, `otp`, or `app`.
+3. Install the deployment dependencies, ideally in a virtualenv: `python3 -m venv .venv && source .venv/bin/activate && pip install -r python/cac_tripplanner/deployment_requirements.txt`
+4. Build AMIs by running (within the virtualenv): `AWS_PROFILE=gophillygo deployment/cac-stack.py create-ami`
+5. The previous command builds all AMIs. To only build a single AMI, run the same command, but also specify the `--machine-type` parameter, which may be set to one of: `bastion`, `otp`, or `app`.
 
 
 Launching AWS Stacks
 ------------------------
 1. Copy `deployment/default_template.yaml` to `deployment/default.yaml` and edit variables
 1. Configure an AWS profile with `aws configure --profile gophillygo` if you haven't already
+1. Create a virtualenv with the deployment dependencies if you haven't already (see Building AMIs, above).
 2. In the project directory, for a set of `Blue` stacks in the `Production` environment, run: `AWS_PROFILE=gophillygo deployment/cac-stack.py launch-stacks --stack-color blue --stack-type prod`
 3. The previous command will do the following:
  * Ensure the `VPC` stack is up in Production -- it will be launched if it isn't already running

--- a/README.md
+++ b/README.md
@@ -29,16 +29,18 @@ Note that if there is an existing build Graph.obj in `otp_data`, vagrant provisi
 
 Building AMIs
 ------------------------
+1. Configure an AWS profile with `aws configure --profile gophillygo` if you haven't already
 1. Make a production group_vars file (similarly to how is described above with development). Make sure production is set to true, and also specify an app_username, which should be set to: ubuntu
 2. If building the `otp` machine, make sure the latest GTFS are in `otp_data`, then build a graph when them in the development environment provisioning.  This will result in a new `Graph.obj` file being written to `otp_data`.
-3. In the project directory within the app VM, run: `deployment/cac-stack.py create-ami --aws-access-key-id YOUR_ACCESS_KEY --aws-secret-access-key YOUR_SECRET_KEY --aws-role-arn YOUR_ASSUMED_ROLE_ARN`
+3. In the project directory within the app VM, run: `AWS_PROFILE=gophillygo deployment/cac-stack.py create-ami`
 4. The previous command builds all AMIs. To only build a single AMI, run the same command, but also specify the `--machine-type` parameter, which may be set to one of: `bastion`, `otp`, or `app`.
 
 
 Launching AWS Stacks
 ------------------------
 1. Copy `deployment/default_template.yaml` to `deployment/default.yaml` and edit variables
-2. In the project directory, for a set of `Blue` stacks in the `Production` environment, run: `deployment/cac-stack.py launch-stacks --stack-type prod --stack-color blue --aws-access-key-id YOUR_ACCESS_KEY --aws-secret-access-key YOUR_SECRET_KEY --aws-role-arn YOUR_ASSUMED_ROLE_ARN`
+1. Configure an AWS profile with `aws configure --profile gophillygo` if you haven't already
+2. In the project directory, for a set of `Blue` stacks in the `Production` environment, run: `AWS_PROFILE=gophillygo deployment/cac-stack.py launch-stacks --stack-color blue --stack-type prod`
 3. The previous command will do the following:
  * Ensure the `VPC` stack is up in Production -- it will be launched if it isn't already running
  * Ensure the `DataPlane` stack is up in Production -- it will be launched if it isn't already running

--- a/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml
@@ -12,9 +12,6 @@
       - libproj-dev
       - libjpeg-dev
 
-- name: Install pip packages for deployment
-  pip: requirements={{ root_app_dir }}/deployment_requirements.txt executable=/usr/bin/pip3
-
 - name: Install pip packages for app
   pip: requirements={{ root_app_dir }}/requirements.txt executable=/usr/bin/pip3
 

--- a/deployment/cloudformation/app.py
+++ b/deployment/cloudformation/app.py
@@ -54,10 +54,10 @@ class AppServerStack(StackNode):
         if not self.INPUTS or not self.STACK_NAME_PREFIX or not self.HEALTH_ENDPOINT:
             raise MKInputError('Must define INPUTS, STACK_NAME_PREFIX, and HEALTH_ENDPOINT')
 
-        super(AppServerStack, self).set_up_stack()
+        self.set_version()
 
         tags = self.get_input('Tags').copy()
-        self.add_description('{} App Server Stack for Cac'.format(self.STACK_NAME_PREFIX))
+        self.set_description('{} App Server Stack for Cac'.format(self.STACK_NAME_PREFIX))
 
         assert isinstance(tags, dict), 'tags must be a dictionary'
 

--- a/deployment/cloudformation/data.py
+++ b/deployment/cloudformation/data.py
@@ -241,8 +241,8 @@ class DataPlaneGenerator(StackNode):
 
     def set_up_stack(self):
         """Sets up the stack"""
-        super(DataPlaneGenerator, self).set_up_stack()
-        self.add_description('Data Plane Stack for Cac')
+        self.set_version()
+        self.set_description('Data Plane Stack for Cac')
         self.rds_stack = RDSFactory()
         self.rds_stack.populate_template(self)
         for key in self.parameters:

--- a/deployment/cloudformation/vpc.py
+++ b/deployment/cloudformation/vpc.py
@@ -81,7 +81,7 @@ class VPC(StackNode):
 
     def set_up_stack(self):
         """Sets up the stack"""
-        super(VPC, self).set_up_stack()
+        self.set_version()
 
         """Creates a VPC object. See Class docstring for description of class
 
@@ -92,7 +92,7 @@ class VPC(StackNode):
           tags (dict): Arbitrary tags to add to all resources that accept tags
         """
         tags = self.get_input('Tags').copy()
-        self.add_description('VPC Stack for Cac')
+        self.set_description('VPC Stack for Cac')
 
         assert isinstance(tags, dict), 'tags must be a dictionary'
 

--- a/python/cac_tripplanner/deployment_requirements.txt
+++ b/python/cac_tripplanner/deployment_requirements.txt
@@ -2,4 +2,4 @@ boto==2.49.0
 PyYAML==5.3.1
 majorkirby==1.0.0
 requests==2.24.0
-troposphere==2.6.2
+troposphere==3.2.2

--- a/python/cac_tripplanner/requirements.txt
+++ b/python/cac_tripplanner/requirements.txt
@@ -1,5 +1,6 @@
 base58==2.0.1
 boto3==1.15.9
+boto==2.49.0
 Django==3.2.13
 django-ckeditor==6.0.0
 django-image-cropping==1.5.0


### PR DESCRIPTION
## Overview

There was some fallout from [upgrading to Troposphere 3](https://github.com/azavea/cac-tripplanner/pull/1354), namely that the deployment dependencies were getting installed in the app VM, and the app VM is running Python 3.6, which isn't compatible with the version of Troposphere that we upgraded to, which caused app provisioning (and hence AMI building) to fail.

We don't need the deployment dependencies to be in the app VM because we use a Python virtualenv to encapsulate those dependencies separately, so this removes them from the app VM provisioning completely and updates the README instructions. The other option would have been upgrading Python, but that would have been a bigger lift. We've moved toward managing deployment dependencies separately from application dependencies on this and other projects anyway, so this seemed like a good opportunity to cement that change here.

I did open #1356 to cover upgrading Python, and we'll need to do that whenever we upgrade Django, because Django 4.2 no longer supports Python 3.6.

## Notes

- This PR is from the release branch to `master`, so it includes the troposphere upgrade changes, which have been reviewed but hadn't been deployed yet. Only commit 14be417b7964bbfbf0bd6a6f90540daaa5f6fc09 needs to be reviewed.


## Testing Instructions

 * Running `vagrant up app --provision` should not fail (but it will fail on `develop` if you want to check the fix).

## Checklist
- [ ] ~No gulp lint warnings~
- [ ] ~No python lint warnings~
- [ ] ~Python tests pass~