### PR TITLE
Update AWS Ubuntu version in prod

### DIFF
--- a/deployment/packer/cac_packer.py
+++ b/deployment/packer/cac_packer.py
@@ -21,7 +21,7 @@ def get_ubuntu_ami(region):
       creds (Dict): Dictionary containing AWS credentials
     """
 
-    response = urllib.urlopen('http://cloud-images.ubuntu.com/query/bionic/'
+    response = urllib.urlopen('http://cloud-images.ubuntu.com/query/jammy/'
                               'server/released.current.txt').readlines()
     response = [x.decode('utf-8') for x in response]
     fieldnames = ['version', 'version_type', 'release_status', 'date',


### PR DESCRIPTION
## Overview

As part of building the AMI's for the `3.1.46` release, which included Django upgrade work #1380, the build for the `app` AMI errored with `No matching distribution found for Django==4.2.11` on the `Install pip packages for app` task. The AMI was building using `Ubuntu Server 18.04 LTS` which would only have `Python 3.6.8`. This work should have been covered as part of the Python upgrade work in #1378, and was for the local dev environment in https://github.com/azavea/cac-tripplanner/pull/1378/commits/d909581c30650c3eb50a042b632f664543c5d3af, but not the deployment setup which uses an AWS Ubuntu AMI, independently set by querying for an AMI ID from the current release of a given image name. In order to bring production in line with our dev Ubuntu environment and unblock Django upgrades in production, we need to upgrade the server image name in the path to query as part of our packer deployment script.

## Testing Instructions

 * Test AMI's were built using this updated path and used to launch test stack as part of release 3.1.46. Confirm test stack url has no regressions and maintains current functionality: green.production.web.gophillygo.org


## Checklist
- [ ] No gulp lint warnings
- [ ] No python lint warnings
- [ ] Python tests pass
- [ ] All TODOs have an accompanying issue link

