### PR TITLE
Upgrade to Django 4.2

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,4 @@
 [defaults]
 ALLOW_WORLD_READABLE_TMPFILES = True
+stdout_callback=debug
+stderr_callback=debug

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -29,8 +29,8 @@ papertrail_log_files:
     - "/var/log/event-feed.log"
     - "/var/log/upstart/otp.log"
 
-postgresql_version: "9.6"
-postgresql_package_version: "9.6.*"
+postgresql_version: "12"
+postgresql_package_version: "12.*.*"
 postgresql_support_libpq_version: "*"
 
 postgresql_listen_addresses: "*"

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -30,7 +30,7 @@ papertrail_log_files:
     - "/var/log/upstart/otp.log"
 
 postgresql_version: "12"
-postgresql_package_version: "12.*.*"
+postgresql_package_version: "12.*.pgdg20.04+1"
 postgresql_support_libpq_version: "*"
 
 postgresql_listen_addresses: "*"

--- a/deployment/ansible/roles/cac-tripplanner.database/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.database/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # postgresql defaults copied from azavea.postgresql
-postgresql_version: "9.6"
-postgresql_package_version: "9.6.*"
+postgresql_version: "12"
+postgresql_package_version: "12.*.*"
 postgresql_listen_addresses: localhost
 postgresql_port: 5432
 postgresql_data_directory: /var/lib/postgresql/{{ postgresql_version }}/main

--- a/python/cac_tripplanner/cac_tripplanner/settings.py
+++ b/python/cac_tripplanner/cac_tripplanner/settings.py
@@ -187,7 +187,9 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 STATIC_URL = "/static/"
 STATIC_ROOT = "/srv/cac"
-STATICFILES_DIRS = ()
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'static/'),
+]
 
 MEDIA_ROOT = "/media/cac/"
 MEDIA_URL = "/media/"
@@ -312,6 +314,7 @@ WPADMIN = {
             "top": "wpadmin.menu.menus.BasicTopMenu",
             "left": "wpadmin.menu.menus.BasicLeftMenu",
         },
+        'custom_style': STATIC_URL + 'admin/css/pagination.css',
     }
 }
 

--- a/python/cac_tripplanner/cac_tripplanner/settings.py
+++ b/python/cac_tripplanner/cac_tripplanner/settings.py
@@ -165,8 +165,6 @@ TIME_ZONE = "America/New_York"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 # Directory for default featured destinations added in destinations 0012

--- a/python/cac_tripplanner/cac_tripplanner/urls.py
+++ b/python/cac_tripplanner/cac_tripplanner/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import re_path
-from django.urls import include
+from django.urls import include, re_path
 from django.views.generic import RedirectView
 from django.contrib.gis import admin
 

--- a/python/cac_tripplanner/requirements.txt
+++ b/python/cac_tripplanner/requirements.txt
@@ -1,7 +1,7 @@
 base58==2.0.1
 boto3==1.15.9
 boto==2.49.0
-Django==3.2.13
+Django==3.2.25
 django-ckeditor==6.0.0
 django-image-cropping==1.5.0
 django-extensions==3.1.5

--- a/python/cac_tripplanner/requirements.txt
+++ b/python/cac_tripplanner/requirements.txt
@@ -1,9 +1,9 @@
 base58==2.0.1
 boto3==1.15.9
 boto==2.49.0
-Django==3.2.25
+Django==4.0.1
 django-ckeditor==6.0.0
-django-image-cropping==1.5.0
+django-image-cropping==1.7.0
 django-extensions==3.1.5
 django-storages==1.10.1
 easy-thumbnails==2.8.1

--- a/python/cac_tripplanner/requirements.txt
+++ b/python/cac_tripplanner/requirements.txt
@@ -1,12 +1,12 @@
 base58==2.0.1
 boto3==1.15.9
 boto==2.49.0
-Django==4.0.1
+Django==4.2.11
 django-ckeditor==6.0.0
 django-image-cropping==1.7.0
 django-extensions==3.1.5
 django-storages==1.10.1
-easy-thumbnails==2.8.1
+easy-thumbnails==2.8.5
 gunicorn==20.0.4
 lxml==4.9.2
 Pillow==7.2.0

--- a/python/cac_tripplanner/shortlinks/test/urls.py
+++ b/python/cac_tripplanner/shortlinks/test/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import re_path
-from django.urls import include, path
+from django.urls import include, path, re_path
 from shortlinks.test.views import stub_view
 
 app_name = 'shortlinks'

--- a/python/cac_tripplanner/shortlinks/urls.py
+++ b/python/cac_tripplanner/shortlinks/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path
+from django.urls import re_path
 from django.views.decorators.csrf import csrf_exempt
 
 from .views import ShortenedLinkRedirectView, ShortenedLinkCreateView

--- a/python/cac_tripplanner/static/admin/css/pagination.css
+++ b/python/cac_tripplanner/static/admin/css/pagination.css
@@ -1,0 +1,3 @@
+#change-history > p.paginator {
+    width: auto;
+}

--- a/python/cac_tripplanner/templates/admin/base.html
+++ b/python/cac_tripplanner/templates/admin/base.html
@@ -1,4 +1,19 @@
 {% extends "admin/base.html" %}
+{% load i18n %}
+{% block breadcrumbs %}
+  {% if title != 'Site administration' %}
+    <div class="breadcrumbs">
+      <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+      {% if title %}
+          {% if title|slice:'-14:' == 'administration' %}
+              &rsaquo; {{ title|slice:':-14' }}
+          {% else %}
+              &rsaquo; {{ title }}
+          {% endif %}
+      {% endif %}
+    </div>
+  {% endif %}
+{% endblock %}
 {% load cropping thumbnail %}
 {% block extrahead %}
   {{ form.media }}


### PR DESCRIPTION
## Overview

Upgrades to latests Django 4.2 version, which maintains security support April 2026

### Notes
**Remaining deprecation warnings for Django 5+**
Derek largely tackled deprecation warning for Django 4 as part of the work in #1320, so there were minimal changes. Historically we've addressed the next versions's warning as part of current upgrade work, and there are deprecation warning for Django 5, but we're at the end of our contract with minimal budget so I left those warning be for now.

**Django WP Admin**
This is an upstream package that's no longer maintained that we've long since forked and continued updating, used to replicate the look and feel of the WordPress admin in Django. Incompatibilities with our current version of `django-wpadmin` and Django 4+ were largely addressed in #1320 so we didn't have to fix, make a new release, and then update the release tag in our requirements.txt file. One side effect of this however is the original package expects its versioning to maintain parity with Django so we'll continue to see this warning:
```bash
/usr/local/lib/python3.10/dist-packages/wpadmin/__init__.py:13: UserWarning:
Django WP Admin 3.2.14 is not compatible with Django 4.0.1 and may not work properly.
You should install Django WP Admin from 4.0.x branch.
  warnings.warn(
```
Since theres no updates to include in a new `django-wpadmin` release (and given the end of our budget) this felt fine to ignore for now.

**Remaining Boto warnings**
We still use `boto` for one specific method that is now unsupported in `boto3` (and there are no intentions of future support) and has minimal use within our app, see notes of #1377 on the decision to leave `boto` in here. As a result we'll see the following boto deprecation warnings:
```bash
/usr/local/lib/python3.10/dist-packages/boto/plugin.py:40:DeprecationWarning:
the imp module is deprecated in favour of importlib and slated for removal in Python 3.12;
see the module's documentation for alternative uses
  import imp
```
```bash
<frozen importlib._bootstrap>:914: ImportWarning: 
_SixMetaPathImporter.find_spec() not found; falling back to find_module()
```
```bash
<frozen importlib._bootstrap>:671: ImportWarning:
_SixMetaPathImporter.exec_module() not found; falling back to load_module()
  import imp
```
The last two import warnings will display *many* times on running the app. This is because `boto`'s vendored version of `six` causes ImportWarnings to be raised in Python 3.10 -- so this is likely from our recent Python upgrade (#1378) but I didn't see the logs until testing Django changes and manually starting the server. I found [this blogpost](https://blog.pecar.me/six-warnings) helpful context, and confirmed `boto` is the offending package by running the same command in the post to investigate packages with the old version of `six`. We're on the latest version and finding a different package to substitute `boto` is likely more lift than we have budget in our remaining contract so I left this to be ignored as well.

## Testing Instructions
Largely follows the testing instructions found in #1320.
In the below testing we *will* see warnings for:  Deprecations in Django 5+; Prompt to install Django WP Admin from 4.0.x branch; Deprecation and import warnings related to boto. See context for these above.

 * `vagrant provision app`
 * `vagrant ssh app`
 * `cd /opt/app/python/cac_tripplanner`
 * `python3 -Wall manage.py test`
      * Confirm tests pass and no deprecation warnings for Django 4.*
 *  `sudo systemctl stop cac-tripplanner-app` (This stops the server process that comes up by default when you start the VM; you need to do this before starting up the Django dev server manually because you'll get a port conflict if you don't)
 * `python3 -Wall manage.py runserver`
      * Confirm no deprecation warnings for Django 4.*
* Click around application and confirm no regressions, with special attention to the admin since we've had issues with `django-wpadmin`, the Django admin theme that we've forked and updated long ago.

## Checklist
- [ ] No gulp lint warnings
- [ ] No python lint warnings
- [ ] Python tests pass
- [ ] All TODOs have an accompanying issue link

Connects #1373 
