### PR TITLE
Upgrade dev to PostgreSQL 14, PostGIS 3.5

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -10,7 +10,7 @@ postgres_password: "cac_tripplanner"
 postgres_host: "192.168.56.25"
 
 postgresql_support_psycopg2_version: "2.9.*"
-'postgis_version': [3, 0, 1]
+'postgis_version': [3, 5, 0]
 
 packer_version: "1.5.4"
 
@@ -29,8 +29,8 @@ papertrail_log_files:
     - "/var/log/event-feed.log"
     - "/var/log/upstart/otp.log"
 
-postgresql_version: "12"
-postgresql_package_version: "12.*.pgdg20.04+1"
+postgresql_version: "14"
+postgresql_package_version: "14.*.pgdg20.04+1"
 postgresql_support_libpq_version: "*"
 
 postgresql_listen_addresses: "*"

--- a/deployment/ansible/roles/cac-tripplanner.database/defaults/main.yml
+++ b/deployment/ansible/roles/cac-tripplanner.database/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
 # postgresql defaults copied from azavea.postgresql
-postgresql_version: "12"
-postgresql_package_version: "12.*.*"
 postgresql_listen_addresses: localhost
 postgresql_port: 5432
 postgresql_data_directory: /var/lib/postgresql/{{ postgresql_version }}/main

--- a/deployment/ansible/roles/cac-tripplanner.database/tasks/install-postgis-from-source.yml
+++ b/deployment/ansible/roles/cac-tripplanner.database/tasks/install-postgis-from-source.yml
@@ -28,7 +28,7 @@
   args:
     chdir: "/tmp/postgis-{{ postgis_version | join('.') }}"
   with_items:
-    - ./configure
+    - ./configure --without-protobuf
     - make
     - make install
     - ldconfig


### PR DESCRIPTION
## Overview

Upgrades development environment to use PostgreSQL 14 and PostGIS 3.5.

Closes #1374 

## Testing Instructions

- Check out this branch
- Destroy your `database` VM and recreate it:
    ```
    vagrant destroy -f database && vagrant up database
    ```
  - [x] Ensure it reprovisions correctly
  - [x] Ensure the app works afterwards

## Checklist
- [ ] No gulp lint warnings
- [ ] No python lint warnings
- [ ] Python tests pass
- [ ] All TODOs have an accompanying issue link
