### PR TITLE
Add manual updates/validation to GTFS workflow

### DIFF
--- a/.github/workflows/fetch-otp-data.yml
+++ b/.github/workflows/fetch-otp-data.yml
@@ -30,7 +30,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Fetch GTFS zip files
+      - name: Fetch & validate GTFS zip files
         working-directory: deployment/dataproc/gtfs-feed-fetcher
         run: docker compose run --rm gtfs-feed-fetcher ./fetch_cac_feeds.py
 

--- a/.github/workflows/fetch-otp-data.yml
+++ b/.github/workflows/fetch-otp-data.yml
@@ -34,8 +34,9 @@ jobs:
         working-directory: deployment/dataproc/gtfs-feed-fetcher
         run: docker compose run --rm gtfs-feed-fetcher ./fetch_cac_feeds.py
 
-        # TODO 1397: Edit SEPTA bus routes.txt files to bring back to OTPv1 support,
-        # Confirm no errors in .html files, run feedvalidator script
+      - name: Migrate any GTFS files to OTPv1 support
+        working-directory: deployment/dataproc/gtfs-feed-fetcher
+        run: docker compose run --rm gtfs-feed-fetcher ./migrate_feeds_to_otpv1.py
 
       - name: Extend GTFS feed date range
         working-directory: deployment/dataproc/gtfs-feed-fetcher

--- a/README.md
+++ b/README.md
@@ -32,39 +32,11 @@ Django migrations are run as part of app provisioning, [here](https://github.com
 vagrant ssh app -c 'cd /opt/app/python/cac_tripplanner && python3 manage.py migrate'
 ```
 
-
-Building AMIs
+Production Deployment
 ------------------------
-1. Configure an AWS profile with `aws configure --profile gophillygo` if you haven't already
-1. Make a production group_vars file (similarly to how is described above with development). Make sure production is set to true, and also specify an app_username, which should be set to: ubuntu
-2. If building the `otp` machine, make sure the latest GTFS are in `otp_data`, then build a graph when them in the development environment provisioning.  This will result in a new `Graph.obj` file being written to `otp_data`.
-3. Install the deployment dependencies, ideally in a virtualenv: `python3 -m venv .venv && source .venv/bin/activate && pip install -r python/cac_tripplanner/deployment_requirements.txt`
-4. Build AMIs by running (within the virtualenv): `AWS_PROFILE=gophillygo deployment/cac-stack.py create-ami`
-5. The previous command builds all AMIs. To only build a single AMI, run the same command, but also specify the `--machine-type` parameter, which may be set to one of: `bastion`, `otp`, or `app`.
-
-
-Launching AWS Stacks
-------------------------
-1. Copy `deployment/default_template.yaml` to `deployment/default.yaml` and edit variables
-1. Configure an AWS profile with `aws configure --profile gophillygo` if you haven't already
-1. Create a virtualenv with the deployment dependencies if you haven't already (see Building AMIs, above).
-2. In the project directory, for a set of `Blue` stacks in the `Production` environment, run: `AWS_PROFILE=gophillygo deployment/cac-stack.py launch-stacks --stack-color blue --stack-type prod`
-3. The previous command will do the following:
- * Ensure the `VPC` stack is up in Production -- it will be launched if it isn't already running
- * Ensure the `DataPlane` stack is up in Production -- it will be launched if it isn't already running
- * Ensure the `OtpServer` Blue stack is up in Production -- it will be launched if it isn't already running
- * Ensure the `WebServer` Blue stack is up in Production -- it will be launched if it isn't already running
-4. Note that database migrations are not automatically run. When the DataPlane is first brought up, it is necessary to manually create the app user/db and run migrations.
-5. Launching a set of Production stacks with the other color (`Green`), will use the same `VPC` and `DataPlane` stacks, but will create different `OtpServer` and `WebServer` stacks (if they don't already exist).
-
-
-Production Blue/Green deployment
---------------------------------
-1. Note which color is currently running in production. Use the opposite color in the following steps.
-2. Set `otp_host` in production group_vars to the CloudFront distribution with the desired color.
-3. Run `create_ami` command to build new AMIs.
-4. Update `default.yaml` with new AMI ids.
-5. Run `launch_stacks` command to launch stacks with the desired color.
-6. Test new stacks thoroughly.
-7. Switch the public DNS record of the site to point to the new `WebServer` ELB DNS.
-8. The stacks of the previous color may be deleted when ready.
+*Note there is no staging environment*
+1. Dispatch "Build Graph" Github Actions workflow
+     - This will fetch and process the latest GTFS and OSM files, store them on S3, and then use those files (along with the elevation file) to build a new Graph.obj for the OTP builder. New Graph.obj will also be stored in S3 bucket.
+2. Once workflow completes (3-4 hours), remove everything from your local `otp_data` directory and then run the following script to pull the latest Graph.obj: `scripts/download-latest-graph.sh`
+3. Build the AMIs, follow latest instructions in `Building The AMIs` section of deployment instrucions, [found here](https://github.com/azavea/geospatial-apps/blob/master/gophillygo_deployment.md#building-the-amis).
+4. Once AMI builds complete and identifiers set, following latest instructions in `Deploying the AMIs` section of deployment instructions, [found here](https://github.com/azavea/geospatial-apps/blob/master/gophillygo_deployment.md#deploying-the-amis).

--- a/deployment/dataproc/gtfs-feed-fetcher/migrate_feeds_to_otpv1.py
+++ b/deployment/dataproc/gtfs-feed-fetcher/migrate_feeds_to_otpv1.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+"""Modifies GTFS files to OTP v1 standard.
+
+OTPv2 updates as GTFS standard updates, however not backported to OTPv1.
+We can't migrate to OTPv2, so manually modify GTFS for OTPv1 support level.
+"""
+import logging
+import zipfile
+import os
+
+logging.basicConfig()
+LOG = logging.getLogger()
+LOG.setLevel(logging.INFO)
+
+gtfs_dir = 'gtfs'
+
+def unzip_file(filename):
+    feed_path = gtfs_dir + "/" + filename + ".zip"
+    if zipfile.is_zipfile(feed_path):
+        with zipfile.ZipFile(feed_path, 'r') as zip_ref:
+            zip_ref.extractall(gtfs_dir)
+            LOG.debug('Unzipped %s', filename)
+            return
+    else:
+        LOG.warn('File %s does not look like a valid zip file.', filename)
+
+def clean_up_txt_files():
+    for root, _, files in os.walk(gtfs_dir):
+        for file in files:
+            if file.endswith('.txt'):
+                os.remove(os.path.join(root, file))
+    LOG.debug('Cleaned up .txt files')
+
+def re_zip_files(filename):
+    feed_path = gtfs_dir + "/" + filename + ".zip"
+    with zipfile.ZipFile(feed_path, 'w', zipfile.ZIP_DEFLATED) as zip_ref:
+        for root, _, files in os.walk(gtfs_dir):
+            for file in files:
+                if file.endswith('.txt'):
+                    file_path = os.path.join(root, file)
+                    zip_ref.write(file_path, os.path.relpath(file_path, gtfs_dir))
+        LOG.debug('Re-zipped %s', feed_path)
+
+def modify_septa_bus():
+    # New GTFS includes replacement trolleybuses, unsupported transit type in OTPv1
+    # Convert to buses to prevent error building OTP
+    # Reference: https://github.com/septadev/GTFS?tab=readme-ov-file#routestxt
+    txt_path_to_update = os.path.join(gtfs_dir, 'routes.txt')
+    content=''
+    try:
+        with open(txt_path_to_update, 'r') as file:
+            content = file.read()
+            content = content.replace(',,11,,', ',,3,,')
+        with open(txt_path_to_update, 'w') as file:
+            file.write(content)
+        LOG.debug('Modified %s', txt_path_to_update)
+    except Exception as e:
+        raise ValueError('Error modifying %s: %s', txt_path_to_update, e)
+
+def main():
+    filenames_to_modify = ['septa_bus']
+    for filename in filenames_to_modify:
+        unzip_file(filename)
+        # Run modifications
+        # Namely modify SEPTA bus GTFS for OTPv1 support level
+        modify_septa_bus()
+        # Clean up
+        re_zip_files(filename)
+        clean_up_txt_files()
+    
+    LOG.info('Updating GTFS feeds for OTPv1 support complete')
+
+if __name__ == "__main__":
+    main()

--- a/deployment/dataproc/gtfs-feed-fetcher/requirements.txt
+++ b/deployment/dataproc/gtfs-feed-fetcher/requirements.txt
@@ -1,6 +1,5 @@
 beautifulsoup4==4.6.3
 cffi==1.11.5
-cryptography==3.2
 enum34==1.1.6
 ndg-httpsclient==0.5.1
 prettytable==0.7.2


### PR DESCRIPTION
## Overview

- Adds script updating SEPTA bus `routes.txt` file to convert replacement trolleybuses to be within OTPv1 level support
- Parses validation file with each GTFS feed and handles error in runner with message (warnings can pass)
- Updates README with base deployment instructions

### Demo

Successful validation & modifying GTFS feed files job: https://github.com/azavea/cac-tripplanner/actions/runs/14342009743/job/40203301765

Error correctly thrown with invalid GTFS feed file in job (see notes): https://github.com/azavea/cac-tripplanner/actions/runs/14338871722/job/40192902782 


### Notes

Temporarily pushed up a commit to force validating an altered septa_bus.zip in place of first downloading that GTFS file with the intention that this feed file should be caught by validation, the build stops, and the error correctly displays in the github action logs. See [error output here in latest build.](https://github.com/azavea/cac-tripplanner/actions/runs/14338871722/job/40192902782 )

## Testing Instructions

 * Confirm passing "Force & process source data" job with new modify step and updates to validation
 * For the sake of time/runner minutes latest passing workflow skips the actual graph build
 * Confirm updated date/times for all GTFS and OSM data files in `cleanair-otp-data` S3 bucket 
 * Download `septa_bus_extended.zip`, unzip, and open `routes.txt`. Confirm there are no rows with `route_type` of `11` (can search by `,,11,,`, if script unnsuccesful there will be 3 instances of this type)


## Checklist
- [ ] No gulp lint warnings
- [ ] No python lint warnings
- [ ] Python tests pass
- [ ] All TODOs have an accompanying issue link

Connects #1397
