### PR TITLE
Upgrade boto to boto3 in deployment scripts

### DIFF
--- a/deployment/cloudformation/privatehostedzone.py
+++ b/deployment/cloudformation/privatehostedzone.py
@@ -1,9 +1,8 @@
-from boto import route53
-
 from majorkirby import CustomActionNode
 
 import json
-
+import boto3
+import uuid
 
 class R53PrivateHostedZone(CustomActionNode):
     """Represents a Route53 private hosted zone"""
@@ -19,21 +18,32 @@ class R53PrivateHostedZone(CustomActionNode):
 
     def action(self):
         """Creates the zone"""
-        conn = route53.connect_to_region(self.REGION)
+        client = boto3.client('route53', region_name=self.REGION)
         comment = json.dumps(self.get_raw_tags())
 
-        hosted_zones = conn.get_all_hosted_zones()
+        hosted_zones = client.list_hosted_zones()
 
-        for hosted_zone in hosted_zones['ListHostedZonesResponse']['HostedZones']:
+        for hosted_zone in hosted_zones['HostedZones']:
             if ('Comment' in hosted_zone['Config'] and
                     hosted_zone['Config']['Comment'] == comment):
                 self.stack_outputs = {'PrivateHostedZoneId': hosted_zone['Id'].split('/')[-1]}
                 return
+            
+        vpc_config = {
+            'VPCRegion': self.REGION,
+            'VPCId': self.get_input("VpcId")
+        }
+        hosted_zone_config = {
+            'Comment': comment,
+            'PrivateZone': True
+        }
 
-        hosted_zone = conn.create_hosted_zone(self.get_input('PrivateHostedZoneName'),
-                                              comment=comment,
-                                              private_zone=True,
-                                              vpc_id=self.get_input('VpcId'),
-                                              vpc_region=self.REGION)
+        hosted_zone = client.create_hosted_zone(
+            Name=self.get_input("PrivateHostedZoneName"),
+            CallerReference=str(uuid.uuid4()),
+            HostedZoneConfig=hosted_zone_config,
+            VPC=vpc_config,
+        )
         hosted_zone_id = hosted_zone['CreateHostedZoneResponse']['HostedZone']['Id']
         self.stack_outputs = {'PrivateHostedZoneId': hosted_zone_id.split('/')[-1]}
+

--- a/deployment/cloudformation/utils/cfn.py
+++ b/deployment/cloudformation/utils/cfn.py
@@ -1,5 +1,5 @@
 """Helper functions and classes for dealing with cloudformation"""
-import boto
+import boto3
 
 
 class AvailabilityZone(object):
@@ -38,5 +38,5 @@ def get_availability_zones():
     Returns:
       (list of AvailabilityZone): List of availability zones for a given EC2 region
     """
-    conn = boto.connect_ec2()
-    return  [AvailabilityZone(az) for az in conn.get_all_zones()]
+    client = boto3.client('ec2', region_name='us-east-1')
+    return  [AvailabilityZone(az) for az in client.describe_availability_zones()]

--- a/deployment/cloudformation/utils/cfn.py
+++ b/deployment/cloudformation/utils/cfn.py
@@ -15,7 +15,6 @@ class AvailabilityZone(object):
         Args:
         availability_zone (AvailabilityZone): boto object
         """
-
         self.availability_zone = availability_zone
 
     @property
@@ -24,12 +23,12 @@ class AvailabilityZone(object):
         Utility method to return a string appropriate for CloudFormation
         name of a resource (e.g. UsEast1a)
         """
-        return self.availability_zone.name.title().replace('-', '')
+        return self.availability_zone['ZoneName'].title().replace('-', '')
 
     @property
     def name(self):
         """Utility function to return the name of an availability zone (e.g. us-east-1a)"""
-        return self.availability_zone.name
+        return self.availability_zone['ZoneName']
 
 
 def get_availability_zones():
@@ -39,4 +38,4 @@ def get_availability_zones():
       (list of AvailabilityZone): List of availability zones for a given EC2 region
     """
     client = boto3.client('ec2', region_name='us-east-1')
-    return  [AvailabilityZone(az) for az in client.describe_availability_zones()]
+    return  [AvailabilityZone(az) for az in client.describe_availability_zones()['AvailabilityZones']]

--- a/python/cac_tripplanner/deployment_requirements.txt
+++ b/python/cac_tripplanner/deployment_requirements.txt
@@ -1,5 +1,6 @@
-boto==2.49.0
+boto3==1.15.9
 PyYAML==5.3.1
 majorkirby==1.0.0
 requests==2.24.0
 troposphere==3.2.2
+uuid==1.30.0


### PR DESCRIPTION
## Overview

Upgrades `boto`, used for our deployment scripts, with `boto3` version `1.15.9`, now at parity with `boto3` used elsewhere in app. 

### Notes
- There's one instance where we use `boto` outside of deployment scripts for the `app` vm, [here](https://github.com/azavea/cac-tripplanner/blob/develop/python/cac_tripplanner/cac_tripplanner/settings.py#L15), used to add the instance IP to `ALLOWED_HOSTS` for the ELBs. There's currently an [open issue](https://github.com/boto/boto3/issues/313) to add a comparable method to `boto3` and until then the preferred solutions seem to continue to use `boto.utils` or a 3rd party package, [ec2-metadata](https://github.com/adamchainz/ec2-metadata#ec2metadatasessionnone). There *is* a [describe_instances](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_instances.html#) method in `boto3` that looks like we can get the public IP address from, but I'm not sure which instance we should be filtering for here that would be comparable to `get_instance_metadata` in production. Ultimately this is a pretty narrow use case for `boto` and it felt worth keeping this one utility in since it's not part of our deployment.

## Testing Instructions

 * We're not able to test this locally since the actions affected by these updates don't actually run until launching a stack. I tried simulating launching a stack locally by manually running the action methods in a python script, but it raises a `majorkirby.MKUnresolvableInputError` when running the commands outside the context of a `GlobalConfigNode`. To test we will need to temporarily launch a web stack to confirm no issues and then delete once successful.

## Checklist
- [ ] No gulp lint warnings
- [ ] No python lint warnings
- [ ] Python tests pass
- [ ] All TODOs have an accompanying issue link

Connects #1116 
