### PR TITLE
Fix bikeshare location display

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Development Dependencies
 ------------------------
 
 * [Vagrant](http://www.vagrantup.com)
-* [Ansible](http://www.ansible.com)
+* [Ansible](http://www.ansible.com) v4 (versions 6+ seem not to work)
 
 
 Development Installation
@@ -14,7 +14,7 @@ Development Installation
 
 1. Make sure you have the development dependencies installed
 2. Place GTFS .zip files, OSM files, and elevation .tif files (optional) in the root of the otp_data folder
-3. Generate a graph file with (takes approx 3 hours) `docker-compose run --rm otp otp --build /var/otp` in the deployment/graph directory.
+3. (Optional) Generate a graph file with (takes approx 3 hours) `docker-compose run --rm otp otp --build /var/otp` in the deployment/graph directory.
 4. Copy `deployment/ansible/group_vars/development_template` to `deployment/ansible/group_vars/development`
 5. Change into the `src/` folder and run `npm install` to install the node modules on the host machine
 6. Run `vagrant up`. You can choose to change the Virtualbox shared folder type for the `app` VM from its default NFS by:

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+ALLOW_WORLD_READABLE_TMPFILES = True

--- a/src/app/scripts/cac/map/cac-map-overlays.js
+++ b/src/app/scripts/cac/map/cac-map-overlays.js
@@ -27,7 +27,7 @@ CAC.Map.OverlaysControl = (function ($, cartodb, L, Utils) {
         $.ajax({
             cache: false,
             dataType: 'json',
-            url: 'https://kiosks.bicycletransit.workers.dev/phl',
+            url: 'https://bts-status.bicycletransit.workers.dev/phl',
             success: function (data) {
                 $.each(data.features, function (i, share) {
                     bikeShareFeatureGroup.addLayer(getBikeShareMarker(share));


### PR DESCRIPTION
## Overview

Fixes an issue with the bikeshare station locations not showing up. I had to re-provision the app from scratch, so this also addresses a few issues I had getting things spun up.

### Demo

![Screenshot from 2023-10-10 10-46-01](https://github.com/azavea/cac-tripplanner/assets/447977/1a9bc59c-23a6-4960-9a3c-c91012ac0c42)


## Testing Instructions

 * Install Ansible v4 or earlier, and re-provision the application, confirming that it works
 * Navigate to the trip map and confirm you can use the layer picker to display bike share station locations.

## Checklist
- [x] No gulp lint warnings
- [ ] No python lint warnings
- [ ] Python tests pass
- [ ] All TODOs have an accompanying issue link

Connects #1362 
