### PR TITLE
Upgrade Python to 3.10 in app VM and psycopg2 to 2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ CAC_APP_SHARED_FOLDER_TYPE=virtualbox vagrant up
 
 Note that if there is an existing build Graph.obj in `otp_data`, vagrant provisioning in development mode will not attempt to rebuild the graph, but will use the one already present.
 
+Django migrations are run as part of app provisioning, [here](https://github.com/azavea/cac-tripplanner/blob/develop/deployment/ansible/roles/cac-tripplanner.app/tasks/main.yml#L67-L72), but there may be instances where you need to manually run migrations outside of provisioning, in which case use the command:
+```
+vagrant ssh app -c 'cd /opt/app/python/cac_tripplanner && python3 manage.py migrate'
+```
+
 
 Building AMIs
 ------------------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,7 +71,7 @@ VAGRANT_PROXYCONF_ENDPOINT = ENV["VAGRANT_PROXYCONF_ENDPOINT"]
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "bento/ubuntu-20.04"
+  config.vm.box = "bento/ubuntu-22.04"
 
   # Wire up the proxy if:
   #
@@ -86,6 +86,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "database" do |database|
+    # SSH issues bringing up DB VM with base box 22.04
+    # Explicitly define downgraded version for use by database until fix 
+    database.vm.box = "bento/ubuntu-20.04"
     database.vm.hostname = "database"
     database.vm.network "private_network", ip: "192.168.56.25"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,7 +71,7 @@ VAGRANT_PROXYCONF_ENDPOINT = ENV["VAGRANT_PROXYCONF_ENDPOINT"]
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "bento/ubuntu-18.04"
+  config.vm.box = "bento/ubuntu-20.04"
 
   # Wire up the proxy if:
   #

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -9,7 +9,7 @@ postgres_user: "cac_tripplanner"
 postgres_password: "cac_tripplanner"
 postgres_host: "192.168.56.25"
 
-postgresql_support_psycopg2_version: "2.8.*"
+postgresql_support_psycopg2_version: "2.9.*"
 'postgis_version': [3, 0, 1]
 
 packer_version: "1.5.4"

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,9 +1,6 @@
 - src: azavea.opentripplanner
   version: 2.0.1
 
-- src: azavea.nginx
-  version: 1.0.0
-
 - src: azavea.nodejs
   version: 0.4.0
 
@@ -12,5 +9,3 @@
 
 - src: azavea.papertrail
   version: 2.0.0
-
-

--- a/deployment/ansible/roles/cac-tripplanner.app/meta/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.app/meta/main.yml
@@ -1,8 +1,8 @@
 ---
   dependencies:
     - { role: "azavea.git" }
-    - { role: "azavea.nginx" }
     - { role: "azavea.nodejs" }
     - { role: "azavea.packer" }
+    - { role: "cac-tripplanner.nginx" }
     - { role: "cac-tripplanner.papertrail", when: production }
     - { role: "cac-tripplanner.python3" }

--- a/deployment/ansible/roles/cac-tripplanner.nginx/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.nginx/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+nginx_version: "stable"
+nginx_delete_default_site: False

--- a/deployment/ansible/roles/cac-tripplanner.nginx/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.nginx/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-nginx_version: "stable"
 nginx_delete_default_site: False

--- a/deployment/ansible/roles/cac-tripplanner.nginx/handlers/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.nginx/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Restart Nginx
+  service: name=nginx state=restarted

--- a/deployment/ansible/roles/cac-tripplanner.nginx/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.nginx/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
+# Tasks and related artifacts copied from azavea.nginx role
+# Customized to use Nginx Stable PPA that works with Ubuntu 22.04
 - name: Configure the Nginx PPA
-  apt_repository: repo=ppa:nginx/{{ nginx_version }} state=present
+  apt_repository: repo=ppa:ondrej/nginx state=present
 
 - name: Install Nginx
   apt: pkg=nginx-full state=present

--- a/deployment/ansible/roles/cac-tripplanner.nginx/tasks/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.nginx/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Configure the Nginx PPA
+  apt_repository: repo=ppa:nginx/{{ nginx_version }} state=present
+
+- name: Install Nginx
+  apt: pkg=nginx-full state=present
+
+- name: Delete default site
+  file: path=/etc/nginx/sites-enabled/default state=absent
+  register: delete_default_site
+  when: nginx_delete_default_site | bool
+  notify:
+    - Restart Nginx
+
+- name: Delete default web root
+  file: path=/var/www/html state=absent
+  when: nginx_delete_default_site | bool and delete_default_site is changed
+
+- name: Check Nginx Upstart service definition exists
+  stat: path=/etc/init/nginx.conf
+  register: nginx_upstart
+
+- name: Configure Nginx log rotation
+  template: src=logrotate_nginx.j2 dest=/etc/logrotate.d/nginx
+  when: nginx_upstart.stat.exists
+
+- name: Configure Nginx
+  template: src=nginx.conf.j2 dest=/etc/nginx/nginx.conf
+  notify:
+    - Restart Nginx

--- a/deployment/ansible/roles/cac-tripplanner.nginx/templates/logrotate_nginx.j2
+++ b/deployment/ansible/roles/cac-tripplanner.nginx/templates/logrotate_nginx.j2
@@ -1,0 +1,18 @@
+/var/log/nginx/*.log {
+	weekly
+	missingok
+	rotate 52
+	compress
+	delaycompress
+	notifempty
+	create 0640 www-data adm
+	sharedscripts
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+			run-parts /etc/logrotate.d/httpd-prerotate; \
+		fi \
+	endscript
+	postrotate
+		service nginx rotate >/dev/null 2>&1
+	endscript
+}

--- a/deployment/ansible/roles/cac-tripplanner.nginx/templates/nginx.conf.j2
+++ b/deployment/ansible/roles/cac-tripplanner.nginx/templates/nginx.conf.j2
@@ -1,0 +1,34 @@
+user www-data;
+worker_processes {{ ansible_processor_count }};
+pid /run/nginx.pid;
+
+events {
+	worker_connections 768;
+}
+
+http {
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+
+	server_tokens off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
+
+	gzip on;
+	gzip_vary on;
+	gzip_proxied any;
+	gzip_comp_level 6;
+	gzip_buffers 16 8k;
+	gzip_http_version 1.1;
+	gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript;
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+}

--- a/python/cac_tripplanner/requirements.txt
+++ b/python/cac_tripplanner/requirements.txt
@@ -10,7 +10,7 @@ easy-thumbnails==2.8.1
 gunicorn==20.0.4
 lxml==4.9.2
 Pillow==7.2.0
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.0
 pytz==2020.1
 PyYAML==5.3.1
 requests==2.24.0


### PR DESCRIPTION
## Overview

Upgrades the app VM from Python 3.6.9 to 3.10.12 as well as upgrades `psycopg2` from 2.8.6 to 2.9 in both app and database VM. Both of these upgrades support upcoming Django and PostgreSQL upgrades in the #1372 task list.

Ideally we would get to Python version 3.12 since that is currently in `bugfix` maintenance status into 2025, but I ran into a variety of issues trying to upgrade to this version so am leaving it at 3.10.12. This version is still receiving security support through October 2026. (see notes for more detail)


### Demo
```
RUNNING HANDLER [cac-tripplanner.app : Restart nginx] **************************
changed: [app]

PLAY RECAP *********************************************************************
app                        : ok=37   changed=32   unreachable=0    failed=0    skipped=17   rescued=0    ignored=0   

rachelemorino@Racheles-MacBook-Pro cac-tripplanner % vagrant ssh app
Welcome to Ubuntu 22.04.3 LTS (GNU/Linux 5.15.0-92-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/pro

  System information as of Fri Mar  1 07:04:49 PM UTC 2024

  System load:  0.39599609375      Processes:             159
  Usage of /:   19.1% of 30.34GB   Users logged in:       0
  Memory usage: 54%                IPv4 address for eth0: 10.0.2.15
  Swap usage:   1%                 IPv4 address for eth1: 192.168.56.24


This system is built by the Bento project by Chef Software
More information can be found at https://github.com/chef/bento
Last login: Fri Mar  1 19:03:31 2024 from 192.168.56.1
vagrant@app:~$ python3 --version
Python 3.10.12
```

```
vagrant@app:~$ pip show psycopg2-binary
Name: psycopg2-binary
Version: 2.9
Summary: psycopg2 - Python-PostgreSQL Database Adapter
Home-page: https://psycopg.org/
Author: Federico Di Gregorio
Author-email: fog@initd.org
License: LGPL with exceptions
Location: /usr/local/lib/python3.8/dist-packages
Requires: 
```

```
vagrant@database:~$ pip show psycopg2
Name: psycopg2
Version: 2.9.9
Summary: psycopg2 - Python-PostgreSQL Database Adapter
Home-page: https://psycopg.org/
Author: Federico Di Gregorio
Author-email: fog@initd.org
License: LGPL with exceptions
Location: /usr/local/lib/python3.8/dist-packages
Requires: 
Required-by: 
```

### Notes
#### Context on the nginx role changes:
Upgrading to Python 3.10 failed app provisioning with the following error:
```
TASK [azavea.nginx : Configure the Nginx PPA] **********************************
fatal: [app]: FAILED! => {"changed": false, "msg": "Failed to update apt cache: E:The repository 'http://ppa.launchpad.net/nginx/stable/ubuntu jammy Release' does not have a Release file."}
```

  After digging it appears upgrading the upgraded Ubuntu version was too modern for the repo defined in the 
    `azavea.nginx` role. Unfortunately, this is a separate repo so I had to copy over the entire role and update app's role 
     dependencies in order to update this task to use the correct stable PPA.


#### Notes on issues upgrading to Python 3.12:
The Ubuntu 22.04 base box brings the Python default to 3.10.12, but ideally we would upgrade to Python 3.12 to give us the most runway before contract end. I tried to manually install Python 3.12 from PPA as part of app provisioning and then update the `ansible_python_interpreter` to [locate the correct version to use](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#locating-python), but ran into incompatibilities with the ansible version:
```
TASK [azavea.packer : Download Packer] *****************************************
fatal: [app]: FAILED! => {"changed": false, "dest": "/usr/local/src/packer_1.5.4_linux_amd64.zip", "elapsed": 0, "msg": "An unknown error occurred: 'CustomHTTPSConnection' object has no attribute 'cert_file'", "url": "https://releases.hashicorp.com/packer/1.5.4/packer_1.5.4_linux_amd64.zip"}
```

The upgraded Python version got rid of some variables, like `cert_file`, that are used by ansible in the `azavea.packer` role and we would need to upgrade local `ansible-core` to version >=2.15 for these to be compatible, see [this ansible issue for more detail](https://github.com/ansible/ansible/issues/80490). This project depends on local installation of `ansible`, but we have historically had [issues using upgraded ansible versions beyond 6.0](https://github.com/azavea/cac-tripplanner/pull/1363/commits/bc29dd23197e2ce8030a489a9e5d4053ee9dcbff#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9) with this project. The latest version of [`ansible` v 5.0 only includes up to `ansible-core` v 2.12.7](https://docs.ansible.com/ansible/latest/roadmap/COLLECTIONS_5.html). I *could* target an update for `ansible-core` to get these fixes, but I suspect this could open a can of worms and given our remaining budget and that we're able to at least get to Python 3.10 I think we should leave this for down the road. Curious if you think it's worth it!

## Testing Instructions

 * `vagrant destroy` (Ensure you have `Graph.obj` in the `otp_data` dir before destroying the otp VM so it doesn't rebuild the graph on up)
 * `vagrant up` (you may need to run `CAC_APP_SHARED_FOLDER_TYPE=virtualbox vagrant up`)
 * Confirm all VMs are successfully brought up and app is working as expected in the browser
 * ssh into the app VM and confirm `python3` version and `psycopg2-binary` version
 * ssh into the database VM and confirm `psycopg2` version


## Checklist
- [ ] No gulp lint warnings
- [ ] No python lint warnings
- [ ] Python tests pass
- [ ] All TODOs have an accompanying issue link

Connects #1356 
